### PR TITLE
staging/operator-registry: Pull in all non-opm-add declarative config updates

### DIFF
--- a/staging/operator-registry/Makefile
+++ b/staging/operator-registry/Makefile
@@ -42,7 +42,7 @@ static: build
 
 .PHONY: unit
 unit:
-	$(GO) test -coverprofile=coverage.out $(SPECIFIC_UNIT_TEST) $(TAGS) $(TEST_RACE) -count=1 -v ./pkg/...
+	$(GO) test -coverprofile=coverage.out $(SPECIFIC_UNIT_TEST) $(TAGS) $(TEST_RACE) -count=1 -v ./pkg/... ./internal/...
 
 .PHONY: sanity-check
 sanity-check:

--- a/staging/operator-registry/cmd/opm/root/cmd.go
+++ b/staging/operator-registry/cmd/opm/root/cmd.go
@@ -25,7 +25,7 @@ func NewCmd() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(registry.NewOpmRegistryCmd(), alpha.NewCmd(), serve.NewCmd(), validate.NewConfigValidateCmd())
+	cmd.AddCommand(registry.NewOpmRegistryCmd(), alpha.NewCmd(), serve.NewCmd(), validate.NewCmd())
 	index.AddCommand(cmd)
 	version.AddCommand(cmd)
 

--- a/staging/operator-registry/cmd/opm/root/cmd.go
+++ b/staging/operator-registry/cmd/opm/root/cmd.go
@@ -8,6 +8,7 @@ import (
 	"github.com/operator-framework/operator-registry/cmd/opm/index"
 	"github.com/operator-framework/operator-registry/cmd/opm/registry"
 	"github.com/operator-framework/operator-registry/cmd/opm/serve"
+	"github.com/operator-framework/operator-registry/cmd/opm/validate"
 	"github.com/operator-framework/operator-registry/cmd/opm/version"
 )
 
@@ -24,7 +25,7 @@ func NewCmd() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(registry.NewOpmRegistryCmd(), alpha.NewCmd(), serve.NewCmd())
+	cmd.AddCommand(registry.NewOpmRegistryCmd(), alpha.NewCmd(), serve.NewCmd(), validate.NewConfigValidateCmd())
 	index.AddCommand(cmd)
 	version.AddCommand(cmd)
 

--- a/staging/operator-registry/cmd/opm/validate/validate.go
+++ b/staging/operator-registry/cmd/opm/validate/validate.go
@@ -1,0 +1,50 @@
+package validate
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/operator-framework/operator-registry/pkg/lib/config"
+)
+
+func NewConfigValidateCmd() *cobra.Command {
+	validate := &cobra.Command{
+		Use:   "validate <directory>",
+		Short: "Validate the declarative index config",
+		Long:  "Validate the declarative config JSON file(s) in a given directory",
+		Args: func(cmd *cobra.Command, args []string) error {
+			return cobra.ExactArgs(1)(cmd, args)
+		},
+		RunE: configValidate,
+	}
+
+	validate.Flags().BoolP("debug", "d", false, "enable debug log output")
+	return validate
+}
+
+func configValidate(cmd *cobra.Command, args []string) error {
+	debug, err := cmd.Flags().GetBool("debug")
+	if err != nil {
+		return err
+	}
+
+	logger := logrus.WithField("cmd", "validate")
+	if debug {
+		logger.Logger.SetLevel(logrus.DebugLevel)
+	}
+
+	if _, err := os.Stat(args[0]); os.IsNotExist(err) {
+		logger.Error(err.Error())
+	}
+
+	err = config.ValidateConfig(args[0])
+	if err != nil {
+		logger.Error(err.Error())
+		return fmt.Errorf("failed to validate config: %s", err)
+	}
+
+	return nil
+}

--- a/staging/operator-registry/cmd/opm/validate/validate.go
+++ b/staging/operator-registry/cmd/opm/validate/validate.go
@@ -10,15 +10,13 @@ import (
 	"github.com/operator-framework/operator-registry/pkg/lib/config"
 )
 
