### PR TITLE
*.Dockerfile: Manually bump the image tags to 4.8

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to bootstrap build and test in openshift-ci
 
-FROM openshift/origin-release:golang-1.13
+FROM registry.ci.openshift.org/ocp/builder:golang-1.15
 
 # Install test dependencies
 RUN yum install -y skopeo && \

--- a/operator-lifecycle-manager.Dockerfile
+++ b/operator-lifecycle-manager.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.8 AS builder
 
 ENV GO111MODULE auto
 ENV GOPATH /go
@@ -24,7 +24,7 @@ COPY go.sum go.sum
 RUN CGO_ENABLED=1 make build
 RUN make build-util
 
-FROM registry.svc.ci.openshift.org/ocp/4.7:base
+FROM registry.ci.openshift.org/ocp/4.8:base
 
 ADD manifests/ /manifests
 LABEL io.openshift.release.operator=true

--- a/operator-registry.Dockerfile
+++ b/operator-registry.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-4.7 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-4.8 AS builder
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
@@ -11,7 +11,7 @@ RUN make build cross
 # copy and build vendored grpc_health_probe
 RUN CGO_ENABLED=0 go build -mod=vendor -tags netgo -ldflags "-w" ./vendor/github.com/grpc-ecosystem/grpc-health-probe/...
 
-FROM registry.svc.ci.openshift.org/ocp/4.7:base
+FROM registry.svc.ci.openshift.org/ocp/4.8:base
 
 COPY --from=builder /src/bin/* /bin/registry/
 COPY --from=builder /src/grpc-health-probe /bin/grpc_health_probe


### PR DESCRIPTION
This is needed to properly substitute in the release prow configurations.