### PR TITLE
Add management workload annotations

### DIFF
--- a/manifests/0000_50_olm_00-namespace.yaml
+++ b/manifests/0000_50_olm_00-namespace.yaml
@@ -4,6 +4,7 @@ metadata:
   name: openshift-operator-lifecycle-manager
   annotations:
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -17,6 +18,7 @@ metadata:
   name: openshift-operators
   annotations:
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
+++ b/manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
@@ -16,6 +16,8 @@ spec:
       app: olm-operator
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: olm-operator
     spec:

--- a/manifests/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/manifests/0000_50_olm_07-olm-operator.deployment.yaml
@@ -17,6 +17,8 @@ spec:
       app: olm-operator
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: olm-operator
     spec:

--- a/manifests/0000_50_olm_08-catalog-operator.deployment.ibm-cloud-managed.yaml
+++ b/manifests/0000_50_olm_08-catalog-operator.deployment.ibm-cloud-managed.yaml
@@ -16,6 +16,8 @@ spec:
       app: catalog-operator
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: catalog-operator
     spec:

--- a/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -17,6 +17,8 @@ spec:
       app: catalog-operator
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: catalog-operator
     spec:

--- a/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+++ b/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
@@ -3,13 +3,14 @@ kind: ClusterServiceVersion
 metadata:
   name: packageserver
   namespace: openshift-operator-lifecycle-manager
-  labels:
-    olm.version: 0.17.0
-    olm.clusteroperator.name: operator-lifecycle-manager-packageserver
   annotations:
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  labels:
+    olm.version: 0.17.0
+    olm.clusteroperator.name: operator-lifecycle-manager-packageserver
 spec:
   displayName: Package Server
   description: Represents an Operator package that is available from a given CatalogSource which will resolve to a ClusterServiceVersion.
@@ -79,6 +80,8 @@ spec:
                 app: packageserver
             template:
               metadata:
+                annotations:
+                  workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
                 labels:
                   app: packageserver
               spec:

--- a/staging/operator-lifecycle-manager/deploy/chart/templates/0000_50_olm_00-namespace.yaml
+++ b/staging/operator-lifecycle-manager/deploy/chart/templates/0000_50_olm_00-namespace.yaml
@@ -5,6 +5,7 @@ metadata:
   {{ if and .Values.installType (eq .Values.installType "ocp") }}
   annotations:
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/scc: "anyuid"
     openshift.io/cluster-monitoring: "true"
@@ -17,6 +18,7 @@ metadata:
   {{ if and .Values.installType (eq .Values.installType "ocp") }}
   annotations:
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/scc: "anyuid"
   {{ end }}

--- a/staging/operator-lifecycle-manager/deploy/chart/templates/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/staging/operator-lifecycle-manager/deploy/chart/templates/0000_50_olm_07-olm-operator.deployment.yaml
@@ -14,6 +14,10 @@ spec:
       app: olm-operator
   template:
     metadata:
+      {{- if and .Values.installType (eq .Values.installType "ocp") }}
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      {{- end }}
       labels:
         app: olm-operator
     spec:

--- a/staging/operator-lifecycle-manager/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/staging/operator-lifecycle-manager/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -14,6 +14,10 @@ spec:
       app: catalog-operator
   template:
     metadata:
+      {{- if and .Values.installType (eq .Values.installType "ocp") }}
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      {{- end }}
       labels:
         app: catalog-operator
     spec:

--- a/staging/operator-lifecycle-manager/deploy/chart/templates/_packageserver.clusterserviceversion.yaml
+++ b/staging/operator-lifecycle-manager/deploy/chart/templates/_packageserver.clusterserviceversion.yaml
@@ -4,6 +4,14 @@ kind: ClusterServiceVersion
 metadata:
   name: packageserver
   namespace: {{ .Values.namespace }}
+  {{- if and .Values.installType (eq .Values.installType "ocp") }}
+  {{- /*
+  This annotation injection is a workaround for BZ-1950047, since the associate
+  annotation in _packageserver.deployment-spec.yaml is presently ignored.
+  */}}
+  annotations:
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+  {{- end }}
   labels:
     olm.version: {{ .Chart.Version }}
     {{- if .Values.writePackageServerStatusName }}

--- a/staging/operator-lifecycle-manager/deploy/chart/templates/_packageserver.deployment-spec.yaml
+++ b/staging/operator-lifecycle-manager/deploy/chart/templates/_packageserver.deployment-spec.yaml
@@ -8,6 +8,10 @@ spec:
       app: packageserver
   template:
     metadata:
+      {{- if and .Values.installType (eq .Values.installType "ocp") }}
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      {{- end }}
       labels:
         app: packageserver
     spec:


### PR DESCRIPTION
In support of the workload partitioning feature
(https://github.com/openshift/enhancements/pull/703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.