### PR TITLE
Dockerfile,Makefile: Add opm binary and cross compilation target(s)

### DIFF
--- a/operator-registry.Dockerfile
+++ b/operator-registry.Dockerfile
@@ -6,7 +6,7 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 WORKDIR /src
 
 COPY . .
-RUN make build/registry
+RUN make build/registry cross
 
 # copy and build vendored grpc_health_probe
 RUN CGO_ENABLED=0 go build -mod=vendor -tags netgo -ldflags "-w" ./vendor/github.com/grpc-ecosystem/grpc-health-probe/...


### PR DESCRIPTION
Update the Makefile and add the opm binary to the list of registry
binaries.

Update the Makefile and add the cross compilation target for non-linux
OS(s).

Update the operator-registry Dockerfile and add the `make cross` target
to the build stage image.