### PR TITLE
Bug 1975432: Resolve InstallPlanStepAppliedWithWarnings alert after some time.

### DIFF
--- a/manifests/0000_90_olm_01-prometheus-rule.yaml
+++ b/manifests/0000_90_olm_01-prometheus-rule.yaml
@@ -33,7 +33,7 @@ spec:
     - name: olm.installplan.rules
       rules:
         - alert: InstallPlanStepAppliedWithWarnings
-          expr: sum(sum_over_time(installplan_warnings_total[5m])) > 0
+          expr: sum(increase(installplan_warnings_total[5m])) > 0
           labels:
             severity: warning
           annotations:

--- a/staging/operator-lifecycle-manager/deploy/chart/templates/0000_90_olm_01-prometheus-rule.yaml
+++ b/staging/operator-lifecycle-manager/deploy/chart/templates/0000_90_olm_01-prometheus-rule.yaml
@@ -30,7 +30,7 @@ spec:
   - name: olm.installplan.rules
     rules:
     - alert: InstallPlanStepAppliedWithWarnings
-      expr: sum(sum_over_time(installplan_warnings_total[5m])) > 0
+      expr: sum(increase(installplan_warnings_total[5m])) > 0
       labels:
         severity: warning
       annotations:


### PR DESCRIPTION
There is an error in the alert expression that causes the alert to
persist indefinitely. The intention of the alert was to fire for
several minutes to inform the administration of the warnings. The
appropriate response to the alert is to stop installing problematic
bundles going forward.
