### PR TITLE
manifests,scripts: Add single node developer release annotation

### DIFF
--- a/manifests/0000_50_olm_00-catalogsources.crd.yaml
+++ b/manifests/0000_50_olm_00-catalogsources.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: catalogsources.operators.coreos.com
 spec:

--- a/manifests/0000_50_olm_00-clusterserviceversions.crd.yaml
+++ b/manifests/0000_50_olm_00-clusterserviceversions.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: clusterserviceversions.operators.coreos.com
 spec:

--- a/manifests/0000_50_olm_00-installplans.crd.yaml
+++ b/manifests/0000_50_olm_00-installplans.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: installplans.operators.coreos.com
 spec:

--- a/manifests/0000_50_olm_00-namespace.yaml
+++ b/manifests/0000_50_olm_00-namespace.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     openshift.io/node-selector: ""
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     openshift.io/scc: "anyuid"
     openshift.io/cluster-monitoring: "true"
@@ -16,5 +17,6 @@ metadata:
   annotations:
     openshift.io/node-selector: ""
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     openshift.io/scc: "anyuid"

--- a/manifests/0000_50_olm_00-operatorconditions.crd.yaml
+++ b/manifests/0000_50_olm_00-operatorconditions.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: operatorconditions.operators.coreos.com
 spec:

--- a/manifests/0000_50_olm_00-operatorgroups.crd.yaml
+++ b/manifests/0000_50_olm_00-operatorgroups.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: operatorgroups.operators.coreos.com
 spec:

--- a/manifests/0000_50_olm_00-operators.crd.yaml
+++ b/manifests/0000_50_olm_00-operators.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: operators.operators.coreos.com
 spec:

--- a/manifests/0000_50_olm_00-subscriptions.crd.yaml
+++ b/manifests/0000_50_olm_00-subscriptions.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: subscriptions.operators.coreos.com
 spec:

--- a/manifests/0000_50_olm_01-olm-operator.serviceaccount.yaml
+++ b/manifests/0000_50_olm_01-olm-operator.serviceaccount.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -12,6 +13,7 @@ metadata:
   name: system:controller:operator-lifecycle-manager
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
   - apiGroups: ["*"]
     resources: ["*"]
@@ -25,6 +27,7 @@ metadata:
   name: olm-operator-binding-openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/0000_50_olm_02-services.yaml
+++ b/manifests/0000_50_olm_02-services.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: olm-operator-serving-cert
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     app: olm-operator
 spec:
@@ -26,6 +27,7 @@ metadata:
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: catalog-operator-serving-cert
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     app: catalog-operator
 spec:

--- a/manifests/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/manifests/0000_50_olm_07-olm-operator.deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app: olm-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   strategy:
     type: RollingUpdate

--- a/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app: catalog-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   strategy:
     type: RollingUpdate

--- a/manifests/0000_50_olm_09-aggregated.clusterrole.yaml
+++ b/manifests/0000_50_olm_09-aggregated.clusterrole.yaml
@@ -8,6 +8,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
   - apiGroups: ["operators.coreos.com"]
     resources: ["subscriptions"]
@@ -27,6 +28,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
   - apiGroups: ["operators.coreos.com"]
     resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions", "operatorgroups"]

--- a/manifests/0000_50_olm_13-operatorgroup-default.yaml
+++ b/manifests/0000_50_olm_13-operatorgroup-default.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-operators
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 ---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
@@ -13,6 +14,7 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   targetNamespaces:
     - openshift-operator-lifecycle-manager

--- a/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+++ b/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
@@ -72,7 +72,7 @@ spec:
           spec:
             strategy:
               type: RollingUpdate
-            replicas: 2
+            replicas: 1
             selector:
               matchLabels:
                 app: packageserver

--- a/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+++ b/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
@@ -8,6 +8,7 @@ metadata:
     olm.clusteroperator.name: operator-lifecycle-manager-packageserver
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   displayName: Package Server
   description: Represents an Operator package that is available from a given CatalogSource which will resolve to a ClusterServiceVersion.

--- a/manifests/0000_50_olm_99-operatorstatus.yaml
+++ b/manifests/0000_50_olm_99-operatorstatus.yaml
@@ -4,6 +4,7 @@ metadata:
   name: operator-lifecycle-manager
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 status:
   versions:
     - name: operator
@@ -15,6 +16,7 @@ metadata:
   name: operator-lifecycle-manager-catalog
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 status:
   versions:
     - name: operator
@@ -26,6 +28,7 @@ metadata:
   name: operator-lifecycle-manager-packageserver
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 status:
   versions:
     - name: operator

--- a/manifests/0000_90_olm_00-service-monitor.yaml
+++ b/manifests/0000_90_olm_00-service-monitor.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
   - apiGroups:
       - ""
