### PR TITLE
Add verify target to Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,12 +114,12 @@ vendor:
 	go mod vendor
 	go mod verify
 
-.PHONY: sanity
-sanity:
-	$(MAKE) vendor && git diff --stat HEAD --ignore-submodules --exit-code
-
 manifests: vendor ## Generate manifests
 	./scripts/generate_crds_manifests.sh
+
+verify: vendor
+	git diff --stat HEAD --ignore-submodules --exit-code
+.PHONY: verify
 
 .PHONY: help
 help: ## Display this help.


### PR DESCRIPTION
For a start, it does the same thing as is currently configured in
openshift/release. The job config can be updated to run "make verify"
so that future verifications can be added to this repository
directly. This replaces the existing "sanity" target in favor of a
more conventional name.

See also: https://github.com/openshift/release/blob/7e61829f682e1574513f78c3e94537836d824ab3/ci-operator/config/openshift/operator-framework-olm/openshift-operator-framework-olm-master.yaml#L47.