### PR TITLE
Bug 1961472: Explicitly set `readOnlyRootFilesystem: false` on created registry pods.

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
@@ -4,13 +4,14 @@ package reconciler
 import (
 	"strings"
 
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	controllerclient "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/controller-runtime/client"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorlister"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type nowFunc func() metav1.Time
@@ -102,6 +103,8 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, saName strin
 		pullPolicy = v1.PullAlways
 	}
 
+	readOnlyRootFilesystem := false
+
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: source.GetName() + "-",
@@ -142,6 +145,9 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, saName strin
 							v1.ResourceCPU:    resource.MustParse("10m"),
 							v1.ResourceMemory: resource.MustParse("50Mi"),
 						},
+					},
+					SecurityContext: &v1.SecurityContext{
+						ReadOnlyRootFilesystem: &readOnlyRootFilesystem,
 					},
 					ImagePullPolicy:          pullPolicy,
 					TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,

--- a/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler_test.go
@@ -1,11 +1,13 @@
 package reconciler
 
 import (
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"testing"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 )
 
 func TestPodNodeSelector(t *testing.T) {
@@ -73,4 +75,22 @@ func TestPullPolicy(t *testing.T) {
 			t.Fatalf("expected pull policy %s for image  %s", tt.policy, tt.image)
 		}
 	}
+}
+
+func TestPodContainerSecurityContext(t *testing.T) {
+	expectedReadOnlyRootFilesystem := false
+	expectedContainerSecCtx := &corev1.SecurityContext{
+		ReadOnlyRootFilesystem: &expectedReadOnlyRootFilesystem,
+	}
+
+	catsrc := &v1alpha1.CatalogSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "testns",
+		},
+	}
+
+	gotPod := Pod(catsrc, "hello", "busybox", "", map[string]string{}, map[string]string{}, int32(0), int32(0))
+	gotContainerSecCtx := gotPod.Spec.Containers[0].SecurityContext
+	require.Equal(t, expectedContainerSecCtx, gotContainerSecCtx)
 }

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
@@ -4,13 +4,14 @@ package reconciler
 import (
 	"strings"
 
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	controllerclient "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/controller-runtime/client"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorlister"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type nowFunc func() metav1.Time
@@ -102,6 +103,8 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, saName strin
 		pullPolicy = v1.PullAlways
 	}
 
+	readOnlyRootFilesystem := false
+
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: source.GetName() + "-",
@@ -142,6 +145,9 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, saName strin
 							v1.ResourceCPU:    resource.MustParse("10m"),
 							v1.ResourceMemory: resource.MustParse("50Mi"),
 						},
+					},
+					SecurityContext: &v1.SecurityContext{
+						ReadOnlyRootFilesystem: &readOnlyRootFilesystem,
 					},
 					ImagePullPolicy:          pullPolicy,
 					TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,


### PR DESCRIPTION
When running in environments that impose strict security (e.g.
OpenShift with unknown SCC defaults), it is important to be explicit
about the security context requirements of the pods we run to avoid
runtime failures due to missing permissions.

This commit explicitly sets `readOnlyRootFilesystem: false` because
the registry pods need to copy the registry pod's databile file to
a separate read-only copy.

Cherry-pick of operator-framework/operator-lifecycle-manager#2167

Signed-off-by: Joe Lanford <joe.lanford@gmail.com>