### PR TITLE
Bug 1952238: Report catalog pod termination logs to catalog operator on exit

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
@@ -143,7 +143,8 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, saName strin
 							v1.ResourceMemory: resource.MustParse("50Mi"),
 						},
 					},
-					ImagePullPolicy: pullPolicy,
+					ImagePullPolicy:          pullPolicy,
+					TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
 				},
 			},
 			NodeSelector: map[string]string{

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
@@ -143,7 +143,8 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, saName strin
 							v1.ResourceMemory: resource.MustParse("50Mi"),
 						},
 					},
-					ImagePullPolicy: pullPolicy,
+					ImagePullPolicy:          pullPolicy,
+					TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
 				},
 			},
 			NodeSelector: map[string]string{


### PR DESCRIPTION
This PR sets the terminationMessagePolicy for the registry container in the
catalog pod as FallBackToLogsOnError to report back termination logs from a
catalog pod to the catalog operator

Signed-off-by: Anik Bhattacharjee <anikbhattacharya93@gmail.com>