### PR TITLE
Add additional make targets and update Dockerfile(s)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SHELL := /bin/bash
 ROOT_DIR:= $(patsubst %/,%,$(dir $(realpath $(lastword $(MAKEFILE_LIST)))))
+CONTAINER_ENGINE := docker
 
 GO_BUILD_OPTS := -mod=vendor
 GO_BUILD_TAGS := -tags "json1"
@@ -13,10 +14,12 @@ REGISTRY_PKG := $(GO_PKG)/operator-registry
 OLM_PKG := $(GO_PKG)/operator-lifecycle-manager
 API_PKG := $(GO_PKG)/api
 
-arch_flags=GOOS=linux GOARCH=386
-
 OLM_CMDS  := $(shell go list -mod=vendor $(OLM_PKG)/cmd/...)
-REGISTRY_CMDS  := $(shell go list -mod=vendor $(REGISTRY_PKG)/cmd/...)
+REGISTRY_CMDS  := $(addprefix bin/, $(shell ls staging/operator-registry/cmd | grep -v opm))
+
+# Phony prerequisite for targets that rely on the go build cache to determine staleness.
+.PHONY: FORCE
+FORCE:
 
 KUBEBUILDER_ASSETS := $(or $(or $(KUBEBUILDER_ASSETS),$(dir $(shell command -v kubebuilder))),/usr/local/kubebuilder/bin)
 export KUBEBUILDER_ASSETS
@@ -33,42 +36,34 @@ ifeq (, $(wildcard $(KUBEBUILDER_ASSETS)/kube-apiserver))
 	$(error kube-apiserver $(KUBEBUILDER_ASSETS_ERR))
 endif
 
-# Phony prerequisite for targets that rely on the go build cache to determine staleness.
-.PHONY: FORCE
-FORCE:
-
-build-util: bin/cpb
-
-bin/cpb: FORCE
-	CGO_ENABLED=0 $(arch_flags) go build $(GO_BUILD_OPTS) -ldflags '-extldflags "-static"' -o $@ ./util/cpb
-
-.PHONY: vendor
-vendor:
-	go mod tidy
-	go mod vendor
-	go mod verify
-
-build: $(OLM_CMDS) $(REGISTRY_CMDS)
+build: $(REGISTRY_CMDS) $(OLM_CMDS)
 
 $(REGISTRY_CMDS): version_flags=-ldflags "-X '$(REGISTRY_PKG)/cmd/opm/version.gitCommit=$(GIT_COMMIT)' -X '$(REGISTRY_PKG)/cmd/opm/version.opmVersion=$(OPM_VERSION)' -X '$(REGISTRY_PKG)/cmd/opm/version.buildDate=$(BUILD_DATE)'"
 $(REGISTRY_CMDS):
-	go build $(version_flags) $(GO_BUILD_OPTS) $(GO_BUILD_TAGS) -o bin/$(shell basename $@) $@
+	go build $(version_flags) $(GO_BUILD_OPTS) $(GO_BUILD_TAGS) -o $@ $(REGISTRY_PKG)/cmd/$(notdir $@)
 
 $(OLM_CMDS): version_flags=-ldflags "-X $(OLM_PKG)/pkg/version.GitCommit=$(GIT_COMMIT) -X $(OLM_PKG)/pkg/version.OLMVersion=`cat staging/operator-lifecycle-manager/OLM_VERSION`"
 $(OLM_CMDS):
 	go build $(version_flags) $(GO_BUILD_OPTS) $(GO_BUILD_TAGS) -o bin/$(shell basename $@) $@
 
-build/olm: version_flags=-ldflags "-X $(OLM_PKG)/pkg/version.GitCommit=$(GIT_COMMIT) -X $(OLM_PKG)/pkg/version.OLMVersion=`cat staging/operator-lifecycle-manager/OLM_VERSION`"
-build/olm:
-	go build $(version_flags) $(GO_BUILD_OPTS) $(GO_BUILD_TAGS) -o bin/olm $(OLM_PKG)/cmd/olm
+build/olm-container:
+	$(CONTAINER_ENGINE) build -f operator-lifecycle-manager.Dockerfile -t test:test .
+
+build/registry-container:
+	$(CONTAINER_ENGINE) build -f operator-registry.Dockerfile -t test:test .
 
 bin/kubebuilder:
 	$(ROOT_DIR)/scripts/install_kubebuilder.sh
 
-unit/operator-lifecycle-manager: bin/kubebuilder
+build-util: bin/cpb
+bin/cpb: arch_flags=GOOS=linux GOARCH=386
+bin/cpb: FORCE
+	CGO_ENABLED=0 $(arch_flags) go build $(GO_BUILD_OPTS) -ldflags '-extldflags "-static"' -o $@ ./util/cpb
+
+unit/olm: bin/kubebuilder
 	$(MAKE) unit WHAT=operator-lifecycle-manager
 
-unit/operator-registry:
+unit/registry:
 	$(MAKE) unit WHAT=operator-registry
 
 unit/api:
@@ -78,12 +73,17 @@ unit:
 	$(ROOT_DIR)/scripts/unit.sh
 
 e2e/operator-registry:
