### PR TITLE
staging: Update OLM modules after recent changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,11 +72,14 @@ unit/api:
 unit: ## Run unit tests
 	$(ROOT_DIR)/scripts/unit.sh
 
+e2e:
+	scripts/e2e.sh
+
 e2e/operator-registry: ## Run e2e registry tests
-	go run -mod=vendor github.com/onsi/ginkgo/ginkgo --v --randomizeAllSpecs --randomizeSuites --race $(TAGS) ./staging/operator-registry/test/e2e/
+	$(MAKE) e2e WHAT=operator-registry
 
 e2e/olm: ## Run e2e olm tests
-	scripts/e2e.sh
+	$(MAKE) e2e WHAT=operator-lifecycle-manager
 
 .PHONY: vendor
 vendor:

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,12 @@ endif
 
 build: $(REGISTRY_CMDS) $(OLM_CMDS) ## build opm and olm binaries
 
+build/registry:
+	$(MAKE) $(REGISTRY_CMDS)
+
+build/olm:
+	$(MAKE) $(OLM_CMDS)
+
 $(REGISTRY_CMDS): version_flags=-ldflags "-X '$(REGISTRY_PKG)/cmd/opm/version.gitCommit=$(GIT_COMMIT)' -X '$(REGISTRY_PKG)/cmd/opm/version.opmVersion=$(OPM_VERSION)' -X '$(REGISTRY_PKG)/cmd/opm/version.buildDate=$(BUILD_DATE)'"
 $(REGISTRY_CMDS):
 	go build $(version_flags) $(GO_BUILD_OPTS) $(GO_BUILD_TAGS) -o $@ $(REGISTRY_PKG)/cmd/$(notdir $@)

--- a/cmds.go
+++ b/cmds.go
@@ -4,5 +4,10 @@ import (
 	_ "github.com/operator-framework/operator-lifecycle-manager/cmd/catalog"
 	_ "github.com/operator-framework/operator-lifecycle-manager/cmd/olm"
 	_ "github.com/operator-framework/operator-lifecycle-manager/cmd/package-server"
+
+	_ "github.com/operator-framework/operator-registry/cmd/appregistry-server"
+	_ "github.com/operator-framework/operator-registry/cmd/configmap-server"
+	_ "github.com/operator-framework/operator-registry/cmd/initializer"
 	_ "github.com/operator-framework/operator-registry/cmd/opm"
+	_ "github.com/operator-framework/operator-registry/cmd/registry-server"
 )

--- a/operator-lifecycle-manager.Dockerfile
+++ b/operator-lifecycle-manager.Dockerfile
@@ -12,7 +12,7 @@ COPY .git/refs/heads/. .git/refs/heads
 RUN mkdir -p .git/objects
 
 COPY . .
-RUN make build
+RUN make build/olm
 RUN make build-util
 
 FROM registry.ci.openshift.org/ocp/4.8:base

--- a/operator-registry.Dockerfile
+++ b/operator-registry.Dockerfile
@@ -6,7 +6,7 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 WORKDIR /src
 
 COPY . .
-RUN make build
+RUN make build/registry
 
 # copy and build vendored grpc_health_probe
 RUN CGO_ENABLED=0 go build -mod=vendor -tags netgo -ldflags "-w" ./vendor/github.com/grpc-ecosystem/grpc-health-probe/...

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,4 +1,4 @@
-## Syncing downstream OLM
+# Syncing downstream OLM
 
 All of the staged repositories live in the top level `staging` directory. The versions of each staged dependency are tracked in the [`scripts/tracked`](./tracked) file.
 
