### PR TITLE
Bug 1959158: Make ClusterOperator Available condition sticky.

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/lib/operatorstatus/csv_reporter.go
+++ b/staging/operator-lifecycle-manager/pkg/lib/operatorstatus/csv_reporter.go
@@ -104,9 +104,9 @@ func (r *csvStatusReporter) GetNewStatus(existing *configv1.ClusterOperatorStatu
 
 	switch phase {
 	case v1alpha1.CSVPhaseSucceeded:
-		builder.WithAvailable(configv1.ConditionTrue, fmt.Sprintf("ClusterServiceVersion %v/%v is in phase %v", csv.Namespace, csv.Name, csv.Status.Phase), reasonCSVSucceeded)
-	default:
-		builder.WithAvailable(configv1.ConditionFalse, fmt.Sprintf("ClusterServiceVersion %v/%v is in phase %v with reason: %v, message: %v", csv.Namespace, csv.Name, csv.Status.Phase, csv.Status.Reason, csv.Status.Message), reasonCSVNotSucceeded)
+		builder.WithAvailable(configv1.ConditionTrue, fmt.Sprintf("ClusterServiceVersion %v/%v observed in phase %v", csv.Namespace, csv.Name, csv.Status.Phase), reasonCSVSucceeded)
+	case v1alpha1.CSVPhaseFailed:
+		builder.WithAvailable(configv1.ConditionFalse, fmt.Sprintf("ClusterServiceVersion %v/%v observed in phase %v with reason: %v, message: %v", csv.Namespace, csv.Name, csv.Status.Phase, csv.Status.Reason, csv.Status.Message), reasonCSVNotSucceeded)
 	}
 
 	switch phase {

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorstatus/csv_reporter.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorstatus/csv_reporter.go
@@ -104,9 +104,9 @@ func (r *csvStatusReporter) GetNewStatus(existing *configv1.ClusterOperatorStatu
 
 	switch phase {
 	case v1alpha1.CSVPhaseSucceeded:
-		builder.WithAvailable(configv1.ConditionTrue, fmt.Sprintf("ClusterServiceVersion %v/%v is in phase %v", csv.Namespace, csv.Name, csv.Status.Phase), reasonCSVSucceeded)
-	default:
-		builder.WithAvailable(configv1.ConditionFalse, fmt.Sprintf("ClusterServiceVersion %v/%v is in phase %v with reason: %v, message: %v", csv.Namespace, csv.Name, csv.Status.Phase, csv.Status.Reason, csv.Status.Message), reasonCSVNotSucceeded)
+		builder.WithAvailable(configv1.ConditionTrue, fmt.Sprintf("ClusterServiceVersion %v/%v observed in phase %v", csv.Namespace, csv.Name, csv.Status.Phase), reasonCSVSucceeded)
+	case v1alpha1.CSVPhaseFailed:
+		builder.WithAvailable(configv1.ConditionFalse, fmt.Sprintf("ClusterServiceVersion %v/%v observed in phase %v with reason: %v, message: %v", csv.Namespace, csv.Name, csv.Status.Phase, csv.Status.Reason, csv.Status.Message), reasonCSVNotSucceeded)
 	}
 
 	switch phase {


### PR DESCRIPTION
The intermediate CSV phases (those other than Succeeded and Failed)
don't on their own provide availability information, so they should
not be used to make decisions about a corresponding ClusterOperator's
Available status condition.