-	go run -mod=vendor github.com/onsi/ginkgo/ginkgo --v --randomizeAllSpecs --randomizeSuites --race $(TAGS) $(REGISTRY_PKG)/test/e2e
+	go run -mod=vendor github.com/onsi/ginkgo/ginkgo --v --randomizeAllSpecs --randomizeSuites --race $(TAGS) ./staging/operator-registry/test/e2e/
 
-olm:
-	podman build -f operator-lifecycle-manager.Dockerfile -t test:test --build-arg STAGING_DIR=./staging/operator-lifecycle-manager .
+e2e/olm:
+	scripts/e2e.sh
 
-# TODO(tflannag): Do we care about non-opm binary packages in operator-registry?
-# DO we still build the things like the initializer, app-registry, etc. binaries?
-registry:
-	podman build -f operator-registry.Dockerfile -t test:test --build-arg STAGING_DIR=./staging/operator-registry .
+.PHONY: vendor
+vendor:
+	go mod tidy
+	go mod vendor
+	go mod verify
+
+.PHONY: sanity
+sanity:
+	$(MAKE) vendor && git diff --stat HEAD --ignore-submodules --exit-code

--- a/operator-lifecycle-manager.Dockerfile
+++ b/operator-lifecycle-manager.Dockerfile
@@ -11,7 +11,6 @@ COPY .git/HEAD .git/HEAD
 COPY .git/refs/heads/. .git/refs/heads
 RUN mkdir -p .git/objects
 
-ARG STAGING_DIR
 COPY . .
 RUN make build
 RUN make build-util

--- a/operator-registry.Dockerfile
+++ b/operator-registry.Dockerfile
@@ -5,15 +5,7 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 WORKDIR /src
 
-# copy just enough of the git repo to parse HEAD, used to record version in OLM binaries
-COPY .git/HEAD .git/HEAD
-COPY .git/refs/heads/. .git/refs/heads
-
-ARG STAGING_DIR
-RUN echo ${STAGING_DIR}
-COPY ${STAGING_DIR} .
-COPY vendor vendor
-COPY Makefile Makefile
+COPY . .
 RUN make build
 
 # copy and build vendored grpc_health_probe
@@ -31,9 +23,7 @@ RUN chgrp -R 0 /registry && \
     chmod -R g+rwx /registry
 WORKDIR /registry
 
-# This image doesn't need to run as root user
 USER 1001
-
 EXPOSE 50051
 
 ENTRYPOINT ["/bin/registry-server"]

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,0 +1,44 @@
+#! /bin/bash
+
+# TODO(tflannag): We'll likely need to transistion towards using
+# a set of root e2e tests once upstream removes some of the
+# downstream-specific e2e tests, but this should be sufficient
+# until that happens.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+: "${KUBECONFIG:?}"
+
+ROOT_DIR=$(dirname "${BASH_SOURCE[0]}")/..
+
+function run_olm_tests() {
+    pushd "${ROOT_DIR}/staging/operator-lifecycle-manager"
+
+    echo "Running OLM e2e tests"
+    go test \
+        -mod=vendor \
+        -v \
+        -failfast \
+        -timeout 150m \
+        ./test/e2e/... \
+        -namespace=openshift-operators \
+        -kubeconfig="${KUBECONFIG}" \
+        -olmNamespace=openshift-operator-lifecycle-manager \
+        -dummyImage=bitnami/nginx:latest \
+        -ginkgo.flakeAttempts=3
+
+    popd
+}
+
+function run_registry_tests() {
+    pushd "${ROOT_DIR}/staging/operator-registry"
+
+    echo "Running registry e2e tests"
+    go run -mod=vendor github.com/onsi/ginkgo/ginkgo --v --randomizeAllSpecs --randomizeSuites --race -tags "json1" ./test/e2e
+
+    popd
+}
+
+run_registry_tests

--- a/vendor/github.com/operator-framework/operator-registry/pkg/lib/bundle/generate.go
+++ b/vendor/github.com/operator-framework/operator-registry/pkg/lib/bundle/generate.go
@@ -20,7 +20,7 @@ const (
 	RegistryV1Type      = "registry+v1"
 	PlainType           = "plain"
 	HelmType            = "helm"
-	AnnotationsFile     = "test.annotations.yaml"
+	AnnotationsFile     = "annotations.yaml"
 	DockerFile          = "bundle.Dockerfile"
 	ManifestsDir        = "manifests/"
 	MetadataDir         = "metadata/"


### PR DESCRIPTION
Update the root Makefile and add additional test/build/etc. targets.

Add a helper script that is responsible for running the registry and/or OLM staging test e2e packages.

Re-sync the vendor directory after merging a change that updated one of the staging packages, to verify that the root vendor folder got updated with that change, and reverting that staging change without re-updating the root vendor directory.

Update the Dockerfile(s) and copy the entire source tree. Note: this is something we should avoid doing in the future, but this will allow us to easily build binaries for the time-being and add additional prow checks so we can get some actual CI feedback on subsequent PRs to this repository.