@@ -7,7 +7,8 @@ All of the staged repositories live in the top level `staging` directory. The ve
 The sync process requires the git-subtree command. See [git subtree](https://github.com/git/git/blob/master/contrib/subtree/INSTALL) for more detailed instructions.
 
 The local repo also needs to track the upstream remotes in [`scripts/tracked`](./tracked). To add these to your repo, run the `init_remotes` script from the root of your repo:
-```
+
+```bash
 ./scripts/init_remotes.sh
 ```
 
@@ -15,13 +16,16 @@ The local repo also needs to track the upstream remotes in [`scripts/tracked`](.
 
 To sync a staged dependency with an upstream version, you can use the `pull_upstream.sh` helper script. This adds a staged repo if it is not present and updates it to the provided tag/branch otherwise. The script is run as follows:
 
-```
+```bash
 ./scripts/pull_upstream.sh <remote url or name> [<ref>]
 ```
-The ref can be a valid tag or branch on the remote, and defaults to master. A successful run adds a new commit to the current branch, similar to 
-```
+
+The ref can be a valid tag or branch on the remote, and defaults to master. A successful run adds a new commit to the current branch, similar to
+
+```text
 1bec1e8bb Sync upstream api v0.6.1
 ```
+
 Commit history for the staged repositories is not preserved. The latest synced upstream commit for each staged repo can be found in the `./scripts/tracked` file.
 
 Once the sync is completed, verify it by running the unit tests for the dependencies.
@@ -30,7 +34,8 @@ Once the sync is completed, verify it by running the unit tests for the dependen
 
 Changes made to the staged repositories may be pushed upstream by providing specific commit ranges. For this run:
 
-```
+```bash
 ./scripts/push_upstream.sh <remote name> <commit range or list>
 ```
+
 This creates a local branch containing from the last synced version of the staged dependency with the specified commits cherry-picked onto it. You can then create a PR from this branch to the required upstream repository.

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -10,35 +10,17 @@ set -o nounset
 set -o pipefail
 
 : "${KUBECONFIG:?}"
+: "${WHAT:?}"
 
 ROOT_DIR=$(dirname "${BASH_SOURCE[0]}")/..
 
-function run_olm_tests() {
-    pushd "${ROOT_DIR}/staging/operator-lifecycle-manager"
+function run_test() {
+    local staging_dir=$1
 
-    echo "Running OLM e2e tests"
-    go test \
-        -mod=vendor \
-        -v \
-        -failfast \
-        -timeout 150m \
-        ./test/e2e/... \
-        -namespace=openshift-operators \
-        -kubeconfig="${KUBECONFIG}" \
-        -olmNamespace=openshift-operator-lifecycle-manager \
-        -dummyImage=bitnami/nginx:latest \
-        -ginkgo.flakeAttempts=3
-
+    pushd "${ROOT_DIR}/staging/${staging_dir}"
+    echo "Running ${staging_dir} e2e tests"
+    make e2e
     popd
 }
 
-function run_registry_tests() {
-    pushd "${ROOT_DIR}/staging/operator-registry"
-
-    echo "Running registry e2e tests"
-    go run -mod=vendor github.com/onsi/ginkgo/ginkgo --v --randomizeAllSpecs --randomizeSuites --race -tags "json1" ./test/e2e
-
-    popd
-}
-
-run_registry_tests
+run_test "${WHAT}"

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -16,8 +16,15 @@ ROOT_DIR=$(dirname "${BASH_SOURCE[0]}")/..
 
 function run_test() {
     local staging_dir=$1
+    local path_to_staging_dir="${ROOT_DIR}/staging/${staging_dir}"
 
-    pushd "${ROOT_DIR}/staging/${staging_dir}"
+    pushd "${path_to_staging_dir}"
+
+    if [[ ! -d ${path_to_staging_dir}/vendor ]]; then
+        echo "Populating nested vendor directory"
+        go mod tidy && go mod vendor && go mod verify
+    fi
+
     echo "Running ${staging_dir} e2e tests"
     make e2e
     popd

--- a/staging/operator-lifecycle-manager/go.mod
+++ b/staging/operator-lifecycle-manager/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/ghodss/yaml v1.0.0
+	github.com/go-bindata/go-bindata/v3 v3.1.3
 	github.com/go-logr/logr v0.3.0
 	github.com/go-openapi/spec v0.19.4
 	github.com/golang/mock v1.4.1

--- a/staging/operator-lifecycle-manager/go.sum
+++ b/staging/operator-lifecycle-manager/go.sum
@@ -305,6 +305,7 @@ github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
+github.com/go-bindata/go-bindata/v3 v3.1.3 h1:F0nVttLC3ws0ojc7p60veTurcOm//D4QBODNM7EGrCI=
 github.com/go-bindata/go-bindata/v3 v3.1.3/go.mod h1:1/zrpXsLD8YDIbhZRqXzm1Ghc7NhEvIN9+Z6R5/xH4I=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -577,6 +578,7 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uiaSepXwyf3o52HaUYcV+Tu66S3F5GA=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
+github.com/kisielk/errcheck v1.2.0 h1:reN85Pxc5larApoH1keMBiu2GWtPqXQ1nc9gx+jOU+E=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/staging/operator-lifecycle-manager/tools.go
+++ b/staging/operator-lifecycle-manager/tools.go
@@ -3,7 +3,7 @@
 package tools
 
 import (
-	_ "github.com/go-bindata/go-bindata/v3/go-bindata/"
+	_ "github.com/go-bindata/go-bindata/v3/go-bindata"
 	_ "github.com/golang/mock/mockgen"
 	_ "github.com/googleapis/gnostic"
 	_ "github.com/maxbrunsfeld/counterfeiter/v6"

--- a/vendor/github.com/operator-framework/operator-registry/cmd/appregistry-server/main.go
+++ b/vendor/github.com/operator-framework/operator-registry/cmd/appregistry-server/main.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+
+	"github.com/operator-framework/operator-registry/pkg/api"
+	health "github.com/operator-framework/operator-registry/pkg/api/grpc_health_v1"
+	"github.com/operator-framework/operator-registry/pkg/appregistry"
+	"github.com/operator-framework/operator-registry/pkg/lib/dns"
+	"github.com/operator-framework/operator-registry/pkg/lib/log"
+	"github.com/operator-framework/operator-registry/pkg/registry"
+	"github.com/operator-framework/operator-registry/pkg/server"
+)
+
+func main() {
+	var rootCmd = &cobra.Command{
+		Short: "appregistry-server",
+		Long:  `appregistry-server downloads operator manifest(s) from remote appregistry, builds a sqlite database containing these downloaded manifest(s) and serves a grpc API to query it`,
+
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if debug, _ := cmd.Flags().GetBool("debug"); debug {
+				logrus.SetLevel(logrus.DebugLevel)
+			}
+			return nil
+		},
+
+		RunE: runCmdFunc,
+	}
+
+	rootCmd.Flags().Bool("debug", false, "enable debug logging")
+	rootCmd.Flags().StringP("kubeconfig", "k", "", "absolute path to kubeconfig file")
+	rootCmd.Flags().StringP("download-folder", "f", "downloaded", "directory where downloaded nested operator bundle(s) will be stored to be processed further")
+	rootCmd.Flags().StringP("database", "d", "bundles.db", "name of db to output")
+	rootCmd.Flags().StringSliceP("registry", "r", []string{}, "pipe delimited operator source - {base url with cnr prefix}|{quay registry namespace}|{secret namespace/secret name}")
+	rootCmd.Flags().StringP("packages", "o", "", "comma separated list of package(s) to be downloaded from the specified operator source(s). The requested release can be appended to the package name, delimited with a colone (e.g some-pkg:1.1.0)")
+	rootCmd.Flags().StringP("port", "p", "50051", "port number to serve on")
+	rootCmd.Flags().StringP("termination-log", "t", "/dev/termination-log", "path to a container termination log file")
+	rootCmd.Flags().Bool("strict", false, "fail on registry load errors")
+
+	if err := rootCmd.Flags().MarkHidden("debug"); err != nil {
+		logrus.Panic(err.Error())
+	}
+
+	if err := rootCmd.Execute(); err != nil {
+		logrus.Panic(err.Error())
+	}
+}
+
+func runCmdFunc(cmd *cobra.Command, args []string) error {
+	// Immediately set up termination log
+	terminationLogPath, err := cmd.Flags().GetString("termination-log")
+	if err != nil {
+		return err
+	}
+	err = log.AddDefaultWriterHooks(terminationLogPath)
+	if err != nil {
+		logrus.WithError(err).Warn("unable to set termination log path")
+	}
+	// Ensure there is a default nsswitch config
+	if err := dns.EnsureNsswitch(); err != nil {
+		return err
+	}
+	kubeconfig, err := cmd.Flags().GetString("kubeconfig")
+	if err != nil {
+		return err
+	}
+	downloadPath, err := cmd.Flags().GetString("download-folder")
+	if err != nil {
+		return err
+	}
+	port, err := cmd.Flags().GetString("port")
+	if err != nil {
+		return err
+	}
+
+	sources, err := cmd.Flags().GetStringSlice("registry")
+	if err != nil {
+		return err
+	}
+
+	packages, err := cmd.Flags().GetString("packages")
+	if err != nil {
+		return err
+	}
+	dbName, err := cmd.Flags().GetString("database")
+	if err != nil {
+		return err
+	}
+	strict, err := cmd.Flags().GetBool("strict")
+	if err != nil {
+		return err
+	}
+
+	logger := logrus.WithFields(logrus.Fields{"type": "appregistry", "port": port})
+
+	loader, err := appregistry.NewLoader(kubeconfig, dbName, downloadPath, logger)
+	if err != nil {
+		logger.Fatalf("error initializing: %s", err)
+	}
+
+	store, err := loader.Load(sources, packages)
+	if err != nil {
+		err = fmt.Errorf("error loading manifests from appregistry: %s", err)
+		if strict {
+			logger.WithError(err).Fatal("strict mode enabled")
+		}
+		logger.WithError(err).Warn("strict mode disabled")
+	}
+	if store == nil {
+		logger.Warn("using empty querier")
+		store = registry.NewEmptyQuerier()
+	}
+
+	lis, err := net.Listen("tcp", ":"+port)
+	if err != nil {
+		logger.Fatalf("failed to listen: %s", err)
+	}
+	s := grpc.NewServer()
+
+	api.RegisterRegistryServer(s, server.NewRegistryServer(store))
+	health.RegisterHealthServer(s, server.NewHealthServer())
+	reflection.Register(s)
+
+	logger.Info("serving registry")
+	if err := s.Serve(lis); err != nil {
+		logger.Fatalf("failed to serve: %s", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/operator-framework/operator-registry/cmd/configmap-server/main.go
+++ b/vendor/github.com/operator-framework/operator-registry/cmd/configmap-server/main.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/operator-framework/operator-registry/pkg/api"
+	health "github.com/operator-framework/operator-registry/pkg/api/grpc_health_v1"
+	"github.com/operator-framework/operator-registry/pkg/lib/dns"
+	"github.com/operator-framework/operator-registry/pkg/lib/log"
+	"github.com/operator-framework/operator-registry/pkg/registry"
+	"github.com/operator-framework/operator-registry/pkg/server"
+	"github.com/operator-framework/operator-registry/pkg/sqlite"
+)
+
+var rootCmd = &cobra.Command{
+	Short: "configmap-server",
+	Long:  `configmap-server reads a configmap and builds a sqlite database containing operator manifests and serves a grpc API to query it`,
+
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if debug, _ := cmd.Flags().GetBool("debug"); debug {
+			logrus.SetLevel(logrus.DebugLevel)
+		}
+		return nil
+	},
+
+	RunE: runCmdFunc,
+}
+
+func init() {
+	rootCmd.Flags().Bool("debug", false, "enable debug logging")
+	rootCmd.Flags().StringP("kubeconfig", "k", "", "absolute path to kubeconfig file")
+	rootCmd.Flags().StringP("database", "d", "bundles.db", "name of db to output")
+	rootCmd.Flags().StringP("configMapName", "c", "", "name of a configmap")
+	rootCmd.Flags().StringP("configMapNamespace", "n", "", "namespace of a configmap")
+	rootCmd.Flags().StringP("port", "p", "50051", "port number to serve on")
+	rootCmd.Flags().StringP("termination-log", "t", "/dev/termination-log", "path to a container termination log file")
+	rootCmd.Flags().Bool("permissive", false, "allow registry load errors")
+	if err := rootCmd.Flags().MarkHidden("debug"); err != nil {
+		logrus.Panic(err.Error())
+	}
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		logrus.Panic(err.Error())
+	}
+}
+
+func runCmdFunc(cmd *cobra.Command, args []string) error {
+	// Immediately set up termination log
+	terminationLogPath, err := cmd.Flags().GetString("termination-log")
+	if err != nil {
+		return err
+	}
+	err = log.AddDefaultWriterHooks(terminationLogPath)
+	if err != nil {
+		logrus.WithError(err).Warn("unable to set termination log path")
+	}
+	// Ensure there is a default nsswitch config
+	if err := dns.EnsureNsswitch(); err != nil {
+		return err
+	}
+	kubeconfig, err := cmd.Flags().GetString("kubeconfig")
+	if err != nil {
+		return err
+	}
+	port, err := cmd.Flags().GetString("port")
+	if err != nil {
+		return err
+	}
+	configMapName, err := cmd.Flags().GetString("configMapName")
+	if err != nil {
+		return err
+	}
+	configMapNamespace, err := cmd.Flags().GetString("configMapNamespace")
+	if err != nil {
+		return err
+	}
+	dbName, err := cmd.Flags().GetString("database")
+	if err != nil {
+		return err
+	}
+	permissive, err := cmd.Flags().GetBool("permissive")
+	if err != nil {
+		return err
+	}
+	logger := logrus.WithFields(logrus.Fields{"configMapName": configMapName, "configMapNamespace": configMapNamespace, "port": port})
+
+	client := NewClientFromConfig(kubeconfig, logger.Logger)
+	configMap, err := client.CoreV1().ConfigMaps(configMapNamespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
+	if err != nil {
+		logger.Fatalf("error getting configmap: %s", err)
+	}
+
+	db, err := sql.Open("sqlite3", dbName)
+	if err != nil {
+		return err
+	}
+
+	sqlLoader, err := sqlite.NewSQLLiteLoader(db)
+	if err != nil {
+		return err
+	}
+	if err := sqlLoader.Migrate(context.TODO()); err != nil {
+		return err
+	}
+
+	configMapPopulator := sqlite.NewSQLLoaderForConfigMap(sqlLoader, *configMap)
+	if err := configMapPopulator.Populate(); err != nil {
+		err = fmt.Errorf("error loading manifests from configmap: %s", err)
+		if !permissive {
+			logger.WithError(err).Fatal("permissive mode disabled")
+		}
+		logger.WithError(err).Warn("permissive mode enabled")
+	}
+
+	var store registry.Query
+	store, err = sqlite.NewSQLLiteQuerier(dbName)
+	if err != nil {
+		logger.WithError(err).Warnf("failed to load db")
+	}
+	if store == nil {
+		store = registry.NewEmptyQuerier()
+	}
+
+	// sanity check that the db is available
+	tables, err := store.ListTables(context.TODO())
+	if err != nil {
+		logger.WithError(err).Warnf("couldn't list tables in db")
+	}
+	if len(tables) == 0 {
+		logger.Warn("no tables found in db")
+	}
+
+	lis, err := net.Listen("tcp", ":"+port)
+	if err != nil {
+		logger.Fatalf("failed to listen: %s", err)
+	}
+	s := grpc.NewServer()
+
+	api.RegisterRegistryServer(s, server.NewRegistryServer(store))
+	health.RegisterHealthServer(s, server.NewHealthServer())
+	reflection.Register(s)
+
+	logger.Info("serving registry")
+	if err := s.Serve(lis); err != nil {
+		logger.Fatalf("failed to serve: %s", err)
+	}
+	return nil
+}
+
+// NewClient creates a kubernetes client or bails out on on failures.
+func NewClientFromConfig(kubeconfig string, logger *logrus.Logger) kubernetes.Interface {
+	var config *rest.Config
+	var err error
+
+	if kubeconfig != "" {
+		logger.Infof("Loading kube client config from path %q", kubeconfig)
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+	} else {
+		logger.Infof("Using in-cluster kube client config")
+		config, err = rest.InClusterConfig()
+	}
+
+	if err != nil {
+		logger.Fatalf("Cannot load config for REST client: %s", err)
+	}
+
+	return kubernetes.NewForConfigOrDie(config)
+}

--- a/vendor/github.com/operator-framework/operator-registry/cmd/initializer/main.go
+++ b/vendor/github.com/operator-framework/operator-registry/cmd/initializer/main.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/operator-framework/operator-registry/pkg/sqlite"
+)
+
+var rootCmd = &cobra.Command{
+	Short: "initializer",
+	Long:  `initializer takes a directory of OLM manifests and outputs a sqlite database containing them`,
+
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if debug, _ := cmd.Flags().GetBool("debug"); debug {
+			logrus.SetLevel(logrus.DebugLevel)
+		}
+		return nil
+	},
+
+	RunE: runCmdFunc,
+}
+
+func init() {
+	rootCmd.Flags().Bool("debug", false, "enable debug logging")
+	rootCmd.Flags().StringP("manifests", "m", "manifests", "relative path to directory of manifests")
+	rootCmd.Flags().StringP("output", "o", "bundles.db", "relative path to a sqlite file to create or overwrite")
+	rootCmd.Flags().Bool("permissive", false, "allow registry load errors")
+	if err := rootCmd.Flags().MarkHidden("debug"); err != nil {
+		panic(err)
+	}
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		panic(err)
+	}
+}
+
+func runCmdFunc(cmd *cobra.Command, args []string) error {
+	outFilename, err := cmd.Flags().GetString("output")
+	if err != nil {
+		return err
+	}
+	manifestDir, err := cmd.Flags().GetString("manifests")
+	if err != nil {
+		return err
+	}
+	permissive, err := cmd.Flags().GetBool("permissive")
+	if err != nil {
+		return err
+	}
+
+	db, err := sql.Open("sqlite3", outFilename)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	dbLoader, err := sqlite.NewSQLLiteLoader(db)
+	if err != nil {
+		return err
+	}
+	if err := dbLoader.Migrate(context.TODO()); err != nil {
+		return err
+	}
+
+	loader := sqlite.NewSQLLoaderForDirectory(dbLoader, manifestDir)
+	if err := loader.Populate(); err != nil {
+		err = fmt.Errorf("error loading manifests from directory: %s", err)
+		if !permissive {
+			logrus.WithError(err).Fatal("permissive mode disabled")
+			return err
+		}
+		logrus.WithError(err).Warn("permissive mode enabled")
+	}
+
+	return nil
+}

