### PR TITLE
Bug 1948725: Add IBM managed cloud profile annotations to manifests

### DIFF
--- a/OLM_VERSION
+++ b/OLM_VERSION
@@ -1,0 +1,1 @@
+./staging/operator-lifecycle-manager/OLM_VERSION

--- a/manifests/0000_50_olm_00-catalogsources.crd.yaml
+++ b/manifests/0000_50_olm_00-catalogsources.crd.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null

--- a/manifests/0000_50_olm_00-clusterserviceversions.crd.yaml
+++ b/manifests/0000_50_olm_00-clusterserviceversions.crd.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null

--- a/manifests/0000_50_olm_00-installplans.crd.yaml
+++ b/manifests/0000_50_olm_00-installplans.crd.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null

--- a/manifests/0000_50_olm_00-namespace.yaml
+++ b/manifests/0000_50_olm_00-namespace.yaml
@@ -4,6 +4,7 @@ metadata:
   name: openshift-operator-lifecycle-manager
   annotations:
     openshift.io/node-selector: ""
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:
@@ -16,6 +17,7 @@ metadata:
   name: openshift-operators
   annotations:
     openshift.io/node-selector: ""
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:

--- a/manifests/0000_50_olm_00-operatorconditions.crd.yaml
+++ b/manifests/0000_50_olm_00-operatorconditions.crd.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null

--- a/manifests/0000_50_olm_00-operatorgroups.crd.yaml
+++ b/manifests/0000_50_olm_00-operatorgroups.crd.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null

--- a/manifests/0000_50_olm_00-operators.crd.yaml
+++ b/manifests/0000_50_olm_00-operators.crd.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null

--- a/manifests/0000_50_olm_00-subscriptions.crd.yaml
+++ b/manifests/0000_50_olm_00-subscriptions.crd.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null

--- a/manifests/0000_50_olm_01-olm-operator.serviceaccount.yaml
+++ b/manifests/0000_50_olm_01-olm-operator.serviceaccount.yaml
@@ -4,6 +4,7 @@ metadata:
   name: olm-operator-serviceaccount
   namespace: openshift-operator-lifecycle-manager
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 ---
@@ -12,6 +13,7 @@ kind: ClusterRole
 metadata:
   name: system:controller:operator-lifecycle-manager
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 rules:
@@ -26,6 +28,7 @@ kind: ClusterRoleBinding
 metadata:
   name: olm-operator-binding-openshift-operator-lifecycle-manager
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 roleRef:

--- a/manifests/0000_50_olm_02-services.yaml
+++ b/manifests/0000_50_olm_02-services.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: olm-operator-serving-cert
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:
@@ -26,6 +27,7 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: catalog-operator-serving-cert
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:

--- a/manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
+++ b/manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: olm-operator
+  namespace: openshift-operator-lifecycle-manager
+  labels:
+    app: olm-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: olm-operator
+  template:
+    metadata:
+      labels:
+        app: olm-operator
+    spec:
+      serviceAccountName: olm-operator-serviceaccount
+      priorityClassName: "system-cluster-critical"
+      containers:
+        - name: olm-operator
+          command:
+            - /bin/olm
+          args:
+            - --namespace
+            - $(OPERATOR_NAMESPACE)
+            - --writeStatusName
+            - operator-lifecycle-manager
+            - --writePackageServerStatusName
+            - operator-lifecycle-manager-packageserver
+            - --tls-cert
+            - /var/run/secrets/serving-cert/tls.crt
+            - --tls-key
+            - /var/run/secrets/serving-cert/tls.key
+          image: quay.io/operator-framework/olm@sha256:de396b540b82219812061d0d753440d5655250c621c753ed1dc67d6154741607
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+            - containerPort: 8081
+              name: metrics
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          terminationMessagePolicy: FallbackToLogsOnError
+          env:
+            - name: RELEASE_VERSION
+              value: "0.0.1-snapshot"
+            - name: OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPERATOR_NAME
+              value: olm-operator
+          resources:
+            requests:
+              cpu: 10m
+              memory: 160Mi
+          volumeMounts:
+            - mountPath: /var/run/secrets/serving-cert
+              name: serving-cert
+      volumes:
+        - name: serving-cert
+          secret:
+            secretName: olm-operator-serving-cert
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 120
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 120

