### PR TITLE
manifests,staging: Add default values to the PackageServer CSV and regenerate manifests

### DIFF
--- a/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+++ b/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
@@ -12,9 +12,6 @@ metadata:
     olm.version: 0.17.0
     olm.clusteroperator.name: operator-lifecycle-manager-packageserver
 spec:
-  cleanup:
-    enabled: false
-  customresourcedefinitions: {}
   displayName: Package Server
   description: Represents an Operator package that is available from a given CatalogSource which will resolve to a ClusterServiceVersion.
   minKubeVersion: 1.11.0
@@ -24,6 +21,9 @@ spec:
       email: openshift-operators@redhat.com
   provider:
     name: Red Hat
+  cleanup:
+    enabled: false
+  customresourcedefinitions: {}
   links:
     - name: Package Server
       url: https://github.com/operator-framework/operator-lifecycle-manager/tree/master/pkg/package-server
@@ -88,9 +88,9 @@ spec:
               metadata:
                 annotations:
                   target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
-                creationTimestamp: null
                 labels:
                   app: packageserver
+                creationTimestamp: null
               spec:
                 serviceAccountName: olm-operator-serviceaccount
                 priorityClassName: "system-cluster-critical"

--- a/staging/operator-lifecycle-manager/deploy/chart/templates/_packageserver.clusterserviceversion.yaml
+++ b/staging/operator-lifecycle-manager/deploy/chart/templates/_packageserver.clusterserviceversion.yaml
@@ -27,6 +27,9 @@ spec:
     email: openshift-operators@redhat.com
   provider:
     name: Red Hat
+  cleanup:
+    enabled: false
+  customresourcedefinitions: {}
   links:
   - name: Package Server
     url: https://github.com/operator-framework/operator-lifecycle-manager/tree/master/pkg/package-server

--- a/staging/operator-lifecycle-manager/deploy/chart/templates/_packageserver.deployment-spec.yaml
+++ b/staging/operator-lifecycle-manager/deploy/chart/templates/_packageserver.deployment-spec.yaml
@@ -17,6 +17,7 @@ spec:
       {{- end }}
       labels:
         app: packageserver
+      creationTimestamp: null
     spec:
       serviceAccountName: olm-operator-serviceaccount
       {{- if and .Values.installType (eq .Values.installType "ocp") }}
@@ -53,6 +54,7 @@ spec:
         imagePullPolicy: {{ .Values.package.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.package.service.internalPort }}
+          protocol: TCP
         livenessProbe:
           httpGet:
             scheme: HTTPS


### PR DESCRIPTION
Update the staging/operator-lifecycle-manager helm charts for the
PackageServer CSV resource and add the defaults for various fields to
avoid the CVO hot looping when attempting to create this resource.

These changes were introduced directly into the root list of manifests
in https://github.com/openshift/operator-framework-olm/pull/84 and this
PR attempts to ensure those changes were also propagated to the helm
charts and regenerated to keep the manifest directory in sync.