### PR TITLE
Update the base image for the operator-registry image

### DIFF
--- a/operator-registry.Dockerfile
+++ b/operator-registry.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-4.8 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.8 AS builder
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH


### PR DESCRIPTION
Update the base image tag to `rhel-8-golang-1.15-openshift-4.8` to match
what we have specified in the OLM base image as well. This allows us to
only have to override a single image input in the downstream OLM prow
repository configuration.