### PR TITLE
Bug 1985697: Update the package-server-manager leader election configuration

### DIFF
--- a/cmd/package-server-manager/main.go
+++ b/cmd/package-server-manager/main.go
@@ -6,13 +6,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	configv1 "github.com/openshift/api/config/v1"
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -71,6 +67,9 @@ func run(cmd *cobra.Command, args []string) error {
 		LeaderElection:          !disableLeaderElection,
 		LeaderElectionNamespace: namespace,
 		LeaderElectionID:        leaderElectionConfigmapName,
+		RetryPeriod:             timeDurationPtr(defaultRetryPeriod),
+		RenewDeadline:           timeDurationPtr(defaultRenewDeadline),
+		LeaseDuration:           timeDurationPtr(defaultLeaseDuration),
 		HealthProbeBindAddress:  healthCheckAddr,
 		NewCache: cache.BuilderWithOptions(cache.Options{
 			SelectorsByObject: cache.SelectorsByObject{
@@ -113,13 +112,4 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
-}
-
-func setupScheme() *runtime.Scheme {
-	scheme := runtime.NewScheme()
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(configv1.Install(scheme))
-	utilruntime.Must(olmv1alpha1.AddToScheme(scheme))
-
-	return scheme
 }

--- a/cmd/package-server-manager/util.go
+++ b/cmd/package-server-manager/util.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+)
+
+const (
+	// Note: In order for SNO to GA, controllers need to handle ~60s of API server
+	// disruptions when attempting to get and sustain leader election:
+	// - https://github.com/openshift/library-go/pull/1104#discussion_r649313822
+	// - https://bugzilla.redhat.com/show_bug.cgi?id=1985697
+	defaultRetryPeriod   = 30 * time.Second
+	defaultRenewDeadline = 60 * time.Second
+	defaultLeaseDuration = 90 * time.Second
+)
+
+func timeDurationPtr(t time.Duration) *time.Duration {
+	return &t
+}
+
+func setupScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(configv1.Install(scheme))
+	utilruntime.Must(olmv1alpha1.AddToScheme(scheme))
+
+	return scheme
+}


### PR DESCRIPTION
Update the package-server-manager controller and update the leader
election intervals. This is in order to comply with the need for OCP
components to be able to withstand 60s of API server disruption on
SNO-enabled clusters.

For more information, see the following resources:
- https://github.com/openshift/library-go/pull/1104#discussion_r649313822
- https://bugzilla.redhat.com/show_bug.cgi?id=1985697

Alternative implementations include disabling leader election entirely
for SNO-enabled clusters. This implementation is centered around
dynamically querying for the Infrastructure/cluster singleton resource,
checking the HA/non-HA expectations being exposed, and setting leader
election properly. This implementation would still need to be careful
about how to handle transient errors and provide an escape hatch (e.g.
prefer enablement of leader election through a CLI flag, vs. the dynamic
value) that users can pass to the PSM deployment for failed upgrades.