-func NewConfigValidateCmd() *cobra.Command {
+func NewCmd() *cobra.Command {
 	validate := &cobra.Command{
 		Use:   "validate <directory>",
 		Short: "Validate the declarative index config",
 		Long:  "Validate the declarative config JSON file(s) in a given directory",
-		Args: func(cmd *cobra.Command, args []string) error {
-			return cobra.ExactArgs(1)(cmd, args)
-		},
-		RunE: configValidate,
+		Args:  cobra.ExactArgs(1),
+		RunE:  configValidate,
 	}
 
 	validate.Flags().BoolP("debug", "d", false, "enable debug log output")
@@ -31,16 +29,17 @@ func configValidate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	directory := args[0]
+	if _, err := os.Stat(directory); os.IsNotExist(err) {
+		return err
+	}
+
 	logger := logrus.WithField("cmd", "validate")
 	if debug {
 		logger.Logger.SetLevel(logrus.DebugLevel)
 	}
 
-	if _, err := os.Stat(args[0]); os.IsNotExist(err) {
-		logger.Error(err.Error())
-	}
-
-	err = config.ValidateConfig(args[0])
+	err = config.ValidateConfig(directory)
 	if err != nil {
 		logger.Error(err.Error())
 		return fmt.Errorf("failed to validate config: %s", err)

--- a/staging/operator-registry/internal/declcfg/declcfg_to_model.go
+++ b/staging/operator-registry/internal/declcfg/declcfg_to_model.go
@@ -41,8 +41,16 @@ func ConvertToModel(cfg DeclarativeConfig) (model.Model, error) {
 			return nil, fmt.Errorf("parse properties for bundle %q: %v", b.Name, err)
 		}
 
+		if len(props.Packages) == 0 {
+			return nil, fmt.Errorf("missing package property for bundle %q", b.Name)
+		}
+
 		if b.Package != props.Packages[0].PackageName {
 			return nil, fmt.Errorf("package %q does not match %q property %q", b.Package, property.TypePackage, props.Packages[0].PackageName)
+		}
+
+		if len(props.Channels) == 0 {
+			return nil, fmt.Errorf("bundle %q is missing channel information", b.Name)
 		}
 
 		for _, bundleChannel := range props.Channels {
@@ -75,7 +83,7 @@ func ConvertToModel(cfg DeclarativeConfig) (model.Model, error) {
 
 	for _, mpkg := range mpkgs {
 		defaultChannelName := defaultChannels[mpkg.Name]
-		if mpkg.DefaultChannel == nil {
+		if defaultChannelName != "" && mpkg.DefaultChannel == nil {
 			dch := &model.Channel{
 				Package: mpkg,
 				Name:    defaultChannelName,

--- a/staging/operator-registry/internal/declcfg/declcfg_to_model_test.go
+++ b/staging/operator-registry/internal/declcfg/declcfg_to_model_test.go
@@ -28,11 +28,11 @@ func TestConvertToModel(t *testing.T) {
 			assertion: require.Error,
 			cfg: DeclarativeConfig{
 				Packages: []Package{newTestPackage("foo", "alpha", svgSmallCircle)},
-				Bundles:  []Bundle{newTestBundle("bar", "0.1.0")},
+				Bundles:  []Bundle{newTestBundle("bar", "0.1.0", withChannel("alpha", ""))},
 			},
 		},
 		{
-			name:      "Error/FailedModelValidation",
+			name:      "Error/BundleMissingChannel",
 			assertion: require.Error,
 			cfg: DeclarativeConfig{
 				Packages: []Package{newTestPackage("foo", "alpha", svgSmallCircle)},
@@ -45,6 +45,38 @@ func TestConvertToModel(t *testing.T) {
 			cfg: DeclarativeConfig{
 				Packages: []Package{newTestPackage("foo", "alpha", svgSmallCircle)},
 				Bundles:  []Bundle{newTestBundle("foo", "0.1.0", withChannel("alpha", "1"), withChannel("alpha", "2"))},
+			},
+		},
+		{
+			name:      "Error/BundleMissingDefaultChannel",
+			assertion: require.Error,
+			cfg: DeclarativeConfig{
+				Packages: []Package{newTestPackage("foo", "", svgSmallCircle)},
+				Bundles:  []Bundle{newTestBundle("foo", "0.1.0", withChannel("alpha", ""))},
+			},
+		},
+		{
+			name:      "Error/BundleMissingImageAndData",
+			assertion: require.Error,
+			cfg: DeclarativeConfig{
+				Packages: []Package{newTestPackage("foo", "alpha", svgSmallCircle)},
+				Bundles:  []Bundle{newTestBundle("foo", "0.1.0", withChannel("alpha", ""), withNoBundleImage(), withNoBundleData())},
+			},
+		},
+		{
+			name:      "NoError/BundleMissingProperties",
+			assertion: require.Error,
+			cfg: DeclarativeConfig{
+				Packages: []Package{newTestPackage("foo", "alpha", svgSmallCircle)},
+				Bundles:  []Bundle{newTestBundle("foo", "0.1.0", withChannel("alpha", ""), withNoProperties())},
+			},
+		},
+		{
+			name:      "NoError/BundleWithDataButMissingImage",
+			assertion: require.NoError,
+			cfg: DeclarativeConfig{
+				Packages: []Package{newTestPackage("foo", "alpha", svgSmallCircle)},
+				Bundles:  []Bundle{newTestBundle("foo", "0.1.0", withChannel("alpha", ""), withNoBundleImage())},
 			},
 		},
 		{

--- a/staging/operator-registry/internal/declcfg/helpers_test.go
+++ b/staging/operator-registry/internal/declcfg/helpers_test.go
@@ -79,6 +79,25 @@ func withSkips(name string) func(*Bundle) {
 	}
 }
 
+func withNoProperties() func(*Bundle) {
+	return func(b *Bundle) {
+		b.Properties = []property.Property{}
+	}
+}
+
+func withNoBundleImage() func(*Bundle) {
+	return func(b *Bundle) {
+		b.Image = ""
+	}
+}
+
+func withNoBundleData() func(*Bundle) {
+	return func(b *Bundle) {
+		b.Objects = []string{}
+		b.CsvJSON = ""
+	}
+}
+
 func newTestBundle(packageName, version string, opts ...bundleOpt) Bundle {
 	csvJson := fmt.Sprintf(`{"kind": "ClusterServiceVersion", "apiVersion": "operators.coreos.com/v1alpha1", "metadata":{"name":%q}}`, testBundleName(packageName, version))
 	b := Bundle{

--- a/staging/operator-registry/internal/model/model.go
+++ b/staging/operator-registry/internal/model/model.go
@@ -54,12 +54,12 @@ func (m *Package) Validate() error {
 		result = multierror.Append(result, fmt.Errorf("invalid icon: %v", err))
 	}
 
-	if len(m.Channels) == 0 {
-		result = multierror.Append(result, fmt.Errorf("package must contain at least one channel"))
-	}
-
 	if m.DefaultChannel == nil {
 		result = multierror.Append(result, fmt.Errorf("default channel must be set"))
+	}
+
+	if len(m.Channels) == 0 {
+		result = multierror.Append(result, fmt.Errorf("package must contain at least one channel"))
 	}
 
 	foundDefault := false
@@ -258,6 +258,10 @@ func (b *Bundle) Validate() error {
 
 	if props != nil && len(props.Packages) != 1 {
 		result = multierror.Append(result, fmt.Errorf("must be exactly one property with type %q", property.TypePackage))
+	}
+
+	if b.Image == "" && len(b.Objects) == 0 {
+		result = multierror.Append(result, errors.New("bundle image must be set"))
 	}
 
 	return result.ErrorOrNil()

--- a/staging/operator-registry/internal/model/model_test.go
+++ b/staging/operator-registry/internal/model/model_test.go
@@ -362,7 +362,7 @@ func TestValidators(t *testing.T) {
 				Package:  pkg,
 				Channel:  ch,
 				Name:     "anakin.v0.1.0",
-				Image:    "",
+				Image:    "registry.io/image",
 				Replaces: "anakin.v0.0.1",
 				Skips:    []string{"anakin.v0.0.2"},
 				Properties: []property.Property{
@@ -374,6 +374,39 @@ func TestValidators(t *testing.T) {
 				},
 			},
 			assertion: require.NoError,
+		},
+		{
+			name: "Bundle/Success/NoBundleImage/HaveBundleData",
+			v: &Bundle{
+				Package: pkg,
+				Channel: ch,
+				Name:    "anakin.v0.1.0",
+				Image:   "",
+				Properties: []property.Property{
+					property.MustBuildPackage("anakin", "0.1.0"),
+					property.MustBuildGVK("skywalker.me", "v1alpha1", "PodRacer"),
+					property.MustBuildChannel("light", "anakin.v0.0.1"),
+					property.MustBuildBundleObjectRef("path/to/data"),
+				},
+				Objects: []string{"testdata"},
+				CsvJSON: "CSVjson",
+			},
+			assertion: require.NoError,
+		},
+		{
+			name: "Bundle/Error/NoBundleImage/NoBundleData",
+			v: &Bundle{
+				Package: pkg,
+				Channel: ch,
+				Name:    "anakin.v0.1.0",
+				Image:   "",
+				Properties: []property.Property{
+					property.MustBuildPackage("anakin", "0.1.0"),
+					property.MustBuildGVK("skywalker.me", "v1alpha1", "PodRacer"),
+					property.MustBuildChannel("light", "anakin.v0.0.1"),
+				},
+			},
+			assertion: require.Error,
 		},
 		{
 			name:      "Bundle/Error/NoName",

--- a/staging/operator-registry/operator-registry.Dockerfile
+++ b/staging/operator-registry/operator-registry.Dockerfile
@@ -1,1 +1,0 @@
-Dockerfile

--- a/staging/operator-registry/pkg/api/api_to_model.go
+++ b/staging/operator-registry/pkg/api/api_to_model.go
@@ -86,10 +86,11 @@ func convertAPIBundleToModelProperties(b *Bundle) ([]property.Property, error) {
 			k := property.GVKRequired{Group: v.Group, Kind: v.Kind, Version: v.Version}
 			requiredGVKs[k] = struct{}{}
 		case property.TypePackage:
-			out = append(out, property.Property{
-				Type:  property.TypePackageRequired,
-				Value: json.RawMessage(p.Value),
-			})
+			var v property.Package
+			if err := json.Unmarshal(json.RawMessage(p.Value), &v); err != nil {
+				return nil, property.ParseError{Idx: i, Typ: p.Type, Err: err}
+			}
+			out = append(out, property.MustBuildPackageRequired(v.PackageName, v.Version))
 		}
 	}
 

--- a/staging/operator-registry/pkg/api/conversion_test.go
+++ b/staging/operator-registry/pkg/api/conversion_test.go
@@ -1,0 +1,140 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/operator-framework/operator-registry/internal/model"
+	"github.com/operator-framework/operator-registry/internal/property"
+)
+
+func TestConvertAPIBundleToModelBundle(t *testing.T) {
+	apiBundle := testAPIBundle()
+	expected := testModelBundle()
+
+	actual, err := ConvertAPIBundleToModelBundle(&apiBundle)
+	require.NoError(t, err)
+	assertEqualsModelBundle(t, expected, *actual)
+}
+
+func TestConvertModelBundleToAPIBundle(t *testing.T) {
+	modelBundle := testModelBundle()
+	modelBundle.Package = &model.Package{Name: "etcd"}
+	modelBundle.Channel = &model.Channel{Name: "singlenamespace-alpha"}
+	expected := testAPIBundle()
+	expected.Properties = append(expected.Properties,
+		&Property{Type: "olm.channel", Value: "{\"name\":\"singlenamespace-alpha\",\"replaces\":\"etcdoperator.v0.9.2\"}"},
+		&Property{Type: "olm.package.required", Value: "{\"packageName\":\"test\",\"versionRange\":\">=1.2.3 <2.0.0-0\"}"},
+		&Property{Type: "olm.gvk.required", Value: "{\"group\":\"testapi.coreos.com\",\"kind\":\"Testapi\",\"version\":\"v1\"}"},
+	)
+
+	actual, err := ConvertModelBundleToAPIBundle(modelBundle)
+	require.NoError(t, err)
+	assertEqualsAPIBundle(t, expected, *actual)
+}
+
+const (
+	csvJson     = "{\"apiVersion\":\"operators.coreos.com/v1alpha1\",\"kind\":\"ClusterServiceVersion\",\"metadata\":{\"annotations\":{\"alm-examples\":\"[\\n  {\\n    \\\"apiVersion\\\": \\\"etcd.database.coreos.com/v1beta2\\\",\\n    \\\"kind\\\": \\\"EtcdCluster\\\",\\n    \\\"metadata\\\": {\\n      \\\"name\\\": \\\"example\\\"\\n    },\\n    \\\"spec\\\": {\\n      \\\"size\\\": 3,\\n      \\\"version\\\": \\\"3.2.13\\\"\\n    }\\n  },\\n  {\\n    \\\"apiVersion\\\": \\\"etcd.database.coreos.com/v1beta2\\\",\\n    \\\"kind\\\": \\\"EtcdRestore\\\",\\n    \\\"metadata\\\": {\\n      \\\"name\\\": \\\"example-etcd-cluster-restore\\\"\\n    },\\n    \\\"spec\\\": {\\n      \\\"etcdCluster\\\": {\\n        \\\"name\\\": \\\"example-etcd-cluster\\\"\\n      },\\n      \\\"backupStorageType\\\": \\\"S3\\\",\\n      \\\"s3\\\": {\\n        \\\"path\\\": \\\"\\u003cfull-s3-path\\u003e\\\",\\n        \\\"awsSecret\\\": \\\"\\u003caws-secret\\u003e\\\"\\n      }\\n    }\\n  },\\n  {\\n    \\\"apiVersion\\\": \\\"etcd.database.coreos.com/v1beta2\\\",\\n    \\\"kind\\\": \\\"EtcdBackup\\\",\\n    \\\"metadata\\\": {\\n      \\\"name\\\": \\\"example-etcd-cluster-backup\\\"\\n    },\\n    \\\"spec\\\": {\\n      \\\"etcdEndpoints\\\": [\\\"\\u003cetcd-cluster-endpoints\\u003e\\\"],\\n      \\\"storageType\\\":\\\"S3\\\",\\n      \\\"s3\\\": {\\n        \\\"path\\\": \\\"\\u003cfull-s3-path\\u003e\\\",\\n        \\\"awsSecret\\\": \\\"\\u003caws-secret\\u003e\\\"\\n      }\\n    }\\n  }\\n]\\n\",\"capabilities\":\"Full Lifecycle\",\"categories\":\"Database\",\"containerImage\":\"quay.io/coreos/etcd-operator@sha256:66a37fd61a06a43969854ee6d3e21087a98b93838e284a6086b13917f96b0d9b\",\"createdAt\":\"2019-02-28 01:03:00\",\"description\":\"Create and maintain highly-available etcd clusters on Kubernetes\",\"repository\":\"https://github.com/coreos/etcd-operator\",\"tectonic-visibility\":\"ocs\"},\"name\":\"etcdoperator.v0.9.4\",\"namespace\":\"placeholder\"},\"spec\":{\"relatedImages\":[{\"name\":\"etcdv0.9.4\",\"image\":\"quay.io/coreos/etcd-operator@sha256:66a37fd61a06a43969854ee6d3e21087a98b93838e284a6086b13917f96b0d9b\"}],\"customresourcedefinitions\":{\"owned\":[{\"description\":\"Represents a cluster of etcd nodes.\",\"displayName\":\"etcd Cluster\",\"kind\":\"EtcdCluster\",\"name\":\"etcdclusters.etcd.database.coreos.com\",\"resources\":[{\"kind\":\"Service\",\"version\":\"v1\"},{\"kind\":\"Pod\",\"version\":\"v1\"}],\"specDescriptors\":[{\"description\":\"The desired number of member Pods for the etcd cluster.\",\"displayName\":\"Size\",\"path\":\"size\",\"x-descriptors\":[\"urn:alm:descriptor:com.tectonic.ui:podCount\"]},{\"description\":\"Limits describes the minimum/maximum amount of compute resources required/allowed\",\"displayName\":\"Resource Requirements\",\"path\":\"pod.resources\",\"x-descriptors\":[\"urn:alm:descriptor:com.tectonic.ui:resourceRequirements\"]}],\"statusDescriptors\":[{\"description\":\"The status of each of the member Pods for the etcd cluster.\",\"displayName\":\"Member Status\",\"path\":\"members\",\"x-descriptors\":[\"urn:alm:descriptor:com.tectonic.ui:podStatuses\"]},{\"description\":\"The service at which the running etcd cluster can be accessed.\",\"displayName\":\"Service\",\"path\":\"serviceName\",\"x-descriptors\":[\"urn:alm:descriptor:io.kubernetes:Service\"]},{\"description\":\"The current size of the etcd cluster.\",\"displayName\":\"Cluster Size\",\"path\":\"size\"},{\"description\":\"The current version of the etcd cluster.\",\"displayName\":\"Current Version\",\"path\":\"currentVersion\"},{\"description\":\"The target version of the etcd cluster, after upgrading.\",\"displayName\":\"Target Version\",\"path\":\"targetVersion\"},{\"description\":\"The current status of the etcd cluster.\",\"displayName\":\"Status\",\"path\":\"phase\",\"x-descriptors\":[\"urn:alm:descriptor:io.kubernetes.phase\"]},{\"description\":\"Explanation for the current status of the cluster.\",\"displayName\":\"Status Details\",\"path\":\"reason\",\"x-descriptors\":[\"urn:alm:descriptor:io.kubernetes.phase:reason\"]}],\"version\":\"v1beta2\"},{\"description\":\"Represents the intent to backup an etcd cluster.\",\"displayName\":\"etcd Backup\",\"kind\":\"EtcdBackup\",\"name\":\"etcdbackups.etcd.database.coreos.com\",\"specDescriptors\":[{\"description\":\"Specifies the endpoints of an etcd cluster.\",\"displayName\":\"etcd Endpoint(s)\",\"path\":\"etcdEndpoints\",\"x-descriptors\":[\"urn:alm:descriptor:etcd:endpoint\"]},{\"description\":\"The full AWS S3 path where the backup is saved.\",\"displayName\":\"S3 Path\",\"path\":\"s3.path\",\"x-descriptors\":[\"urn:alm:descriptor:aws:s3:path\"]},{\"description\":\"The name of the secret object that stores the AWS credential and config files.\",\"displayName\":\"AWS Secret\",\"path\":\"s3.awsSecret\",\"x-descriptors\":[\"urn:alm:descriptor:io.kubernetes:Secret\"]}],\"statusDescriptors\":[{\"description\":\"Indicates if the backup was successful.\",\"displayName\":\"Succeeded\",\"path\":\"succeeded\",\"x-descriptors\":[\"urn:alm:descriptor:text\"]},{\"description\":\"Indicates the reason for any backup related failures.\",\"displayName\":\"Reason\",\"path\":\"reason\",\"x-descriptors\":[\"urn:alm:descriptor:io.kubernetes.phase:reason\"]}],\"version\":\"v1beta2\"},{\"description\":\"Represents the intent to restore an etcd cluster from a backup.\",\"displayName\":\"etcd Restore\",\"kind\":\"EtcdRestore\",\"name\":\"etcdrestores.etcd.database.coreos.com\",\"specDescriptors\":[{\"description\":\"References the EtcdCluster which should be restored,\",\"displayName\":\"etcd Cluster\",\"path\":\"etcdCluster.name\",\"x-descriptors\":[\"urn:alm:descriptor:io.kubernetes:EtcdCluster\",\"urn:alm:descriptor:text\"]},{\"description\":\"The full AWS S3 path where the backup is saved.\",\"displayName\":\"S3 Path\",\"path\":\"s3.path\",\"x-descriptors\":[\"urn:alm:descriptor:aws:s3:path\"]},{\"description\":\"The name of the secret object that stores the AWS credential and config files.\",\"displayName\":\"AWS Secret\",\"path\":\"s3.awsSecret\",\"x-descriptors\":[\"urn:alm:descriptor:io.kubernetes:Secret\"]}],\"statusDescriptors\":[{\"description\":\"Indicates if the restore was successful.\",\"displayName\":\"Succeeded\",\"path\":\"succeeded\",\"x-descriptors\":[\"urn:alm:descriptor:text\"]},{\"description\":\"Indicates the reason for any restore related failures.\",\"displayName\":\"Reason\",\"path\":\"reason\",\"x-descriptors\":[\"urn:alm:descriptor:io.kubernetes.phase:reason\"]}],\"version\":\"v1beta2\"}]},\"description\":\"The etcd Operater creates and maintains highly-available etcd clusters on Kubernetes, allowing engineers to easily deploy and manage etcd clusters for their applications.\\n\\netcd is a distributed key value store that provides a reliable way to store data across a cluster of machines. Itâ€™s open-source and available on GitHub. etcd gracefully handles leader elections during network partitions and will tolerate machine failure, including the leader.\\n\\n\\n### Reading and writing to etcd\\n\\nCommunicate with etcd though its command line utility `etcdctl` via port forwarding:\\n\\n    $ kubectl --namespace default port-forward service/example-client 2379:2379\\n    $ etcdctl --endpoints http://127.0.0.1:2379 get /\\n\\nOr directly to the API using the automatically generated Kubernetes Service:\\n\\n    $ etcdctl --endpoints http://example-client.default.svc:2379 get /\\n\\nBe sure to secure your etcd cluster (see Common Configurations) before exposing it outside of the namespace or cluster.\\n\\n\\n### Supported Features\\n\\n* **High availability** - Multiple instances of etcd are networked together and secured. Individual failures or networking issues are transparently handled to keep your cluster up and running.\\n\\n* **Automated updates** - Rolling out a new etcd version works like all Kubernetes rolling updates. Simply declare the desired version, and the etcd service starts a safe rolling update to the new version automatically.\\n\\n* **Backups included** - Create etcd backups and restore them through the etcd Operator.\\n\\n### Common Configurations\\n\\n* **Configure TLS** - Specify [static TLS certs](https://github.com/coreos/etcd-operator/blob/master/doc/user/cluster_tls.md) as Kubernetes secrets.\\n\\n* **Set Node Selector and Affinity** - [Spread your etcd Pods](https://github.com/coreos/etcd-operator/blob/master/doc/user/spec_examples.md#three-member-cluster-with-node-selector-and-anti-affinity-across-nodes) across Nodes and availability zones.\\n\\n* **Set Resource Limits** - [Set the Kubernetes limit and request](https://github.com/coreos/etcd-operator/blob/master/doc/user/spec_examples.md#three-member-cluster-with-resource-requirement) values for your etcd Pods.\\n\\n* **Customize Storage** - [Set a custom StorageClass](https://github.com/coreos/etcd-operator/blob/master/doc/user/spec_examples.md#custom-persistentvolumeclaim-definition) that you would like to use.\\n\",\"displayName\":\"etcd\",\"icon\":[{\"base64data\":\"iVBORw0KGgoAAAANSUhEUgAAAOEAAADZCAYAAADWmle6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAEKlJREFUeNrsndt1GzkShmEev4sTgeiHfRYdgVqbgOgITEVgOgLTEQydwIiKwFQCayoCU6+7DyYjsBiBFyVVz7RkXvqCSxXw/+f04XjGQ6IL+FBVuL769euXgZ7r39f/G9iP0X+u/jWDNZzZdGI/Ftama1jjuV4BwmcNpbAf1Fgu+V/9YRvNAyzT2a59+/GT/3hnn5m16wKWedJrmOCxkYztx9Q+py/+E0GJxtJdReWfz+mxNt+QzS2Mc0AI+HbBBwj9QViKbH5t64DsP2fvmGXUkWU4WgO+Uve2YQzBUGd7r+zH2ZG/tiUQc4QxKwgbwFfVGwwmdLL5wH78aPC/ZBem9jJpCAX3xtcNASSNgJLzUPSQyjB1zQNl8IQJ9MIU4lx2+Jo72ysXYKl1HSzN02BMa/vbZ5xyNJIshJzwf3L0dQhJw4Sih/SFw9Tk8sVeghVPoefaIYCkMZCKbrcP9lnZuk0uPUjGE/KE8JQry7W2tgfuC3vXgvNV+qSQbyFtAtyWk7zWiYevvuUQ9QEQCvJ+5mmu6dTjz1zFHLFj8Eb87MtxaZh/IQFIHom+9vgTWwZxAQjT9X4vtbEVPojwjiV471s00mhAckpwGuCn1HtFtRDaSh6y9zsL+LNBvCG/24ThcxHObdlWc1v+VQJe8LcO0jwtuF8BwnAAUgP9M8JPU2Me+Oh12auPGT6fHuTePE3bLDy+x9pTLnhMn+07TQGh//Bz1iI0c6kvtqInjvPZcYR3KsPVmUsPYt9nFig9SCY8VQNhpPBzn952bbgcsk2EvM89wzh3UEffBbyPqvBUBYQ8ODGPFOLsa7RF096WJ69L+E4EmnpjWu5o4ChlKaRTKT39RMMaVPEQRsz/nIWlDN80chjdJlSd1l0pJCAMVZsniobQVuxceMM9OFoaMd9zqZtjMEYYDW38Drb8Y0DYPLShxn0pvIFuOSxd7YCPet9zk452wsh54FJoeN05hcgSQoG5RR0Qh9Q4E4VvL4wcZq8UACgaRFEQKgSwWrkr5WFnGxiHSutqJGlXjBgIOayhwYBTA0ER0oisIVSUV0AAMT0IASCUO4hRIQSAEECMCCEPwqyQA0JCQBzEGjWNAqHiUVAoXUWbvggOIQCEAOJzxTjoaQ4AIaE64/aZridUsBYUgkhB15oGg1DBIl8IqirYwV6hPSGBSFteMCUBSVXwfYixBmamRubeMyjzMJQBDDowE3OesDD+zwqFoDqiEwXoXJpljB+PvWJGy75BKF1FPxhKygJuqUdYQGlLxNEXkrYyjQ0GbaAwEnUIlLRNvVjQDYUAsJB0HKLE4y0AIpQNgCIhBIhQTgCKhZBBpAN/v6LtQI50JfUgYOnnjmLUFHKhjxbAmdTCaTiBm3ovLPqG2urWAij6im0Nd9aTN9ygLUEt9LgSRnohxUPIKxlGaE+/6Y7znFf0yX+GnkvFFWmarkab2o9PmTeq8sbd2a7DaysXz7i64VeznN4jCQhN9gdDbRiuWrfrsq0mHIrlaq+hlotCtd3Um9u0BYWY8y5D67wccJoZjFca7iUs9VqZcfsZwTd1sbWGG+OcYaTnPAP7rTQVVlM4Sg3oGvB1tmNh0t/HKXZ1jFoIMwCQjtqbhNxUmkGYqgZEDZP11HN/S3gAYRozf0l8C5kKEKUvW0t1IfeWG/5MwgheZTT1E0AEhDkAePQO+Ig2H3DncAkQM4cwUQCD530dU4B5Yvmi2LlDqXfWrxMCcMth51RToRMNUXFnfc2KJ0+Ryl0VNOUwlhh6NoxK5gnViTgQpUG4SqSyt5z3zRJpuKmt3Q1614QaCBPaN6je+2XiFcWAKOXcUfIYKRyL/1lb7pe5VxSxxjQ6hImshqGRt5GWZVKO6q2wHwujfwDtIvaIdexj8Cm8+a68EqMfox6x/voMouZF4dHnEGNeCDMwT6vdNfekH1MafMk4PI06YtqLVGl95aEM9Z5vAeCTOA++YLtoVJRrsqNCaJ6WRmkdYaNec5BT/lcTRMqrhmwfjbpkj55+OKp8IEbU/JLgPJE6Wa3TTe9sHS+ShVD5QIyqIxMEwKh12olC6mHIed5ewEop80CNlfIOADYOT2nd6ZXCop+Ebqchc0JqxKcKASxChycJgUh1rnHA5ow9eTrhqNI7JWiAYYwBGGdpyNLoGw0Pkh96h1BpHihyywtATDM/7Hk2fN9EnH8BgKJCU4ooBkbXFMZJiPbrOyecGl3zgQDQL4hk10IZiOe+5w99Q/gBAEIJgPhJM4QAEEoFREAIAAEiIASAkD8Qt4AQAEIAERAGFlX4CACKAXGVM4ivMwWwCLFAlyeoaa70QePKm5Dlp+/n+ye/5dYgva6YsUaVeMa+tzNFeJtWwc+udbJ0Fg399kLielQJ5Ze61c2+7ytA6EZetiPxZC6tj22yJCv6jUwOyj/zcbqAxOMyAKEbfeHtNa7DtYXptjsk2kJxR+eIeim/tHNofUKYy8DMrQcAKWz6brpvzyIAlpwPhQ49l6b7skJf5Z+YTOYQc4FwLDxvoTDwaygQK+U/kVr+ytSFBG01Q3gnJJR4cNiAhx4HDub8/b5DULXlj6SVZghFiE+LdvE9vo/o8Lp1RmH5hzm0T6wdbZ6n+D6i44zDRc3ln6CpAEJfXiRU45oqLz8gFAThWsh7ughrRibc0QynHgZpNJa/ENJ+loCwu/qOGnFIjYR/n7TfgycULhcQhu6VC+HfF+L3BoAQ4WiZTw1M+FPCnA2gKC6/FAhXgDC+ojQGh3NuWsvfF1L/D5ohlCKtl1j2ldu9a/nPAKFwN56Bst10zCG0CPleXN/zXPgHQZXaZaBgrbzyY5V/mUA+6F0hwtGN9rwu5DVZPuwWqfxdFz1LWbJ2lwKEa+0Qsm4Dl3fp+Pu0lV97PgwIPfSsS+UQhj5Oo+vvFULazRIQyvGEcxPuNLCth2MvFsrKn8UOilAQShkh7TTczYNMoS6OdP47msrPi82lXKGWhCdMZYS0bFy+vcnGAjP1CIfvgbKNA9glecEH9RD6Ol4wRuWyN/G9MHnksS6o/GPf5XcwNSUlHzQhDuAKtWJmkwKElU7lylP5rgIcsquh/FI8YZCDpkJBuE4FQm7Icw8N+SrUGaQKyi8FwiDt1ve5o+Vu7qYHy/psgK8cvh+FTYuO77bhEC7GuaPiys/L1X4IgXDL+e3M5+ovLxBy5VLuIebw1oqcHoPfoaMJUsHays878r8KbDc3xtPx/84gZPBG/JwaufrsY/SRG/OY3//8QMNdsvdZCFtbW6f8pFuf5bflILAlX7O+4fdfugKyFYS8T2zAsXthdG0VurPGKwI06oF5vkBgHWkNp6ry29+lsPZMU3vijnXFNmoclr+6+Ou/FIb8yb30sS8YGjmTqCLyQsi5N/6ZwKs0Yenj68pfPjF6N782Dp2FzV9CTyoSeY8mLK16qGxIkLI8oa1n8tz9juP40DlK0epxYEbojbq+9QfurBeVIlCO9D2396bxiV4lkYQ3hOAFw2pbhqMGISkkQOMcQ9EqhDmGZZdo92JC0YHRNTfoSg+5e0IT+opqCKHoIU+4ztQIgBD1EFNrQAgIpYSil9lDmPHqkROPt+JC6AgPquSuumJmg0YARVCuneDfvPVeJokZ6pIXDkNxQtGzTF9/BQjRG0tQznfb74RwCQghpALBtIQnfK4zhxdyQvVCUeknMIT3hLyY+T5jo0yABqKPQNpUNw/09tGZod5jgCaYFxyYvJcNPkv9eof+I3pnCFEHIETjSM8L9tHZHYCQT9PaZGycU6yg8S4akDnJ+P03L0+t23XGzCLzRgII/Wqa+fv/xlfvmKvMUOcOrlCDdoei1MGdZm6G5VEIfRzzjd4aQs69n699Rx7ewhvCGzr2gmTPs8zNsJOrXt24FbkhhOjCfT4ICA/rPbyhUy94Dks0gJCX1NzCZui9YUd3oei+c257TalFbgg19ILHrlrL2gvWgXAL26EX76gZTNASQnad8Ibwhl284NhgXpB0c+jKhWO3Ms1hP9ihJYB9eMF6qd1BCPk0qA1s+LimFIu7m4nsdQIzPK4VbQ8hYvrnuSH2G9b2ggP78QmWqBdF9Vx8SSY6QYdUW7BTA1schZATyhvY8lHvcRbNUS9YGFy2U+qmzh2YPVc0I7yAOFyHfRpyUwtCSzOdPXMHmz7qDIM0e0V2wZTEk+6Ym6N63eBLp/b5Bts+2cKCSJ/LuoZO3ANSiE5hKAZjnvNSS4931jcw9jpwT0feV/qSJ1pVtCyfHKDkvK8Ejx7pUxGh2xFNSwx8QTi2H9ceC0/nni64MS/5N5dG39pDqvRV+WgGk71c9VFXF9b+xYvOw/d61iv7m3MvEHryhvecwC52jSSx4VIIgwnMNT/UsTxIgpPt3K/ARj15CptwL3Zd/ceDSATj2DGQjbxgWwhdeMMte7zpy5On9vymRm/YxBYljGVjKWF9VJf7I1+sex3wY8w/V1QPTborW/72gkdsRDaZMJBdbdHIC7aCkAu9atlLbtnrzerMnyToDaGwelOnk3/hHSem/ZK7e/t7jeeR20LYBgqa8J80gS8jbwi5F02Uj1u2NYJxap8PLkJfLxA2hIJyvnHX/AfeEPLpBfe0uSFHbnXaea3Qd5d6HcpYZ8L6M7lnFwMQ3MNg+RxUR1+6AshtbsVgfXTEg1sIGax9UND2p7f270wdG3eK9gXVGHdw2k5sOyZv+Nbs39Z308XR9DqWb2J+PwKDhuKHPobfuXf7gnYGHdCs7bhDDadD4entDug7LWNsnRNW4mYqwJ9dk+GGSTPBiA2j0G8RWNM5upZtcG4/3vMfP7KnbK2egx6CCnDPhRn7NgD3cghLIad5WcM2SO38iqHvvMOosyeMpQ5zlVCaaj06GVs9xUbHdiKoqrHWgquFEFMWUEWfXUxJAML23hAHFOctmjZQffKD2pywkhtSGHKNtpitLroscAeE7kCkSsC60vxEl6yMtL9EL5HKGCMszU5bk8gdkklAyEn5FO0yK419rIxBOIqwFMooDE0tHEVYijAUECIshRCGIhxFWIowFJ5QkEYIS5PTJrUwNGlPyN6QQPyKtpuM1E/K5+YJDV/MiA3AaehzqgAm7QnZG9IGYKo8bHnSK7VblLL3hOwNHziPuEGOqE5brrdR6i+atCfckyeWD47HkAkepRGLY/e8A8J0gCwYSNypF08bBm+e6zVz2UL4AshhBUjML/rXLefqC82bcQFhGC9JDwZ1uuu+At0S5gCETYHsV4DUeD9fDN2Zfy5OXaW2zAwQygCzBLJ8cvaW5OXKC1FxfTggFAHmoAJnSiOw2wps9KwRWgJCLaEswaj5NqkLwAYIU4BxqTSXbHXpJdRMPZgAOiAMqABCNGYIEEJutEK5IUAIwYMDQgiCACEEAcJs1Vda7gGqDhCmoiEghAAhBAHCrKXVo2C1DCBMRlp37uMIEECoX7xrX3P5C9QiINSuIcoPAUI0YkAICLNWgfJDh4T9hH7zqYH9+JHAq7zBqWjwhPAicTVCVQJCNF50JghHocahKK0X/ZnQKyEkhSdUpzG8OgQI42qC94EQjsYLRSmH+pbgq73L6bYkeEJ4DYTYmeg1TOBFc/usTTp3V9DdEuXJ2xDCUbXhaXk0/kAYmBvuMB4qkC35E5e5AMKkwSQgyxufyuPy6fMMgAFCSI73LFXU/N8AmEL9X4ABACNSKMHAgb34AAAAAElFTkSuQmCC\",\"mediatype\":\"image/png\"}],\"install\":{\"spec\":{\"deployments\":[{\"name\":\"etcd-operator\",\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"name\":\"etcd-operator-alm-owned\"}},\"template\":{\"metadata\":{\"labels\":{\"name\":\"etcd-operator-alm-owned\"},\"name\":\"etcd-operator-alm-owned\"},\"spec\":{\"containers\":[{\"command\":[\"etcd-operator\",\"--create-crd=false\"],\"env\":[{\"name\":\"MY_POD_NAMESPACE\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.namespace\"}}},{\"name\":\"MY_POD_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.name\"}}}],\"image\":\"quay.io/coreos/etcd-operator@sha256:66a37fd61a06a43969854ee6d3e21087a98b93838e284a6086b13917f96b0d9b\",\"name\":\"etcd-operator\"},{\"command\":[\"etcd-backup-operator\",\"--create-crd=false\"],\"env\":[{\"name\":\"MY_POD_NAMESPACE\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.namespace\"}}},{\"name\":\"MY_POD_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.name\"}}}],\"image\":\"quay.io/coreos/etcd-operator@sha256:66a37fd61a06a43969854ee6d3e21087a98b93838e284a6086b13917f96b0d9b\",\"name\":\"etcd-backup-operator\"},{\"command\":[\"etcd-restore-operator\",\"--create-crd=false\"],\"env\":[{\"name\":\"MY_POD_NAMESPACE\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.namespace\"}}},{\"name\":\"MY_POD_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.name\"}}}],\"image\":\"quay.io/coreos/etcd-operator@sha256:66a37fd61a06a43969854ee6d3e21087a98b93838e284a6086b13917f96b0d9b\",\"name\":\"etcd-restore-operator\"}],\"serviceAccountName\":\"etcd-operator\"}}}}],\"permissions\":[{\"rules\":[{\"apiGroups\":[\"etcd.database.coreos.com\"],\"resources\":[\"etcdclusters\",\"etcdbackups\",\"etcdrestores\"],\"verbs\":[\"*\"]},{\"apiGroups\":[\"\"],\"resources\":[\"pods\",\"services\",\"endpoints\",\"persistentvolumeclaims\",\"events\"],\"verbs\":[\"*\"]},{\"apiGroups\":[\"apps\"],\"resources\":[\"deployments\"],\"verbs\":[\"*\"]},{\"apiGroups\":[\"\"],\"resources\":[\"secrets\"],\"verbs\":[\"get\"]}],\"serviceAccountName\":\"etcd-operator\"}]},\"strategy\":\"deployment\"},\"installModes\":[{\"supported\":true,\"type\":\"OwnNamespace\"},{\"supported\":true,\"type\":\"SingleNamespace\"},{\"supported\":false,\"type\":\"MultiNamespace\"},{\"supported\":false,\"type\":\"AllNamespaces\"}],\"keywords\":[\"etcd\",\"key value\",\"database\",\"coreos\",\"open source\"],\"labels\":{\"alm-owner-etcd\":\"etcdoperator\",\"operated-by\":\"etcdoperator\"},\"links\":[{\"name\":\"Blog\",\"url\":\"https://coreos.com/etcd\"},{\"name\":\"Documentation\",\"url\":\"https://coreos.com/operators/etcd/docs/latest/\"},{\"name\":\"etcd Operator Source Code\",\"url\":\"https://github.com/coreos/etcd-operator\"}],\"maintainers\":[{\"email\":\"etcd-dev@googlegroups.com\",\"name\":\"etcd Community\"}],\"maturity\":\"alpha\",\"provider\":{\"name\":\"CNCF\"},\"replaces\":\"etcdoperator.v0.9.2\",\"selector\":{\"matchLabels\":{\"alm-owner-etcd\":\"etcdoperator\",\"operated-by\":\"etcdoperator\"}},\"version\":\"0.9.4\"}}"
+	crdbackups  = `{"apiVersion":"apiextensions.k8s.io/v1beta1","kind":"CustomResourceDefinition","metadata":{"name":"etcdbackups.etcd.database.coreos.com"},"spec":{"group":"etcd.database.coreos.com","names":{"kind":"EtcdBackup","listKind":"EtcdBackupList","plural":"etcdbackups","singular":"etcdbackup"},"scope":"Namespaced","version":"v1beta2"}}`
+	crdclusters = `{"apiVersion":"apiextensions.k8s.io/v1beta1","kind":"CustomResourceDefinition","metadata":{"name":"etcdclusters.etcd.database.coreos.com"},"spec":{"group":"etcd.database.coreos.com","names":{"kind":"EtcdCluster","listKind":"EtcdClusterList","plural":"etcdclusters","shortNames":["etcdclus","etcd"],"singular":"etcdcluster"},"scope":"Namespaced","version":"v1beta2"}}`
+	crdrestores = `{"apiVersion":"apiextensions.k8s.io/v1beta1","kind":"CustomResourceDefinition","metadata":{"name":"etcdrestores.etcd.database.coreos.com"},"spec":{"group":"etcd.database.coreos.com","names":{"kind":"EtcdRestore","listKind":"EtcdRestoreList","plural":"etcdrestores","singular":"etcdrestore"},"scope":"Namespaced","version":"v1beta2"}}`
+)
+
+func testModelBundle() model.Bundle {
+	b := model.Bundle{
+		Name:     "etcdoperator.v0.9.4",
+		Image:    "quay.io/operatorhubio/etcd:v0.9.4",
+		Replaces: "etcdoperator.v0.9.2",
+		Skips:    nil,
+		Properties: []property.Property{
+			property.MustBuildChannel("singlenamespace-alpha", "etcdoperator.v0.9.2"),
+			property.MustBuildPackage("etcd", "0.9.4"),
+			property.MustBuildPackageRequired("test", ">=1.2.3 <2.0.0-0"),
+			property.MustBuildGVKRequired("testapi.coreos.com", "v1", "Testapi"),
+			property.MustBuildGVK("etcd.database.coreos.com", "v1beta2", "EtcdBackup"),
+			property.MustBuildBundleObjectRef("objects/etcdoperator.v0.9.4/etcdbackups.etcd.database.coreos.com_apiextensions.k8s.io_v1beta1_customresourcedefinition.yaml"),
+			property.MustBuildBundleObjectRef("objects/etcdoperator.v0.9.4/etcdclusters.etcd.database.coreos.com_apiextensions.k8s.io_v1beta1_customresourcedefinition.yaml"),
+			property.MustBuildBundleObjectRef("objects/etcdoperator.v0.9.4/etcdoperator.v0.9.4_operators.coreos.com_v1alpha1_clusterserviceversion.yaml"),
+			property.MustBuildBundleObjectRef("objects/etcdoperator.v0.9.4/etcdrestores.etcd.database.coreos.com_apiextensions.k8s.io_v1beta1_customresourcedefinition.yaml"),
+		},
+		CsvJSON: csvJson,
+		Objects: []string{
+			crdbackups,
+			crdclusters,
+			csvJson,
+			crdrestores,
+		},
+		RelatedImages: []model.RelatedImage{
+			{
+				Name:  "etcdv0.9.4",
+				Image: "quay.io/coreos/etcd-operator@sha256:66a37fd61a06a43969854ee6d3e21087a98b93838e284a6086b13917f96b0d9b",
+			},
+		},
+	}
+	return b
+}
+
+func testAPIBundle() Bundle {
+	return Bundle{
+		CsvName:     "etcdoperator.v0.9.4",
+		PackageName: "etcd",
+		ChannelName: "singlenamespace-alpha",
+		BundlePath:  "quay.io/operatorhubio/etcd:v0.9.4",
+		ProvidedApis: []*GroupVersionKind{
+			{Group: "etcd.database.coreos.com", Version: "v1beta2", Kind: "EtcdBackup"},
+		},
+		RequiredApis: []*GroupVersionKind{
+			{Group: "testapi.coreos.com", Version: "v1", Kind: "Testapi"},
+		},
+		Version: "0.9.4",
+		Dependencies: []*Dependency{
+			{Type: "olm.package", Value: `{"packageName":"test","version":">=1.2.3 <2.0.0-0"}`},
+			{Type: "olm.gvk", Value: `{"group":"testapi.coreos.com","kind":"Testapi","version":"v1"}`},
+		},
+		Properties: []*Property{
+			{Type: "olm.package", Value: `{"packageName":"etcd","version":"0.9.4"}`},
+			{Type: "olm.gvk", Value: `{"group":"etcd.database.coreos.com","kind":"EtcdBackup","version":"v1beta2"}`},
+		},
+		Replaces: "etcdoperator.v0.9.2",
+		CsvJson:  csvJson,
+		Object: []string{
+			crdbackups,
+			crdclusters,
+			csvJson,
+			crdrestores},
+	}
+}
+
+func assertEqualsModelBundle(t *testing.T, a, b model.Bundle) bool {
+	assert.ElementsMatch(t, a.Properties, b.Properties)
+	assert.ElementsMatch(t, a.Objects, b.Objects)
+	assert.ElementsMatch(t, a.Skips, b.Skips)
+	assert.ElementsMatch(t, a.RelatedImages, b.RelatedImages)
+
+	a.Properties, b.Properties = nil, nil
+	a.Objects, b.Objects = nil, nil
+	a.Skips, b.Skips = nil, nil
+	a.RelatedImages, b.RelatedImages = nil, nil
+
+	return assert.Equal(t, a, b)
+}
+
+func assertEqualsAPIBundle(t *testing.T, a, b Bundle) bool {
+	assert.ElementsMatch(t, a.Properties, b.Properties)
+	assert.ElementsMatch(t, a.Dependencies, b.Dependencies)
+	assert.ElementsMatch(t, a.Object, b.Object)
+	assert.ElementsMatch(t, a.Skips, b.Skips)
+	assert.ElementsMatch(t, a.ProvidedApis, b.ProvidedApis)
+	assert.ElementsMatch(t, a.RequiredApis, b.RequiredApis)
+
+	a.Properties, b.Properties = nil, nil
+	a.Dependencies, b.Dependencies = nil, nil
+	a.Object, b.Object = nil, nil
+	a.Skips, b.Skips = nil, nil
+	a.ProvidedApis, b.ProvidedApis = nil, nil
+	a.RequiredApis, b.RequiredApis = nil, nil
+
+	return assert.Equal(t, a, b)
+}

--- a/staging/operator-registry/pkg/lib/config/validate.go
+++ b/staging/operator-registry/pkg/lib/config/validate.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"github.com/operator-framework/operator-registry/internal/declcfg"
+)
+
+// ValidateConfig takes a directory containing the declarative config file(s)
+// 1. Validate if declarative config file(s) are valid based on specified schema
+// 2. Validate the `replaces` chains of the upgrade graph
+// Inputs:
+// directory: the directory where declarative config file(s) exist
+// Outputs:
+// error: a wrapped error that contains a list of error strings
+func ValidateConfig(directory string) error {
+	// Load config files
+	cfg, err := declcfg.LoadDir(directory)
+	if err != nil {
+		return err
+	}
+	// Validate the config using model validation
+	_, err = declcfg.ConvertToModel(*cfg)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/staging/operator-registry/pkg/lib/config/validate.go
+++ b/staging/operator-registry/pkg/lib/config/validate.go
@@ -12,12 +12,15 @@ import (
 // Outputs:
 // error: a wrapped error that contains a list of error strings
 func ValidateConfig(directory string) error {
-	// Load config files
+	// Load config files and convert them to declcfg objects
 	cfg, err := declcfg.LoadDir(directory)
 	if err != nil {
 		return err
 	}
-	// Validate the config using model validation
+	// Validate the config using model validation:
+	// This will convert declcfg objects to intermediate model objects that are
+	// also used for serve and add commands. The conversion process will run
+	// validation for the model objects and ensure they are valid.
 	_, err = declcfg.ConvertToModel(*cfg)
 	if err != nil {
 		return err

--- a/staging/operator-registry/pkg/registry/query_test.go
+++ b/staging/operator-registry/pkg/registry/query_test.go
@@ -1,0 +1,186 @@
+package registry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/operator-framework/operator-registry/internal/declcfg"
+)
+
+var testModelQuerier = genTestModelQuerier()
+
+func TestQuerier_GetBundle(t *testing.T) {
+	b, err := testModelQuerier.GetBundle(context.TODO(), "etcd", "singlenamespace-alpha", "etcdoperator.v0.9.4")
+	require.NoError(t, err)
+	require.Equal(t, b.PackageName, "etcd")
+	require.Equal(t, b.ChannelName, "singlenamespace-alpha")
+	require.Equal(t, b.CsvName, "etcdoperator.v0.9.4")
+}
+
+func TestQuerier_GetBundleForChannel(t *testing.T) {
+	b, err := testModelQuerier.GetBundleForChannel(context.TODO(), "etcd", "singlenamespace-alpha")
+	require.NoError(t, err)
+	require.NotNil(t, b)
+	require.Equal(t, b.PackageName, "etcd")
+	require.Equal(t, b.ChannelName, "singlenamespace-alpha")
+	require.Equal(t, b.CsvName, "etcdoperator.v0.9.4")
+}
+
+func TestQuerier_GetBundleThatProvides(t *testing.T) {
+	b, err := testModelQuerier.GetBundleThatProvides(context.TODO(), "etcd.database.coreos.com", "v1beta2", "EtcdBackup")
+	require.NoError(t, err)
+	require.NotNil(t, b)
+	require.Equal(t, b.PackageName, "etcd")
+	require.Equal(t, b.ChannelName, "singlenamespace-alpha")
+	require.Equal(t, b.CsvName, "etcdoperator.v0.9.4")
+}
+
+func TestQuerier_GetBundleThatReplaces(t *testing.T) {
+	b, err := testModelQuerier.GetBundleThatReplaces(context.TODO(), "etcdoperator.v0.9.0", "etcd", "singlenamespace-alpha")
+	require.NoError(t, err)
+	require.NotNil(t, b)
+	require.Equal(t, b.PackageName, "etcd")
+	require.Equal(t, b.ChannelName, "singlenamespace-alpha")
+	require.Equal(t, b.CsvName, "etcdoperator.v0.9.2")
+}
+
+func TestQuerier_GetChannelEntriesThatProvide(t *testing.T) {
+	entries, err := testModelQuerier.GetChannelEntriesThatProvide(context.TODO(), "etcd.database.coreos.com", "v1beta2", "EtcdBackup")
+	require.NoError(t, err)
+	require.NotNil(t, entries)
+	require.ElementsMatch(t, []*ChannelEntry{
+		{
+			PackageName: "etcd",
+			ChannelName: "singlenamespace-alpha",
+			BundleName:  "etcdoperator.v0.9.0",
+			Replaces:    "",
+		},
+		{
+			PackageName: "etcd",
+			ChannelName: "singlenamespace-alpha",
+			BundleName:  "etcdoperator.v0.9.4",
+			Replaces:    "etcdoperator.v0.9.2",
+		},
+		{
+			PackageName: "etcd",
+			ChannelName: "clusterwide-alpha",
+			BundleName:  "etcdoperator.v0.9.0",
+			Replaces:    "",
+		},
+		{
+			PackageName: "etcd",
+			ChannelName: "clusterwide-alpha",
+			BundleName:  "etcdoperator.v0.9.2-clusterwide",
+			Replaces:    "etcdoperator.v0.9.0",
+		},
+		{
+			PackageName: "etcd",
+			ChannelName: "clusterwide-alpha",
+			BundleName:  "etcdoperator.v0.9.2-clusterwide",
+			Replaces:    "etcdoperator.v0.6.1",
+		},
+		{
+			PackageName: "etcd",
+			ChannelName: "clusterwide-alpha",
+			BundleName:  "etcdoperator.v0.9.4-clusterwide",
+			Replaces:    "etcdoperator.v0.9.2-clusterwide",
+		},
+	}, entries)
+}
+
+func TestQuerier_GetChannelEntriesThatReplace(t *testing.T) {
+	entries, err := testModelQuerier.GetChannelEntriesThatReplace(context.TODO(), "etcdoperator.v0.9.0")
+	require.NoError(t, err)
+	require.NotNil(t, entries)
+	require.ElementsMatch(t, []*ChannelEntry{
+		{
+			PackageName: "etcd",
+			ChannelName: "singlenamespace-alpha",
+			BundleName:  "etcdoperator.v0.9.2",
+			Replaces:    "etcdoperator.v0.9.0",
+		},
+		{
+			PackageName: "etcd",
+			ChannelName: "clusterwide-alpha",
+			BundleName:  "etcdoperator.v0.9.2-clusterwide",
+			Replaces:    "etcdoperator.v0.9.0",
+		},
+	}, entries)
+}
+
+func TestQuerier_GetLatestChannelEntriesThatProvide(t *testing.T) {
+	entries, err := testModelQuerier.GetLatestChannelEntriesThatProvide(context.TODO(), "etcd.database.coreos.com", "v1beta2", "EtcdBackup")
+	require.NoError(t, err)
+	require.NotNil(t, entries)
+	require.ElementsMatch(t, []*ChannelEntry{
+		{
+			PackageName: "etcd",
+			ChannelName: "singlenamespace-alpha",
+			BundleName:  "etcdoperator.v0.9.4",
+			Replaces:    "etcdoperator.v0.9.2",
+		},
+		{
+			PackageName: "etcd",
+			ChannelName: "clusterwide-alpha",
+			BundleName:  "etcdoperator.v0.9.4-clusterwide",
+			Replaces:    "etcdoperator.v0.9.2-clusterwide",
+		},
+	}, entries)
+}
+
+func TestQuerier_GetPackage(t *testing.T) {
+	p, err := testModelQuerier.GetPackage(context.TODO(), "etcd")
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	expected := &PackageManifest{
+		PackageName:        "etcd",
+		DefaultChannelName: "singlenamespace-alpha",
+		Channels: []PackageChannel{
+			{
+				Name:           "singlenamespace-alpha",
+				CurrentCSVName: "etcdoperator.v0.9.4",
+			},
+			{
+				Name:           "clusterwide-alpha",
+				CurrentCSVName: "etcdoperator.v0.9.4-clusterwide",
+			},
+			{
+				Name:           "alpha",
+				CurrentCSVName: "etcdoperator-community.v0.6.1",
+			},
+		},
+	}
+
+	require.ElementsMatch(t, expected.Channels, p.Channels)
+	expected.Channels, p.Channels = nil, nil
+	require.Equal(t, expected, p)
+}
+
+func TestQuerier_ListBundles(t *testing.T) {
+	bundles, err := testModelQuerier.ListBundles(context.TODO())
+	require.NoError(t, err)
+	require.NotNil(t, bundles)
+	require.Equal(t, 12, len(bundles))
+}
+
+func TestQuerier_ListPackages(t *testing.T) {
+	packages, err := testModelQuerier.ListPackages(context.TODO())
+	require.NoError(t, err)
+	require.NotNil(t, packages)
+	require.Equal(t, 2, len(packages))
+}
+
+func genTestModelQuerier() *Querier {
+	cfg, err := declcfg.LoadDir("testdata/validDeclCfg")
+	if err != nil {
+		panic(err)
+	}
+	m, err := declcfg.ConvertToModel(*cfg)
+	if err != nil {
+		panic(err)
+	}
+	return NewQuerier(m)
+}

--- a/staging/operator-registry/pkg/registry/testdata/validDeclCfg/cockroachdb.json
+++ b/staging/operator-registry/pkg/registry/testdata/validDeclCfg/cockroachdb.json
@@ -1,0 +1,116 @@
+{
+    "schema": "olm.package",
+    "name": "cockroachdb",
+    "defaultChannel": "stable-5.x",
+    "icon": {
+        "base64data": "PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzMS44MiAzMiIgd2lkdGg9IjI0ODYiIGhlaWdodD0iMjUwMCI+PHRpdGxlPkNMPC90aXRsZT48cGF0aCBkPSJNMTkuNDIgOS4xN2ExNS4zOSAxNS4zOSAwIDAgMS0zLjUxLjQgMTUuNDYgMTUuNDYgMCAwIDEtMy41MS0uNCAxNS42MyAxNS42MyAwIDAgMSAzLjUxLTMuOTEgMTUuNzEgMTUuNzEgMCAwIDEgMy41MSAzLjkxek0zMCAuNTdBMTcuMjIgMTcuMjIgMCAwIDAgMjUuNTkgMGExNy40IDE3LjQgMCAwIDAtOS42OCAyLjkzQTE3LjM4IDE3LjM4IDAgMCAwIDYuMjMgMGExNy4yMiAxNy4yMiAwIDAgMC00LjQ0LjU3QTE2LjIyIDE2LjIyIDAgMCAwIDAgMS4xM2EuMDcuMDcgMCAwIDAgMCAuMDkgMTcuMzIgMTcuMzIgMCAwIDAgLjgzIDEuNTcuMDcuMDcgMCAwIDAgLjA4IDAgMTYuMzkgMTYuMzkgMCAwIDEgMS44MS0uNTQgMTUuNjUgMTUuNjUgMCAwIDEgMTEuNTkgMS44OCAxNy41MiAxNy41MiAwIDAgMC0zLjc4IDQuNDhjLS4yLjMyLS4zNy42NS0uNTUgMXMtLjIyLjQ1LS4zMy42OS0uMzEuNzItLjQ0IDEuMDhhMTcuNDYgMTcuNDYgMCAwIDAgNC4yOSAxOC43Yy4yNi4yNS41My40OS44MS43M3MuNDQuMzcuNjcuNTQuNTkuNDQuODkuNjRhLjA3LjA3IDAgMCAwIC4wOCAwYy4zLS4yMS42LS40Mi44OS0uNjRzLjQ1LS4zNS42Ny0uNTQuNTUtLjQ4LjgxLS43M2ExNy40NSAxNy40NSAwIDAgMCA1LjM4LTEyLjYxIDE3LjM5IDE3LjM5IDAgMCAwLTEuMDktNi4wOWMtLjE0LS4zNy0uMjktLjczLS40NS0xLjA5cy0uMjItLjQ3LS4zMy0uNjktLjM1LS42Ni0uNTUtMWExNy42MSAxNy42MSAwIDAgMC0zLjc4LTQuNDggMTUuNjUgMTUuNjUgMCAwIDEgMTEuNi0xLjg0IDE2LjEzIDE2LjEzIDAgMCAxIDEuODEuNTQuMDcuMDcgMCAwIDAgLjA4IDBxLjQ0LS43Ni44Mi0xLjU2YS4wNy4wNyAwIDAgMCAwLS4wOUExNi44OSAxNi44OSAwIDAgMCAzMCAuNTd6IiBmaWxsPSIjMTUxZjM0Ii8+PHBhdGggZD0iTTIxLjgyIDE3LjQ3YTE1LjUxIDE1LjUxIDAgMCAxLTQuMjUgMTAuNjkgMTUuNjYgMTUuNjYgMCAwIDEtLjcyLTQuNjggMTUuNSAxNS41IDAgMCAxIDQuMjUtMTAuNjkgMTUuNjIgMTUuNjIgMCAwIDEgLjcyIDQuNjgiIGZpbGw9IiMzNDg1NDAiLz48cGF0aCBkPSJNMTUgMjMuNDhhMTUuNTUgMTUuNTUgMCAwIDEtLjcyIDQuNjggMTUuNTQgMTUuNTQgMCAwIDEtMy41My0xNS4zN0ExNS41IDE1LjUgMCAwIDEgMTUgMjMuNDgiIGZpbGw9IiM3ZGJjNDIiLz48L3N2Zz4=",
+        "mediatype": "image/svg+xml"
+    }
+}
+{
+    "schema": "olm.bundle",
+    "name": "cockroachdb.v2.0.9",
+    "package": "cockroachdb",
+    "image": "quay.io/openshift-community-operators/cockroachdb:v2.0.9",
+    "properties": [
+        {
+            "type": "olm.channel",
+            "value": {
+                "name": "stable"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "cockroachdb",
+                "version": "2.0.9"
+            }
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "cockroachdb.v2.1.11",
+    "package": "cockroachdb",
+    "image": "quay.io/openshift-community-operators/cockroachdb:v2.1.11",
+    "properties": [
+        {
+            "type": "olm.channel",
+            "value": {
+                "name": "stable",
+                "replaces": "cockroachdb.v2.1.1"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "cockroachdb",
+                "version": "2.1.11"
+            }
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "cockroachdb.v2.1.1",
+    "package": "cockroachdb",
+    "image": "quay.io/openshift-community-operators/cockroachdb:v2.1.1",
+    "properties": [
+        {
+            "type": "olm.channel",
+            "value": {
+                "name": "stable",
+                "replaces": "cockroachdb.v2.0.9"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "cockroachdb",
+                "version": "2.1.1"
+            }
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "cockroachdb.v3.0.7",
+    "package": "cockroachdb",
+    "image": "quay.io/openshift-community-operators/cockroachdb:v3.0.7",
+    "properties": [
+        {
+            "type": "olm.channel",
+            "value": {
+                "name": "stable-3.x"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "cockroachdb",
+                "version": "3.0.7"
+            }
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "cockroachdb.v5.0.3",
+    "package": "cockroachdb",
+    "image": "quay.io/openshift-community-operators/cockroachdb:v5.0.3",
+    "properties": [
+        {
+            "type": "olm.channel",
+            "value": {
+                "name": "stable-5.x"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "cockroachdb",
+                "version": "5.0.3"
+            }
+        }
+    ]
+}

--- a/staging/operator-registry/pkg/registry/testdata/validDeclCfg/etcd.json
+++ b/staging/operator-registry/pkg/registry/testdata/validDeclCfg/etcd.json
@@ -1,0 +1,257 @@
+{
+    "schema": "olm.package",
+    "name": "etcd",
+    "defaultChannel": "singlenamespace-alpha",
+    "icon": {
+        "base64data": "PHN2ZyB3aWR0aD0iMjUwMCIgaGVpZ2h0PSIyNDIyIiB2aWV3Qm94PSIwIDAgMjU2IDI0OCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWlkWU1pZCI+PHBhdGggZD0iTTI1Mi4zODYgMTI4LjA2NGMtMS4yMDIuMS0yLjQxLjE0Ny0zLjY5My4xNDctNy40NDYgMC0xNC42Ny0xLjc0Ni0yMS4xODctNC45NDQgMi4xNy0xMi40NDcgMy4wOTItMjQuOTg3IDIuODUtMzcuNDgxLTcuMDY1LTEwLjIyLTE1LjE0LTE5Ljg2My0yNC4yNTYtMjguNzQ3IDMuOTU1LTcuNDE1IDkuODAxLTEzLjc5NSAxNy4xLTE4LjMxOWwzLjEzMy0xLjkzNy0yLjQ0Mi0yLjc1NGMtMTIuNTgxLTE0LjE2Ny0yNy41OTYtMjUuMTItNDQuNjItMzIuNTUyTDE3NS44NzYgMGwtLjg2MiAzLjU4OGMtMi4wMyA4LjM2My02LjI3NCAxNS45MDgtMTIuMSAyMS45NjJhMTkzLjg0MiAxOTMuODQyIDAgMCAwLTM0Ljk1Ni0xNC40MDVBMTk0LjAxMiAxOTQuMDEyIDAgMCAwIDkzLjA1NiAyNS41MkM4Ny4yNTQgMTkuNDczIDgzLjAyIDExLjk0NyA4MC45OTkgMy42MDhMODAuMTMuMDJsLTMuMzgyIDEuNDdDNTkuOTM5IDguODE1IDQ0LjUxIDIwLjA2NSAzMi4xMzUgMzQuMDJsLTIuNDQ5IDIuNzYgMy4xMyAxLjkzN2M3LjI3NiA0LjUwNiAxMy4xMDYgMTAuODQ5IDE3LjA1NCAxOC4yMjMtOS4wODggOC44NS0xNy4xNTQgMTguNDYyLTI0LjIxNCAyOC42MzUtLjI3NSAxMi40ODkuNiAyNS4xMiAyLjc4IDM3Ljc0LTYuNDg0IDMuMTY3LTEzLjY2OCA0Ljg5NC0yMS4wNjUgNC44OTQtMS4yOTggMC0yLjUxMy0uMDQ3LTMuNjkzLS4xNDVMMCAxMjcuNzg1bC4zNDUgMy42NzFjMS44MDIgMTguNTc4IDcuNTcgMzYuMjQ3IDE3LjE1NCA1Mi41MjNsMS44NyAzLjE3NiAyLjgxLTIuMzg0YTQ4LjA0IDQ4LjA0IDAgMCAxIDIyLjczNy0xMC42NSAxOTQuODYgMTk0Ljg2IDAgMCAwIDE5LjQ2IDMxLjY5NmMxMS44MjggNC4xMzcgMjQuMTUxIDcuMjI1IDM2Ljg3OCA5LjA2MyAxLjIyIDguNDE3LjI0OCAxNy4xMjItMy4wNzIgMjUuMTcxbC0xLjQgMy40MTEgMy42Ljc5M2M5LjIyIDIuMDI3IDE4LjUyMyAzLjA2IDI3LjYzMSAzLjA2bDI3LjYyMy0zLjA2IDMuNjA0LS43OTMtMS40MDMtMy40MTdjLTMuMzEyLTguMDUtNC4yODQtMTYuNzY1LTMuMDYzLTI1LjE4MyAxMi42NzYtMS44NCAyNC45NTQtNC45MiAzNi43MzgtOS4wNDVhMTk1LjEwOCAxOTUuMTA4IDAgMCAwIDE5LjQ4Mi0zMS43MjYgNDguMjU0IDQ4LjI1NCAwIDAgMSAyMi44NDggMTAuNjZsMi44MDkgMi4zOCAxLjg2Mi0zLjE2OGM5LjYtMTYuMjk3IDE1LjM2OC0zMy45NjUgMTcuMTQyLTUyLjUxM2wuMzQ1LTMuNjY1LTMuNjE0LjI3OXpNMTY3LjQ5IDE3Mi45NmMtMTMuMDY4IDMuNTU0LTI2LjM0IDUuMzQ4LTM5LjUzMiA1LjM0OC0xMy4yMjggMC0yNi40ODMtMS43OTMtMzkuNTYzLTUuMzQ4YTE1My4yNTUgMTUzLjI1NSAwIDAgMS0xNi45MzItMzUuNjdjLTQuMDY2LTEyLjUxNy02LjQ0NS0yNS42My03LjEzNS0zOS4xMzQgOC40NDYtMTAuNDQzIDE4LjA1Mi0xOS41OTEgMjguNjY1LTI3LjI5M2ExNTIuNjIgMTUyLjYyIDAgMCAxIDM0Ljk2NS0xOS4wMTEgMTUzLjI0MiAxNTMuMjQyIDAgMCAxIDM0Ljg5OCAxOC45N2MxMC42NTQgNy43NDMgMjAuMzAyIDE2Ljk2MiAyOC43OSAyNy40Ny0uNzI0IDEzLjQyNy0zLjEzMiAyNi40NjUtNy4yMDQgMzguOTYxYTE1Mi43NjcgMTUyLjc2NyAwIDAgMS0xNi45NTIgMzUuNzA3em0tMjguNzQtNjIuOTk4YzAgOS4yMzIgNy40ODIgMTYuNyAxNi43MDIgMTYuNyA5LjIxNyAwIDE2LjY5LTcuNDY2IDE2LjY5LTE2LjcgMC05LjE5Ni03LjQ3My0xNi42OTItMTYuNjktMTYuNjkyLTkuMjIgMC0xNi43MDEgNy40OTYtMTYuNzAxIDE2LjY5MnptLTIxLjU3OCAwYzAgOS4yMzItNy40OCAxNi43LTE2LjcgMTYuNy05LjIyNiAwLTE2LjY4NS03LjQ2Ni0xNi42ODUtMTYuNyAwLTkuMTkzIDcuNDYtMTYuNjg5IDE2LjY4Ni0xNi42ODkgOS4yMiAwIDE2LjcgNy40OTYgMTYuNyAxNi42OXoiIGZpbGw9IiM0MTlFREEiLz48L3N2Zz4K",
+        "mediatype": "image/svg+xml"
+    },
+    "description": "A message about etcd operator, a description of channels"
+}
+{
+    "schema": "olm.bundle",
+    "name": "etcdoperator-community.v0.6.1",
+    "package": "etcd",
+    "image": "quay.io/operatorhubio/etcd:v0.6.1",
+    "properties":[
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.6.1"
+            }
+        },
+        {
+            "type":"olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdCluster",
+                "version": "v1beta2"
+            }
+        },
+        {
+            "type": "olm.channel",
+            "value": {
+                "name": "alpha"
+            }
+        }
+    ],
+    "relatedImages": [
+        {
+            "name": "etcdv0.6.1",
+            "image": "quay.io/coreos/etcd-operator@sha256:bd944a211eaf8f31da5e6d69e8541e7cada8f16a9f7a5a570b22478997819943"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "etcdoperator.v0.9.0",
+    "package": "etcd",
+    "image": "quay.io/operatorhubio/etcd:v0.9.0",
+    "properties":[
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.9.0"
+            }
+        },
+        {
+            "type":"olm.gvk",
+            "value":{
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdBackup",
+                "version": "v1beta2"
+            }
+        },
+        {
+            "type": "olm.channel",
+            "value": {
+                "name": "singlenamespace-alpha"
+            }
+        },
+        {
+            "type": "olm.channel",
+            "value": {
+                "name": "clusterwide-alpha"
+            }
+        }
+    ],
+    "relatedImages" : [
+        {
+            "name": "etcdv0.9.0",
+            "image": "quay.io/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "etcdoperator.v0.9.2",
+    "package": "etcd",
+    "image": "quay.io/operatorhubio/etcd:v0.9.2",
+    "properties":[
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.9.2"
+            }
+        },
+        {
+            "type":"olm.gvk",
+            "value":{
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdRestore",
+                "version": "v1beta2"
+            }
+        },
+        {
+            "type": "olm.channel",
+            "value": {
+                "name": "singlenamespace-alpha",
+                "replaces": "etcdoperator.v0.9.0"
+            }
+        }
+    ],
+    "relatedImages":[
+        {
+            "name":"etcdv0.9.2",
+            "image": "quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "etcdoperator.v0.9.2-clusterwide",
+    "package": "etcd",
+    "image": "quay.io/operatorhubio/etcd:v0.9.2-clusterwide",
+    "properties":[
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.9.2-clusterwide"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdBackup",
+                "version": "v1beta2"
+            }
+        },
+        {
+            "type": "olm.skipRange",
+            "value": ">=0.9.0 <=0.9.1"
+        },
+        {
+            "type": "olm.skips",
+            "value" : "etcdoperator.v0.6.1"
+        },
+        {
+            "type": "olm.skips",
+            "value" : "etcdoperator.v0.9.0"
+        },
+        {
+            "type": "olm.channel",
+            "value": {
+                "name": "clusterwide-alpha",
+                "replaces": "etcdoperator.v0.9.0"
+            }
+        }
+    ],
+    "relatedImages":[
+        {
+            "name":"etcdv0.9.2",
+            "image":"quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name" : "etcdoperator.v0.9.4",
+    "package": "etcd",
+    "image": "quay.io/operatorhubio/etcd:v0.9.4",
+    "properties":[
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.9.4"
+            }
+        },
+        {
+            "type": "olm.package.required",
+            "value": {
+                "packageName": "test",
+                "versionRange": ">=1.2.3 <2.0.0-0"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdBackup",
+                "version": "v1beta2"
+            }
+        },
+        {
+            "type": "olm.gvk.required",
+            "value": {
+                "group": "testapi.coreos.com",
+                "kind": "Testapi",
+                "version": "v1"
+            }
+        },
+        {
+            "type": "olm.channel",
+            "value": {
+                "name": "singlenamespace-alpha",
+                "replaces": "etcdoperator.v0.9.2"
+            }
+        }
+    ],
+    "relatedImages":[
+        {
+            "name":"etcdv0.9.2",
+            "image": "quay.io/coreos/etcd-operator@sha256:66a37fd61a06a43969854ee6d3e21087a98b93838e284a6086b13917f96b0d9b"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "etcdoperator.v0.9.4-clusterwide",
+    "package": "etcd",
+    "image": "quay.io/operatorhubio/etcd:v0.9.4-clusterwide",
+    "properties":[
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.9.4-clusterwide"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdBackup",
+                "version": "v1beta2"
+            }
+        },
+        {
+            "type": "olm.channel",
+            "value": {
+                "name": "clusterwide-alpha",
+                "replaces": "etcdoperator.v0.9.2-clusterwide"
+            }
+        }
+    ],
+    "relatedImages":[
+        {
+            "name":"etcdv0.9.2",
+            "image": "quay.io/coreos/etcd-operator@sha256:66a37fd61a06a43969854ee6d3e21087a98b93838e284a6086b13917f96b0d9b"
+        }
+    ]
+}

--- a/staging/operator-registry/pkg/sqlite/conversion_test.go
+++ b/staging/operator-registry/pkg/sqlite/conversion_test.go
@@ -1,0 +1,73 @@
+package sqlite
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToModel(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "server_test-")
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	db, err := Open(dbPath)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	load, err := NewSQLLiteLoader(db)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	if err := load.Migrate(context.TODO()); err != nil {
+		logrus.Fatal(err)
+	}
+
+	loader := NewSQLLoaderForDirectory(load, "../../manifests")
+	if err := loader.Populate(); err != nil {
+		logrus.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		logrus.Fatal(err)
+	}
+	store, err := NewSQLLiteQuerier(dbPath)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	m, err := ToModel(context.TODO(), store)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	require.NoError(t, m.Validate())
+	require.Equal(t, 3, len(m))
+
+	require.Equal(t, "etcd", m["etcd"].Name)
+	require.NotNil(t, m["etcd"].Icon)
+	require.Equal(t, "alpha", m["etcd"].DefaultChannel.Name)
+	require.Equal(t, 3, len(m["etcd"].Channels))
+	require.Equal(t, 3, len(m["etcd"].Channels["alpha"].Bundles))
+	require.Equal(t, 2, len(m["etcd"].Channels["beta"].Bundles))
+	require.Equal(t, 3, len(m["etcd"].Channels["stable"].Bundles))
+
+	require.Equal(t, "prometheus", m["prometheus"].Name)
+	require.NotNil(t, m["prometheus"].Icon)
+	require.Equal(t, "preview", m["prometheus"].DefaultChannel.Name)
+	require.Equal(t, 1, len(m["prometheus"].Channels))
+	require.Equal(t, 3, len(m["prometheus"].Channels["preview"].Bundles))
+
+	require.Equal(t, "strimzi-kafka-operator", m["strimzi-kafka-operator"].Name)
+	require.NotNil(t, m["strimzi-kafka-operator"].Icon)
+	require.Equal(t, "stable", m["strimzi-kafka-operator"].DefaultChannel.Name)
+	require.Equal(t, 3, len(m["strimzi-kafka-operator"].Channels))
+	require.Equal(t, 4, len(m["strimzi-kafka-operator"].Channels["alpha"].Bundles))
+	require.Equal(t, 3, len(m["strimzi-kafka-operator"].Channels["beta"].Bundles))
+	require.Equal(t, 2, len(m["strimzi-kafka-operator"].Channels["stable"].Bundles))
+}

--- a/vendor/github.com/operator-framework/operator-registry/cmd/opm/root/cmd.go
+++ b/vendor/github.com/operator-framework/operator-registry/cmd/opm/root/cmd.go
@@ -8,6 +8,7 @@ import (
 	"github.com/operator-framework/operator-registry/cmd/opm/index"
 	"github.com/operator-framework/operator-registry/cmd/opm/registry"
 	"github.com/operator-framework/operator-registry/cmd/opm/serve"
+	"github.com/operator-framework/operator-registry/cmd/opm/validate"
 	"github.com/operator-framework/operator-registry/cmd/opm/version"
 )
 
@@ -24,7 +25,7 @@ func NewCmd() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(registry.NewOpmRegistryCmd(), alpha.NewCmd(), serve.NewCmd())
+	cmd.AddCommand(registry.NewOpmRegistryCmd(), alpha.NewCmd(), serve.NewCmd(), validate.NewCmd())
 	index.AddCommand(cmd)
 	version.AddCommand(cmd)
 

--- a/vendor/github.com/operator-framework/operator-registry/cmd/opm/validate/validate.go
+++ b/vendor/github.com/operator-framework/operator-registry/cmd/opm/validate/validate.go
@@ -1,0 +1,49 @@
+package validate
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/operator-framework/operator-registry/pkg/lib/config"
+)
+
+func NewCmd() *cobra.Command {
+	validate := &cobra.Command{
+		Use:   "validate <directory>",
+		Short: "Validate the declarative index config",
+		Long:  "Validate the declarative config JSON file(s) in a given directory",
+		Args:  cobra.ExactArgs(1),
+		RunE:  configValidate,
+	}
+
+	validate.Flags().BoolP("debug", "d", false, "enable debug log output")
+	return validate
+}
+
+func configValidate(cmd *cobra.Command, args []string) error {
+	debug, err := cmd.Flags().GetBool("debug")
+	if err != nil {
+		return err
+	}
+
+	directory := args[0]
+	if _, err := os.Stat(directory); os.IsNotExist(err) {
+		return err
+	}
+
+	logger := logrus.WithField("cmd", "validate")
+	if debug {
+		logger.Logger.SetLevel(logrus.DebugLevel)
+	}
+
+	err = config.ValidateConfig(directory)
+	if err != nil {
+		logger.Error(err.Error())
+		return fmt.Errorf("failed to validate config: %s", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/operator-framework/operator-registry/internal/declcfg/declcfg_to_model.go
+++ b/vendor/github.com/operator-framework/operator-registry/internal/declcfg/declcfg_to_model.go
@@ -41,8 +41,16 @@ func ConvertToModel(cfg DeclarativeConfig) (model.Model, error) {
 			return nil, fmt.Errorf("parse properties for bundle %q: %v", b.Name, err)
 		}
 
+		if len(props.Packages) == 0 {
+			return nil, fmt.Errorf("missing package property for bundle %q", b.Name)
+		}
+
 		if b.Package != props.Packages[0].PackageName {
 			return nil, fmt.Errorf("package %q does not match %q property %q", b.Package, property.TypePackage, props.Packages[0].PackageName)
+		}
+
+		if len(props.Channels) == 0 {
+			return nil, fmt.Errorf("bundle %q is missing channel information", b.Name)
 		}
 
 		for _, bundleChannel := range props.Channels {
@@ -75,7 +83,7 @@ func ConvertToModel(cfg DeclarativeConfig) (model.Model, error) {
 
 	for _, mpkg := range mpkgs {
 		defaultChannelName := defaultChannels[mpkg.Name]
-		if mpkg.DefaultChannel == nil {
+		if defaultChannelName != "" && mpkg.DefaultChannel == nil {
 			dch := &model.Channel{
 				Package: mpkg,
 				Name:    defaultChannelName,

--- a/vendor/github.com/operator-framework/operator-registry/internal/model/model.go
+++ b/vendor/github.com/operator-framework/operator-registry/internal/model/model.go
@@ -54,12 +54,12 @@ func (m *Package) Validate() error {
 		result = multierror.Append(result, fmt.Errorf("invalid icon: %v", err))
 	}
 
-	if len(m.Channels) == 0 {
-		result = multierror.Append(result, fmt.Errorf("package must contain at least one channel"))
-	}
-
 	if m.DefaultChannel == nil {
 		result = multierror.Append(result, fmt.Errorf("default channel must be set"))
+	}
+
+	if len(m.Channels) == 0 {
+		result = multierror.Append(result, fmt.Errorf("package must contain at least one channel"))
 	}
 
 	foundDefault := false
@@ -258,6 +258,10 @@ func (b *Bundle) Validate() error {
 
 	if props != nil && len(props.Packages) != 1 {
 		result = multierror.Append(result, fmt.Errorf("must be exactly one property with type %q", property.TypePackage))
+	}
+
+	if b.Image == "" && len(b.Objects) == 0 {
+		result = multierror.Append(result, errors.New("bundle image must be set"))
 	}
 
 	return result.ErrorOrNil()

--- a/vendor/github.com/operator-framework/operator-registry/pkg/api/api_to_model.go
+++ b/vendor/github.com/operator-framework/operator-registry/pkg/api/api_to_model.go
@@ -86,10 +86,11 @@ func convertAPIBundleToModelProperties(b *Bundle) ([]property.Property, error) {
 			k := property.GVKRequired{Group: v.Group, Kind: v.Kind, Version: v.Version}
 			requiredGVKs[k] = struct{}{}
 		case property.TypePackage:
-			out = append(out, property.Property{
-				Type:  property.TypePackageRequired,
-				Value: json.RawMessage(p.Value),
-			})
+			var v property.Package
+			if err := json.Unmarshal(json.RawMessage(p.Value), &v); err != nil {
+				return nil, property.ParseError{Idx: i, Typ: p.Type, Err: err}
+			}
+			out = append(out, property.MustBuildPackageRequired(v.PackageName, v.Version))
 		}
 	}
 

--- a/vendor/github.com/operator-framework/operator-registry/pkg/lib/config/validate.go
+++ b/vendor/github.com/operator-framework/operator-registry/pkg/lib/config/validate.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"github.com/operator-framework/operator-registry/internal/declcfg"
+)
+
+// ValidateConfig takes a directory containing the declarative config file(s)
+// 1. Validate if declarative config file(s) are valid based on specified schema
+// 2. Validate the `replaces` chains of the upgrade graph
+// Inputs:
+// directory: the directory where declarative config file(s) exist
+// Outputs:
+// error: a wrapped error that contains a list of error strings
+func ValidateConfig(directory string) error {
+	// Load config files and convert them to declcfg objects
+	cfg, err := declcfg.LoadDir(directory)
+	if err != nil {
+		return err
+	}
+	// Validate the config using model validation:
+	// This will convert declcfg objects to intermediate model objects that are
+	// also used for serve and add commands. The conversion process will run
+	// validation for the model objects and ensure they are valid.
+	_, err = declcfg.ConvertToModel(*cfg)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -571,6 +571,7 @@ github.com/operator-framework/operator-registry/cmd/opm/index
 github.com/operator-framework/operator-registry/cmd/opm/registry
 github.com/operator-framework/operator-registry/cmd/opm/root
 github.com/operator-framework/operator-registry/cmd/opm/serve
+github.com/operator-framework/operator-registry/cmd/opm/validate
 github.com/operator-framework/operator-registry/cmd/opm/version
 github.com/operator-framework/operator-registry/cmd/registry-server
 github.com/operator-framework/operator-registry/internal/declcfg
@@ -586,6 +587,7 @@ github.com/operator-framework/operator-registry/pkg/image/containerdregistry
 github.com/operator-framework/operator-registry/pkg/image/execregistry
 github.com/operator-framework/operator-registry/pkg/lib/bundle
 github.com/operator-framework/operator-registry/pkg/lib/certs
+github.com/operator-framework/operator-registry/pkg/lib/config
 github.com/operator-framework/operator-registry/pkg/lib/dns
 github.com/operator-framework/operator-registry/pkg/lib/graceful
 github.com/operator-framework/operator-registry/pkg/lib/indexer


### PR DESCRIPTION
Builds off the commits in #45

- Adds tests and fixes bugs for the opm serve declarative config implementation
- Adds the opm validate command for validating declarative config files
- Removes the staging/operator-registry/operator-registry.Dockerfile