### PR TITLE
Bug 1945584: Remove overrides for GOOS and GOARCH in cpb Makefile recipe.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,10 +84,8 @@ build/registry-container:
 bin/kubebuilder:
 	$(ROOT_DIR)/scripts/install_kubebuilder.sh
 
-build-util: bin/cpb
-bin/cpb: arch_flags=GOOS=linux GOARCH=386
 bin/cpb: FORCE
-	CGO_ENABLED=0 $(arch_flags) go build $(GO_BUILD_OPTS) -ldflags '-extldflags "-static"' -o $@ ./util/cpb
+	CGO_ENABLED=0 go build $(GO_BUILD_OPTS) -ldflags '-extldflags "-static"' -o $@ ./util/cpb
 
 unit/olm: bin/kubebuilder
 	$(MAKE) unit WHAT=operator-lifecycle-manager

--- a/operator-lifecycle-manager.Dockerfile
+++ b/operator-lifecycle-manager.Dockerfile
@@ -12,8 +12,7 @@ COPY .git/refs/heads/. .git/refs/heads
 RUN mkdir -p .git/objects
 
 COPY . .
-RUN make build/olm
-RUN make build-util
+RUN make build/olm bin/cpb
 
 FROM registry.ci.openshift.org/ocp/4.8:base
 


### PR DESCRIPTION
This appears to have been a mistake during the downstream migration
and results in broken bundle unpack jobs on non-x86 hosts.