### PR TITLE
Bug 1976326: fix configmap registry server liveness probe timeouts

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/configmap.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/configmap.go
@@ -100,7 +100,7 @@ func (s *configMapCatalogSourceDecorator) Service() *v1.Service {
 }
 
 func (s *configMapCatalogSourceDecorator) Pod(image string) *v1.Pod {
-	pod := Pod(s.CatalogSource, "configmap-registry-server", image, "", s.Labels(), s.Annotations(), 5, 2)
+	pod := Pod(s.CatalogSource, "configmap-registry-server", image, "", s.Labels(), s.Annotations(), 5, 5)
 	pod.Spec.ServiceAccountName = s.GetName() + ConfigMapServerPostfix
 	pod.Spec.Containers[0].Command = []string{"configmap-server", "-c", s.Spec.ConfigMap, "-n", s.GetNamespace()}
 	ownerutil.AddOwner(pod, s.CatalogSource, false, false)

--- a/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
@@ -139,6 +139,7 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, saName strin
 							},
 						},
 						InitialDelaySeconds: livenessDelay,
+						TimeoutSeconds:      5,
 					},
 					Resources: v1.ResourceRequirements{
 						Requests: v1.ResourceList{

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/configmap.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/configmap.go
@@ -100,7 +100,7 @@ func (s *configMapCatalogSourceDecorator) Service() *v1.Service {
 }
 
 func (s *configMapCatalogSourceDecorator) Pod(image string) *v1.Pod {
-	pod := Pod(s.CatalogSource, "configmap-registry-server", image, "", s.Labels(), s.Annotations(), 5, 2)
+	pod := Pod(s.CatalogSource, "configmap-registry-server", image, "", s.Labels(), s.Annotations(), 5, 5)
 	pod.Spec.ServiceAccountName = s.GetName() + ConfigMapServerPostfix
 	pod.Spec.Containers[0].Command = []string{"configmap-server", "-c", s.Spec.ConfigMap, "-n", s.GetNamespace()}
 	ownerutil.AddOwner(pod, s.CatalogSource, false, false)

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
@@ -139,6 +139,7 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, saName strin
 							},
 						},
 						InitialDelaySeconds: livenessDelay,
+						TimeoutSeconds:      5,
 					},
 					Resources: v1.ResourceRequirements{
 						Requests: v1.ResourceList{


### PR DESCRIPTION
Failing readiness/liveness probe fires prometheus alerts for
CatalogSources backed by configmap registry servers.

In #1378, the readiness probe initial delay and timeout were bumped
to account for node resource constraints during pod startup. This
PR bumps the liveness probe delay and timeout values too, to account
for scenarios where node resources continue to be overloaded causing
the liveness probe to fail temporarily.

Signed-off-by: Anik Bhattacharjee <anikbhattacharya93@gmail.com>

Upstream-repository: operator-lifecycle-manager
Upstream-commit: 33b957dee280ecfe18097723be1a0eb016c00410
