### PR TITLE
Bug 1951652: Retry failures when pulling images

### DIFF
--- a/staging/operator-registry/go.mod
+++ b/staging/operator-registry/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
+	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6
 	github.com/opencontainers/runc v0.1.1 // indirect
 	github.com/operator-framework/api v0.0.0-00010101000000-000000000000

--- a/staging/operator-registry/pkg/image/buildahregistry/_registry.go
+++ b/staging/operator-registry/pkg/image/buildahregistry/_registry.go
@@ -4,6 +4,7 @@ package buildahregistry
 import (
 	"context"
 	"path"
+	"time"
 
 	"github.com/containers/buildah"
 	"github.com/containers/image/v5/types"
@@ -42,8 +43,8 @@ func (r *Registry) Pull(ctx context.Context, ref image.Reference) error {
 		BlobDirectory:    r.CacheDir,
 		AllTags:          false,
 		RemoveSignatures: false,
-		MaxRetries:       0,
-		RetryDelay:       0,
+		MaxRetries:       5,
+		RetryDelay:       1 * time.Second,
 	})
 
 	r.log.Info(img)

--- a/staging/operator-registry/pkg/image/registry_test.go
+++ b/staging/operator-registry/pkg/image/registry_test.go
@@ -3,12 +3,21 @@ package image_test
 import (
 	"context"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"math/rand"
+	"net/http"
 	"os"
+	"sync"
 	"testing"
 
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/configuration"
+	"github.com/docker/distribution/reference"
+	repositorymiddleware "github.com/docker/distribution/registry/middleware/repository"
+	"github.com/opencontainers/go-digest"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/mod/sumdb/dirhash"
@@ -74,20 +83,20 @@ func TestRegistries(t *testing.T) {
 	}
 
 	for name, registry := range registries {
-		t.Run(name, func(t *testing.T) {
-			testPullAndUnpack(t, registry)
-		})
-
+		testPullAndUnpack(t, name, registry)
 	}
 }
 
-func testPullAndUnpack(t *testing.T, newRegistry newRegistryFunc) {
+func testPullAndUnpack(t *testing.T, name string, newRegistry newRegistryFunc) {
 	type args struct {
 		dockerRootDir string
 		img           string
+		pullErrCount  int
+		pullErr       error
 	}
 	type expected struct {
-		checksum string
+		checksum      string
+		pullAssertion require.ErrorAssertionFunc
 	}
 	tests := []struct {
 		description string
@@ -95,23 +104,61 @@ func testPullAndUnpack(t *testing.T, newRegistry newRegistryFunc) {
 		expected    expected
 	}{
 		{
-			description: "ByTag",
+			description: fmt.Sprintf("%s/ByTag", name),
 			args: args{
 				dockerRootDir: "testdata/golden",
 				img:           "/olmtest/kiali:1.4.2",
 			},
 			expected: expected{
-				checksum: dirChecksum(t, "testdata/golden/bundles/kiali"),
+				checksum:      dirChecksum(t, "testdata/golden/bundles/kiali"),
+				pullAssertion: require.NoError,
 			},
 		},
 		{
-			description: "ByDigest",
+			description: fmt.Sprintf("%s/ByDigest", name),
 			args: args{
 				dockerRootDir: "testdata/golden",
 				img:           "/olmtest/kiali@sha256:a1bec450c104ceddbb25b252275eb59f1f1e6ca68e0ced76462042f72f7057d8",
 			},
 			expected: expected{
-				checksum: dirChecksum(t, "testdata/golden/bundles/kiali"),
+				checksum:      dirChecksum(t, "testdata/golden/bundles/kiali"),
+				pullAssertion: require.NoError,
+			},
+		},
+		{
+			description: fmt.Sprintf("%s/WithOneRetriableError", name),
+			args: args{
+				dockerRootDir: "testdata/golden",
+				img:           "/olmtest/kiali:1.4.2",
+				pullErrCount:  1,
+				pullErr:       errors.New("dummy"),
+			},
+			expected: expected{
+				checksum:      dirChecksum(t, "testdata/golden/bundles/kiali"),
+				pullAssertion: require.NoError,
+			},
+		},
+		// TODO: figure out how to have the server send a detectable non-retriable error.
+		//{
+		//  description: fmt.Sprintf("%s/WithNonRetriableError", name),
+		//	args: args{
+		//		dockerRootDir: "testdata/golden",
+		//		img:           "/olmtest/kiali:1.4.2",
+		//	},
+		//	expected: expected{
+		//		pullAssertion: require.Error,
+		//	},
+		//},
+		{
+			description: fmt.Sprintf("%s/WithAlwaysRetriableError", name),
+			args: args{
+				dockerRootDir: "testdata/golden",
+				img:           "/olmtest/kiali:1.4.2",
+				pullErrCount:  math.MaxInt64,
+				pullErr:       errors.New("dummy"),
+			},
+			expected: expected{
+				pullAssertion: require.Error,
 			},
 		},
 	}
@@ -121,23 +168,45 @@ func testPullAndUnpack(t *testing.T, newRegistry newRegistryFunc) {
 			ctx, close := context.WithCancel(context.Background())
 			defer close()
 
-			host, cafile, err := libimage.RunDockerRegistry(ctx, tt.args.dockerRootDir)
+			configOpts := []libimage.ConfigOpt{}
+
+			if tt.args.pullErrCount > 0 {
+				configOpts = append(configOpts, func(config *configuration.Configuration) {
+					if config.Middleware == nil {
+						config.Middleware = make(map[string][]configuration.Middleware)
+					}
+
+					mockRepo := &mockRepo{blobStore: &mockBlobStore{
+						maxCount: tt.args.pullErrCount,
+						err:      tt.args.pullErr,
+					}}
+					middlewareName := fmt.Sprintf("test-%x", rand.Int())
+					require.NoError(t, repositorymiddleware.Register(middlewareName, mockRepo.init))
+					config.Middleware["repository"] = append(config.Middleware["repository"], configuration.Middleware{
+						Name: middlewareName,
+					})
+				})
+			}
+
+			host, cafile, err := libimage.RunDockerRegistry(ctx, tt.args.dockerRootDir, configOpts...)
 			require.NoError(t, err)
 
 			r, cleanup := newRegistry(t, cafile)
 			defer cleanup()
 
 			ref := image.SimpleReference(host + tt.args.img)
-			require.NoError(t, r.Pull(ctx, ref))
+			tt.expected.pullAssertion(t, r.Pull(ctx, ref))
 
-			// Copy golden manifests to a temp dir
-			dir := "kiali-unpacked"
-			require.NoError(t, r.Unpack(ctx, ref, dir))
+			if tt.expected.checksum != "" {
+				// Copy golden manifests to a temp dir
+				dir := "kiali-unpacked"
+				require.NoError(t, r.Unpack(ctx, ref, dir))
 
-			checksum := dirChecksum(t, dir)
-			require.Equal(t, tt.expected.checksum, checksum)
+				checksum := dirChecksum(t, dir)
+				require.Equal(t, tt.expected.checksum, checksum)
 
-			require.NoError(t, os.RemoveAll(dir))
+				require.NoError(t, os.RemoveAll(dir))
+			}
 		})
 	}
 }
