### PR TITLE
BUG 1984538: Remove monitoring label from openshift-operators namespace

### DIFF
--- a/manifests/0000_50_olm_00-namespace.yaml
+++ b/manifests/0000_50_olm_00-namespace.yaml
@@ -24,4 +24,3 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
   labels:
     openshift.io/scc: "anyuid"
-    openshift.io/cluster-monitoring: "true"

--- a/scripts/generate_crds_manifests.sh
+++ b/scripts/generate_crds_manifests.sh
@@ -60,6 +60,7 @@ add_ibm_managed_cloud_annotations() {
 }
 
 ${YQ} merge --inplace -d'*' manifests/0000_50_olm_00-namespace.yaml scripts/namespaces.patch.yaml
+${YQ} merge --inplace -d'0' manifests/0000_50_olm_00-namespace.yaml scripts/monitoring-namespace.patch.yaml
 ${YQ} write --inplace -s scripts/olm-deployment.patch.yaml manifests/0000_50_olm_07-olm-operator.deployment.yaml
 ${YQ} write --inplace -s scripts/catalog-deployment.patch.yaml manifests/0000_50_olm_08-catalog-operator.deployment.yaml
 ${YQ} write --inplace -s scripts/packageserver-deployment.patch.yaml manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml

--- a/scripts/monitoring-namespace.patch.yaml
+++ b/scripts/monitoring-namespace.patch.yaml
@@ -1,0 +1,3 @@
+metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/scripts/namespaces.patch.yaml
+++ b/scripts/namespaces.patch.yaml
@@ -4,4 +4,3 @@ metadata:
     workload.openshift.io/allowed: "management"
   labels:
     openshift.io/scc: "anyuid"
-    openshift.io/cluster-monitoring: "true"


### PR DESCRIPTION
This commit updates the generate_crd_manifests.sh script
so it does not enable cluster monitoring on the openshift-operators
namespace.