### PR TITLE
Bug 1969320: [release-4.7] packageserver CSV: add missing properties

### DIFF
--- a/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+++ b/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
@@ -9,6 +9,9 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
 spec:
+  cleanup:
+    enabled: false
+  customresourcedefinitions: {}
   displayName: Package Server
   description: Represents an Operator package that is available from a given CatalogSource which will resolve to a ClusterServiceVersion.
   minKubeVersion: 1.11.0
@@ -77,6 +80,7 @@ spec:
                 app: packageserver
             template:
               metadata:
+                creationTimestamp: null
                 labels:
                   app: packageserver
               spec:
@@ -110,6 +114,7 @@ spec:
                     imagePullPolicy: IfNotPresent
                     ports:
                       - containerPort: 5443
+                        protocol: TCP
                     livenessProbe:
                       httpGet:
                         scheme: HTTPS


### PR DESCRIPTION
Some properties are unset and being set to defaults. CVO is however unware of it, so it attempts to remove the fields which are unset in the manifest files.

This PR should prevent CVO from hotlooping on this manifest.

Cherry-pick of https://github.com/openshift/operator-framework-olm/pull/84 on release-4.7