### PR TITLE
[release-4.8] Bug 1982294: Fix for resolution error on channels with deprecated inner entries.

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/cache.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/cache.go
@@ -400,9 +400,6 @@ type OperatorPredicate interface {
 func (s *CatalogSnapshot) Find(p ...OperatorPredicate) []*Operator {
 	s.m.RLock()
 	defer s.m.RUnlock()
-	if len(p) > 0 {
-		p = append(p, WithoutDeprecatedProperty())
-	}
 	return Filter(s.operators, p...)
 }
 
@@ -458,17 +455,6 @@ func WithPackage(pkg string) OperatorPredicate {
 			}
 		}
 		return o.Package() == pkg
-	})
-}
-
-func WithoutDeprecatedProperty() OperatorPredicate {
-	return OperatorPredicateFunc(func(o *Operator) bool {
-		for _, p := range o.bundle.GetProperties() {
-			if p.GetType() == opregistry.DeprecatedType {
-				return false
-			}
-		}
-		return true
 	})
 }
 

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache.go
@@ -400,9 +400,6 @@ type OperatorPredicate interface {
 func (s *CatalogSnapshot) Find(p ...OperatorPredicate) []*Operator {
 	s.m.RLock()
 	defer s.m.RUnlock()
-	if len(p) > 0 {
-		p = append(p, WithoutDeprecatedProperty())
-	}
 	return Filter(s.operators, p...)
 }
 
@@ -458,17 +455,6 @@ func WithPackage(pkg string) OperatorPredicate {
 			}
 		}
 		return o.Package() == pkg
-	})
-}
-
-func WithoutDeprecatedProperty() OperatorPredicate {
-	return OperatorPredicateFunc(func(o *Operator) bool {
-		for _, p := range o.bundle.GetProperties() {
-			if p.GetType() == opregistry.DeprecatedType {
-				return false
-			}
-		}
-		return true
 	})
 }
 


### PR DESCRIPTION
    Resolution would fail with an error in the presence of channels
    containing more than two entries with a deprecated inner
    entry (e.g. V1 -> V2 -> V3, with deprecated V2). This was due to
    special handling that filtered out deprecated bundles at the cache
    query layer. A channel's complete replaces-chain must be returned from
    cache queries in order to correctly determine the relative order
    between entries in the channel.

    Signed-off-by: Ben Luddy <bluddy@redhat.com>

    Upstream-repository: operator-lifecycle-manager
    Upstream-commit: 5afaa1d65ec6b451cf659a09956c6f3173dabf9c