### PR TITLE
Bug 1945548: Filter secret names for registry pod's sa

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/grpc.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/grpc.go
@@ -98,6 +98,9 @@ func (s *grpcCatalogSourceDecorator) ServiceAccount() *corev1.ServiceAccount {
 	blockOwnerDeletion := true
 	isController := true
 	for _, secretName := range s.CatalogSource.Spec.Secrets {
+		if secretName == "" {
+			continue
+		}
 		secrets = append(secrets, corev1.LocalObjectReference{Name: secretName})
 	}
 	return &corev1.ServiceAccount{

--- a/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/grpc_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/grpc_test.go
@@ -33,7 +33,7 @@ func validGrpcCatalogSource(image, address string) *v1alpha1.CatalogSource {
 	}
 }
 
-func grpcCatalogSourceWithSecret(secretName string) *v1alpha1.CatalogSource {
+func grpcCatalogSourceWithSecret(secretNames []string) *v1alpha1.CatalogSource {
 	return &v1alpha1.CatalogSource{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "private-catalog",
@@ -45,7 +45,7 @@ func grpcCatalogSourceWithSecret(secretName string) *v1alpha1.CatalogSource {
 			Image:      "private-image",
 			Address:    "",
 			SourceType: v1alpha1.SourceTypeGrpc,
-			Secrets:    []string{secretName},
+			Secrets:    secretNames,
 		},
 	}
 }
@@ -60,6 +60,10 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 	now := func() metav1.Time { return metav1.Date(2018, time.January, 26, 20, 40, 0, 0, time.UTC) }
 	blockOwnerDeletion := true
 	isController := true
+
+	// We expect the empty string secret name should not be set
+	// on the service account
+	testSecrets := []string{"test-secret", ""}
 
 	type cluster struct {
 		k8sObjs []runtime.Object
@@ -225,7 +229,7 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 						},
 					},
 				},
-				catsrc: grpcCatalogSourceWithSecret("test-secret"),
+				catsrc: grpcCatalogSourceWithSecret(testSecrets),
 			},
 			out: out{
 				status: &v1alpha1.RegistryServiceStatus{

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/grpc.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/grpc.go
@@ -98,6 +98,9 @@ func (s *grpcCatalogSourceDecorator) ServiceAccount() *corev1.ServiceAccount {
 	blockOwnerDeletion := true
 	isController := true
 	for _, secretName := range s.CatalogSource.Spec.Secrets {
+		if secretName == "" {
+			continue
+		}
 		secrets = append(secrets, corev1.LocalObjectReference{Name: secretName})
 	}
 	return &corev1.ServiceAccount{


### PR DESCRIPTION
**Description of the change:**
During the registry server sync the image pull secrets from the catalogsource's spec.secrets are passed
unfiltered to the serviceaccount for the registry pod.
```YAML
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: ditto-index
  namespace: default
spec:
  sourceType: grpc
  image: quay.io/haseeb_tariq/index-image:ditto-index-0.1
  secrets:
    - ""
```
Passing an empty string in the secrets list breaks serverside apply for the registry pod which gets created without the `metadata.managedFields` when it has an empty element in the `imagePullSecrets` list:
```YAML
kind: Pod
apiVersion: v1
metadata:
  generateName: ditto-index-
  ...
  # No managedFields on resource
spec:
  imagePullSecrets:
    - {}
    - name: ditto-index-dockercfg-djmz7
...
```

This prevents the registry pod from being promoted via the SSA client when
there is an update to the index image:
```console
    couldn't ensure registry server - error ensuring updated catalog source pod:
    : detected imageID change: error during update: failed to create manager for
    existing fields: failed to convert new object (/v1, Kind=Pod) to smd typed:
    .spec.imagePullSecrets: element 0: associative list with keys has an element
    that omits key field "name" (and doesn't have default value)
```

To fix this, the image pull secrets list is filtered for empty strings
before being set on the serviceaccount.

**Motivation for the change:**
Fix for: https://bugzilla.redhat.com/show_bug.cgi?id=1945548

Similar to https://github.com/kubernetes-sigs/structured-merge-diff/issues/130

Upstream-commit: ee40fd9b8495ea23fc34daef74c689aad942fd2f
Upstream-repository: operator-lifecycle-manager
Upstream PR: https://github.com/operator-framework/operator-lifecycle-manager/pull/2165