--- a/manifests/0000_50_olm_08-catalog-operator.deployment.ibm-cloud-managed.yaml
+++ b/manifests/0000_50_olm_08-catalog-operator.deployment.ibm-cloud-managed.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: catalog-operator
+  namespace: openshift-operator-lifecycle-manager
+  labels:
+    app: catalog-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: catalog-operator
+  template:
+    metadata:
+      labels:
+        app: catalog-operator
+    spec:
+      serviceAccountName: olm-operator-serviceaccount
+      priorityClassName: "system-cluster-critical"
+      containers:
+        - name: catalog-operator
+          command:
+            - /bin/catalog
+          args:
+            - '-namespace'
+            - openshift-marketplace
+            - -configmapServerImage=quay.io/operator-framework/configmap-operator-registry:latest
+            - -util-image
+            - quay.io/operator-framework/olm@sha256:de396b540b82219812061d0d753440d5655250c621c753ed1dc67d6154741607
+            - -writeStatusName
+            - operator-lifecycle-manager-catalog
+            - -tls-cert
+            - /var/run/secrets/serving-cert/tls.crt
+            - -tls-key
+            - /var/run/secrets/serving-cert/tls.key
+          image: quay.io/operator-framework/olm@sha256:de396b540b82219812061d0d753440d5655250c621c753ed1dc67d6154741607
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+            - containerPort: 8081
+              name: metrics
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          terminationMessagePolicy: FallbackToLogsOnError
+          env:
+            - name: RELEASE_VERSION
+              value: "0.0.1-snapshot"
+          resources:
+            requests:
+              cpu: 10m
+              memory: 80Mi
+          volumeMounts:
+            - mountPath: /var/run/secrets/serving-cert
+              name: serving-cert
+      volumes:
+        - name: serving-cert
+          secret:
+            secretName: catalog-operator-serving-cert
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 120
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 120

--- a/manifests/0000_50_olm_09-aggregated.clusterrole.yaml
+++ b/manifests/0000_50_olm_09-aggregated.clusterrole.yaml
@@ -7,6 +7,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 rules:
@@ -27,6 +28,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 rules:

--- a/manifests/0000_50_olm_13-operatorgroup-default.yaml
+++ b/manifests/0000_50_olm_13-operatorgroup-default.yaml
@@ -4,6 +4,7 @@ metadata:
   name: global-operators
   namespace: openshift-operators
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 ---
@@ -13,6 +14,7 @@ metadata:
   name: olm-operators
   namespace: openshift-operator-lifecycle-manager
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:

--- a/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+++ b/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
@@ -7,6 +7,7 @@ metadata:
     olm.version: 0.17.0
     olm.clusteroperator.name: operator-lifecycle-manager-packageserver
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:

--- a/manifests/0000_50_olm_99-operatorstatus.yaml
+++ b/manifests/0000_50_olm_99-operatorstatus.yaml
@@ -3,6 +3,7 @@ kind: ClusterOperator
 metadata:
   name: operator-lifecycle-manager
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 status:
@@ -15,6 +16,7 @@ kind: ClusterOperator
 metadata:
   name: operator-lifecycle-manager-catalog
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 status:
@@ -27,6 +29,7 @@ kind: ClusterOperator
 metadata:
   name: operator-lifecycle-manager-packageserver
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 status:

--- a/manifests/0000_90_olm_00-service-monitor.yaml
+++ b/manifests/0000_90_olm_00-service-monitor.yaml
@@ -4,6 +4,7 @@ metadata:
   name: operator-lifecycle-manager-metrics
   namespace: openshift-operator-lifecycle-manager
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 rules:
@@ -24,6 +25,7 @@ metadata:
   name: operator-lifecycle-manager-metrics
   namespace: openshift-operator-lifecycle-manager
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 roleRef:
@@ -43,6 +45,7 @@ metadata:
   labels:
     app: olm-operator
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:
@@ -75,6 +78,7 @@ metadata:
   labels:
     app: catalog-operator
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:

--- a/manifests/0000_90_olm_01-prometheus-rule.yaml
+++ b/manifests/0000_90_olm_01-prometheus-rule.yaml
@@ -7,6 +7,7 @@ metadata:
     prometheus: alert-rules
     role: alert-rules
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:


### PR DESCRIPTION
**Description of the change:**
Adds ibm-cloud-managed profile annotation to most manifests.
For deployment manifests, creates an ibm-cloud-managed copy which
removes the master node selector so that OLM can run on worker nodes.
This should not impact other profiles or current function.


**Motivation for the change:**
This PR is necessary to include OLM in a an IBM cloud managed (ROKS) installation of OpenShift. Because there are no master nodes in a ROKS cluster, it is necessary to create ibm-cloud-managed specific copies of the operator's deployments that do not include master node labels.