--- a/vendor/github.com/operator-framework/operator-registry/cmd/registry-server/main.go
+++ b/vendor/github.com/operator-framework/operator-registry/cmd/registry-server/main.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+
+	"github.com/operator-framework/operator-registry/pkg/api"
+	health "github.com/operator-framework/operator-registry/pkg/api/grpc_health_v1"
+	"github.com/operator-framework/operator-registry/pkg/lib/dns"
+	"github.com/operator-framework/operator-registry/pkg/lib/log"
+	"github.com/operator-framework/operator-registry/pkg/lib/tmp"
+	"github.com/operator-framework/operator-registry/pkg/server"
+	"github.com/operator-framework/operator-registry/pkg/sqlite"
+)
+
+var rootCmd = &cobra.Command{
+	Short: "registry-server",
+	Long:  `registry loads a sqlite database containing operator manifests and serves a grpc API to query it`,
+
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if debug, _ := cmd.Flags().GetBool("debug"); debug {
+			logrus.SetLevel(logrus.DebugLevel)
+		}
+		return nil
+	},
+
+	RunE: runCmdFunc,
+}
+
+func init() {
+	rootCmd.Flags().Bool("debug", false, "enable debug logging")
+	rootCmd.Flags().StringP("database", "d", "bundles.db", "relative path to sqlite db")
+	rootCmd.Flags().StringP("port", "p", "50051", "port number to serve on")
+	rootCmd.Flags().StringP("termination-log", "t", "/dev/termination-log", "path to a container termination log file")
+	rootCmd.Flags().Bool("skip-migrate", false, "do  not attempt to migrate to the latest db revision when starting")
+	if err := rootCmd.Flags().MarkHidden("debug"); err != nil {
+		logrus.Panic(err.Error())
+	}
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		logrus.Panic(err.Error())
+	}
+}
+
+func runCmdFunc(cmd *cobra.Command, args []string) error {
+	// Immediately set up termination log
+	terminationLogPath, err := cmd.Flags().GetString("termination-log")
+	if err != nil {
+		return err
+	}
+	err = log.AddDefaultWriterHooks(terminationLogPath)
+	if err != nil {
+		logrus.WithError(err).Warn("unable to set termination log path")
+	}
+	// Ensure there is a default nsswitch config
+	if err := dns.EnsureNsswitch(); err != nil {
+		return err
+	}
+	dbName, err := cmd.Flags().GetString("database")
+	if err != nil {
+		return err
+	}
+
+	port, err := cmd.Flags().GetString("port")
+	if err != nil {
+		return err
+	}
+
+	logger := logrus.WithFields(logrus.Fields{"database": dbName, "port": port})
+
+	// make a writable copy of the db for migrations
+	tmpdb, err := tmp.CopyTmpDB(dbName)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmpdb)
+
+	db, err := sql.Open("sqlite3", tmpdb)
+	if err != nil {
+		return err
+	}
+
+	// migrate to the latest version
+	if err := migrate(cmd, db); err != nil {
+		logger.WithError(err).Warnf("couldn't migrate db")
+	}
+
+	store := sqlite.NewSQLLiteQuerierFromDb(db)
+
+	// sanity check that the db is available
+	tables, err := store.ListTables(context.TODO())
+	if err != nil {
+		logger.WithError(err).Warnf("couldn't list tables in db")
+	}
+	if len(tables) == 0 {
+		logger.Warn("no tables found in db")
+	}
+
+	lis, err := net.Listen("tcp", ":"+port)
+	if err != nil {
+		logger.Fatalf("failed to listen: %s", err)
+	}
+	s := grpc.NewServer()
+
+	api.RegisterRegistryServer(s, server.NewRegistryServer(store))
+	health.RegisterHealthServer(s, server.NewHealthServer())
+	reflection.Register(s)
+	logger.Info("serving registry")
+	if err := s.Serve(lis); err != nil {
+		logger.Fatalf("failed to serve: %s", err)
+	}
+
+	return nil
+}
+
+func migrate(cmd *cobra.Command, db *sql.DB) error {
+	shouldSkipMigrate, err := cmd.Flags().GetBool("skip-migrate")
+	if err != nil {
+		return err
+	}
+	if shouldSkipMigrate {
+		return nil
+	}
+
+	migrator, err := sqlite.NewSQLLiteMigrator(db)
+	if err != nil {
+		return err
+	}
+	if migrator == nil {
+		return fmt.Errorf("failed to load migrator")
+	}
+
+	return migrator.Migrate(context.TODO())
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -551,12 +551,16 @@ github.com/operator-framework/operator-lifecycle-manager/test/e2e/assets/chart
 github.com/operator-framework/operator-lifecycle-manager/test/e2e/ctx
 # github.com/operator-framework/operator-registry v0.0.0-00010101000000-000000000000 => ./staging/operator-registry
 ## explicit
+github.com/operator-framework/operator-registry/cmd/appregistry-server
+github.com/operator-framework/operator-registry/cmd/configmap-server
+github.com/operator-framework/operator-registry/cmd/initializer
 github.com/operator-framework/operator-registry/cmd/opm
 github.com/operator-framework/operator-registry/cmd/opm/alpha
 github.com/operator-framework/operator-registry/cmd/opm/alpha/bundle
 github.com/operator-framework/operator-registry/cmd/opm/index
 github.com/operator-framework/operator-registry/cmd/opm/registry
 github.com/operator-framework/operator-registry/cmd/opm/version
+github.com/operator-framework/operator-registry/cmd/registry-server
 github.com/operator-framework/operator-registry/pkg/api
 github.com/operator-framework/operator-registry/pkg/api/grpc_health_v1
 github.com/operator-framework/operator-registry/pkg/apprclient


### PR DESCRIPTION
Update the staging OLM modules so that running `make vendor` in that
directory can be successful.

Note: we may need to add a check that verifies that `make vendor && git
diff --exit-code` 
for _all_ of the nested modules, and not just the root repository.

Also, when I re-ran `make vendor` at the root, I keep getting extra
files added. We may need to encode some logic of removing any
staging/operator-registry/pkg/sqlite/migrations/*.db-journal files after
pulling down upstream changes.