### PR TITLE
Bug 1881522: packageserver CSV: add missing properties

### DIFF
--- a/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+++ b/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
@@ -12,6 +12,9 @@ metadata:
     olm.version: 0.17.0
     olm.clusteroperator.name: operator-lifecycle-manager-packageserver
 spec:
+  cleanup:
+    enabled: false
+  customresourcedefinitions: {}
   displayName: Package Server
   description: Represents an Operator package that is available from a given CatalogSource which will resolve to a ClusterServiceVersion.
   minKubeVersion: 1.11.0
@@ -85,6 +88,7 @@ spec:
               metadata:
                 annotations:
                   target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+                creationTimestamp: null
                 labels:
                   app: packageserver
               spec:
@@ -118,6 +122,7 @@ spec:
                     imagePullPolicy: IfNotPresent
                     ports:
                       - containerPort: 5443
+                        protocol: TCP
                     livenessProbe:
                       httpGet:
                         scheme: HTTPS


### PR DESCRIPTION
Some properties are unset and being set to defaults. CVO is however unware of it, so it attempts to remove the fields which are unset in the manifest files.

This PR should prevent CVO from hotlooping on this manifest. Verified that its no longer happening:
```
$ curl -sL https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws/1400074947912536064/artifacts/launch/pods/openshift-cluster-version_cluster-version-operator-7d4cc845f6-pwfcm_cluster-version-operator.log | grep -oP "Updating \K.+ due to diff" | cut -d' ' -f1 | sort | uniq -c
    448 Deployment
     14 PriorityClass
```