### PR TITLE
Makefile,scripts: Introduce additional verification checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,12 +114,31 @@ vendor:
 	go mod vendor
 	go mod verify
 
-manifests: vendor ## Generate manifests
+.PHONY: manifests
+manifests: ## Generate manifests
 	./scripts/generate_crds_manifests.sh
 
-verify: vendor
+.PHONY: diff
+diff:
 	git diff --stat HEAD --ignore-submodules --exit-code
+
+verify-vendor: vendor
+	$(MAKE) diff
+
+verify-manifests: manifests
+	$(MAKE) diff
+
+verify-nested-vendor:
+	./scripts/check-staging-vendor.sh
+
 .PHONY: verify
+verify:
+	echo "Checking for unstaged root vendor changes"
+	$(MAKE) verify-vendor
+	echo "Checking whether the CVO manifests need to be generated"
+	$(MAKE) verify-manifests
+	echo "Checking for unsynced nested [go.mod,go.sum] files"
+	$(MAKE) verify-nested-vendor
 
 .PHONY: help
 help: ## Display this help.

--- a/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
+++ b/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
@@ -12,9 +12,6 @@ metadata:
     olm.version: 0.17.0
     olm.clusteroperator.name: operator-lifecycle-manager-packageserver
 spec:
-  cleanup:
-    enabled: false
-  customresourcedefinitions: {}
   displayName: Package Server
   description: Represents an Operator package that is available from a given CatalogSource which will resolve to a ClusterServiceVersion.
   minKubeVersion: 1.11.0
@@ -88,9 +85,9 @@ spec:
               metadata:
                 annotations:
                   target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
-                creationTimestamp: null
                 labels:
                   app: packageserver
+                creationTimestamp: null
               spec:
                 serviceAccountName: olm-operator-serviceaccount
                 priorityClassName: "system-cluster-critical"
@@ -156,3 +153,6 @@ spec:
         description: A PackageManifest is a resource generated from existing CatalogSources and their ConfigMaps
         deploymentName: packageserver
         containerPort: 5443
+  cleanup:
+    enabled: false
+  customresourcedefinitions: {}

--- a/scripts/check-staging-vendor.sh
+++ b/scripts/check-staging-vendor.sh
@@ -1,0 +1,26 @@
+#! /bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+ROOT_DIR=$(dirname "${BASH_SOURCE[0]}")/..
+STAGE_BASE_DIR=${ROOT_DIR}/staging
+STAGE_DIRS=( "api" "operator-lifecycle-manager" "operator-registry" )
+
+for repo in "${STAGE_DIRS[@]}"; do
+    repo_path="${STAGE_BASE_DIR}/$repo"
+
+    echo "Checking for unstaged go.mod,go.sum changes in ${repo_path}"
+    pushd "${repo_path}"
+
+    go mod tidy && go mod vendor && go mod verify
+
+    if ! git diff --quiet go.mod go.sum; then
+        echo "The staging/${repo} has unsynced [go.mod,go.sum] changes"
+        exit 1
+    fi
+
+    popd
+done
+


### PR DESCRIPTION
Introduce the scripts/check-staging-vendor.sh bash script that's
responsible for ensuring the API, operator-registry, and
operator-lifecycle-manager staging repositories have up-to-date go.sum
and go.mod files. This is namely helpful for validating that
cherrypicked commits have updated the nesting module dependencies when
pulling changes downstream.

Update the verify target in the root Makefile and add additional targets
responsible for ensuring that the CVO manifests (the root manifest
directory) have been properly rendered after changes made to the helm
chart(s), verifying the nested vendor contains an updated go.sum and
go.mod when pulling down changes.