### PR TITLE
Makefile: Introduce verify target that checks for unstaged changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,10 @@ sanity:
 manifests: vendor ## Generate manifests
 	./scripts/generate_crds_manifests.sh
 
+verify: vendor
+	@echo Checking for unstaged changes
+	git diff --stat HEAD --ignore-submodules --exit-code
+
 .PHONY: help
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)


### PR DESCRIPTION
This already lives as a check in the openshfit/release repository as a
series of commands, but ideally this should live as a Makefile target
that we instead just call in this verify target in the `verify` prow job.