### PR TITLE
Bug 1948771: Revert "set packageserver replicas to 1 for single node"

### DIFF
--- a/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+++ b/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
@@ -72,7 +72,7 @@ spec:
           spec:
             strategy:
               type: RollingUpdate
-            replicas: 1
+            replicas: 2
             selector:
               matchLabels:
                 app: packageserver

--- a/staging/operator-lifecycle-manager/deploy/chart/values.yaml
+++ b/staging/operator-lifecycle-manager/deploy/chart/values.yaml
@@ -37,7 +37,7 @@ catalog:
      memory: 80Mi
 
 package:
-  replicaCount: 1
+  replicaCount: 2
   image:
     ref: quay.io/operator-framework/olm:master
     pullPolicy: Always

--- a/staging/operator-lifecycle-manager/deploy/ocp/values.yaml
+++ b/staging/operator-lifecycle-manager/deploy/ocp/values.yaml
@@ -62,7 +62,7 @@ catalog:
       cpu: 10m
       memory: 80Mi
 package:
-  replicaCount: 1
+  replicaCount: 2
   image:
     ref: quay.io/operator-framework/olm@sha256:de396b540b82219812061d0d753440d5655250c621c753ed1dc67d6154741607
     pullPolicy: IfNotPresent

--- a/staging/operator-lifecycle-manager/deploy/upstream/quickstart/olm.yaml
+++ b/staging/operator-lifecycle-manager/deploy/upstream/quickstart/olm.yaml
@@ -274,7 +274,7 @@ spec:
         spec:
           strategy:
             type: RollingUpdate
-          replicas: 1
+          replicas: 2
           selector:
             matchLabels:
               app: packageserver

--- a/staging/operator-lifecycle-manager/deploy/upstream/values.yaml
+++ b/staging/operator-lifecycle-manager/deploy/upstream/values.yaml
@@ -21,7 +21,7 @@ catalog:
   service:
     internalPort: 8080
 package:
-  replicaCount: 1
+  replicaCount: 2
   image:
     ref: quay.io/operator-framework/olm@sha256:de396b540b82219812061d0d753440d5655250c621c753ed1dc67d6154741607
     pullPolicy: Always


### PR DESCRIPTION
Cherry-pick of the upstream OLM commit: d74157da300a9874c7dd0f0200875038245e3d0e