@@ -24,6 +25,7 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -42,6 +44,7 @@ metadata:
     app: olm-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -73,6 +76,7 @@ metadata:
     app: catalog-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   jobLabel: k8s-app
   endpoints:

--- a/manifests/0000_90_olm_01-prometheus-rule.yaml
+++ b/manifests/0000_90_olm_01-prometheus-rule.yaml
@@ -8,6 +8,7 @@ metadata:
     role: alert-rules
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   groups:
     - name: olm.failing_operators.rules

--- a/manifests/0000_90_olm_01-prometheus-rule.yaml
+++ b/manifests/0000_90_olm_01-prometheus-rule.yaml
@@ -11,11 +11,21 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
 spec:
   groups:
-    - name: olm.failing_operators.rules
+    - name: olm.csv_abnormal.rules
       rules:
-        - alert: FailingOperator
-          annotations:
-            message: Failed to install Operator {{ $labels.name }} version {{ $labels.version }}. Reason-{{ $labels.reason }}
-          expr: csv_abnormal{phase="Failed"}
+        - alert: CsvAbnormalFailedOver2Min
+          expr: csv_abnormal{phase=~"^Failed$"}
+          for: 2m
           labels:
             severity: warning
+            namespace: "{{ $labels.namespace }}"
+          annotations:
+            message: Failed to install Operator {{ $labels.name }} version {{ $labels.version }}. Reason-{{ $labels.reason }}
+        - alert: CsvAbnormalOver30Min
+          expr: csv_abnormal{phase=~"(^Replacing$|^Pending$|^Deleting$|^Unknown$)"}
+          for: 30m
+          labels:
+            severity: warning
+            namespace: "{{ $labels.namespace }}"
+          annotations:
+            message: Failed to install Operator {{ $labels.name }} version {{ $labels.version }}. Phase-{{ $labels.phase }} Reason-{{ $labels.reason }}

--- a/scripts/add_release_annotation.sh
+++ b/scripts/add_release_annotation.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# TODO(tflannag): Add ability to override yq binary as either a parameter
+# or an environment varaibles like upstream OLM does.
+# For now, you can get the yq binary by running `go install ./vendor/github.com/mikefarah/yq/v3`
+# from the root repository and moving that binary into $PATH.
+chartdir=$1
+
+for f in $chartdir/*.yaml; do
+   yq w -d'*' --inplace --style=double $f 'metadata.annotations['include.release.openshift.io/self-managed-high-availability']' true
+   yq w -d'*' --inplace --style=double $f 'metadata.annotations['include.release.openshift.io/single-node-developer']' true
+done

--- a/scripts/generate_crds_manifests.sh
+++ b/scripts/generate_crds_manifests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash
 
 set -euo pipefail
 
@@ -7,7 +7,7 @@ cd ${repo_root}
 export  GOFLAGS="-mod=vendor"
 YQ="go run ./vendor/github.com/mikefarah/yq/v3/"
 CONTROLLER_GEN="go run ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen"
-ver=$(cat ./OLM_VERSION)
+ver=$(cat ./staging/operator-lifecycle-manager/OLM_VERSION)
 
 tmpdir="$(mktemp -p . -d 2>/dev/null || mktemp -p . -d -t tmpdir)"
 chartdir="${tmpdir}/chart"

--- a/staging/operator-lifecycle-manager/deploy/chart/Chart.yaml
+++ b/staging/operator-lifecycle-manager/deploy/chart/Chart.yaml
@@ -2,3 +2,7 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 name: olm
 version: 0.0.0-dev
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"

--- a/staging/operator-lifecycle-manager/deploy/chart/values.yaml
+++ b/staging/operator-lifecycle-manager/deploy/chart/values.yaml
@@ -18,9 +18,8 @@ olm:
     kubernetes.io/os: linux
   resources:
     requests:
-     cpu: 10m
-     memory: 160Mi
-
+      cpu: 10m
+      memory: 160Mi
 catalog:
   replicaCount: 1
   commandArgs: -configmapServerImage=quay.io/operator-framework/configmap-operator-registry:latest
@@ -33,9 +32,8 @@ catalog:
     kubernetes.io/os: linux
   resources:
     requests:
-     cpu: 10m
-     memory: 80Mi
-
+      cpu: 10m
+      memory: 80Mi
 package:
   replicaCount: 1
   image:
@@ -47,5 +45,9 @@ package:
     kubernetes.io/os: linux
   resources:
     requests:
-     cpu: 10m
-     memory: 50Mi
+      cpu: 10m
+      memory: 50Mi
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"


### PR DESCRIPTION
This was missed when we were pulling down upstream OLM changes.

- CP the OLM upstream commit that introduced this.
- Fix the scripts/generate_crd_manifests.sh bash script that points to a missing OLM_VERSION file.
- Re-generate the YAML manifests.
- Introduce the upstream OLM add_release_annotations bash script.