@@ -146,4 +215,85 @@ func dirChecksum(t *testing.T, dir string) string {
 	sum, err := dirhash.HashDir(dir, "", dirhash.DefaultHash)
 	require.NoError(t, err)
 	return sum
+}
+
+var _ distribution.Repository = &mockRepo{}
+
+type mockRepo struct {
+	base      distribution.Repository
+	blobStore *mockBlobStore
+	once      sync.Once
+}
+
+func (f *mockRepo) init(ctx context.Context, base distribution.Repository, options map[string]interface{}) (distribution.Repository, error) {
+	f.once.Do(func() {
+		f.base = base
+		f.blobStore.base = base.Blobs(ctx)
+	})
+	return f, nil
+}
+
+func (f mockRepo) Named() reference.Named {
+	return f.base.Named()
+}
+
+func (f mockRepo) Manifests(ctx context.Context, options ...distribution.ManifestServiceOption) (distribution.ManifestService, error) {
+	return f.base.Manifests(ctx, options...)
+}
+
+func (f mockRepo) Blobs(ctx context.Context) distribution.BlobStore {
+	return f.blobStore
+}
+
+func (f mockRepo) Tags(ctx context.Context) distribution.TagService {
+	return f.base.Tags(ctx)
+}
+
+var _ distribution.BlobStore = &mockBlobStore{}
+
+type mockBlobStore struct {
+	base     distribution.BlobStore
+	err      error
+	maxCount int
+
+	count int
+	m     sync.Mutex
+}
+
+func (f *mockBlobStore) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
+	f.m.Lock()
+	defer f.m.Unlock()
+	f.count++
+	if f.count <= f.maxCount {
+		return distribution.Descriptor{}, f.err
+	}
+	return f.base.Stat(ctx, dgst)
+}
+
+func (f mockBlobStore) Get(ctx context.Context, dgst digest.Digest) ([]byte, error) {
+	return f.base.Get(ctx, dgst)
+}
+
+func (f mockBlobStore) Open(ctx context.Context, dgst digest.Digest) (distribution.ReadSeekCloser, error) {
+	return f.base.Open(ctx, dgst)
+}
+
+func (f mockBlobStore) Put(ctx context.Context, mediaType string, p []byte) (distribution.Descriptor, error) {
+	return f.base.Put(ctx, mediaType, p)
+}
+
+func (f mockBlobStore) Create(ctx context.Context, options ...distribution.BlobCreateOption) (distribution.BlobWriter, error) {
+	return f.base.Create(ctx, options...)
+}
+
+func (f mockBlobStore) Resume(ctx context.Context, id string) (distribution.BlobWriter, error) {
+	return f.base.Resume(ctx, id)
+}
+
+func (f mockBlobStore) ServeBlob(ctx context.Context, w http.ResponseWriter, r *http.Request, dgst digest.Digest) error {
+	return f.base.ServeBlob(ctx, w, r, dgst)
+}
+
+func (f mockBlobStore) Delete(ctx context.Context, dgst digest.Digest) error {
+	return f.base.Delete(ctx, dgst)
 }


### PR DESCRIPTION
Cherry-pick of upstream PR https://github.com/operator-framework/operator-registry/pull/633

This commit adds retries to the containerd and podman pull tools.
The docker pull tool shells out to the docker CLI, which already
supports retries.

The retry backoff is setup to retry every 1 second, 5 times.

Signed-off-by: Joe Lanford <joe.lanford@gmail.com>