### PR TITLE
Bug 1986685: Fix panic in opm alpha diff when accessing the --skip-tls flag

### DIFF
--- a/staging/operator-registry/cmd/opm/alpha/diff/cmd.go
+++ b/staging/operator-registry/cmd/opm/alpha/diff/cmd.go
@@ -93,7 +93,7 @@ docker push registry.org/my-catalog:headsonly-def456
 func (a *diff) addFunc(cmd *cobra.Command, args []string) error {
 	a.parseArgs(args)
 
-	skipTLS, err := cmd.PersistentFlags().GetBool("skip-tls")
+	skipTLS, err := cmd.Flags().GetBool("skip-tls")
 	if err != nil {
 		panic(err)
 	}

--- a/vendor/github.com/operator-framework/operator-registry/cmd/opm/alpha/diff/cmd.go
+++ b/vendor/github.com/operator-framework/operator-registry/cmd/opm/alpha/diff/cmd.go
@@ -93,7 +93,7 @@ docker push registry.org/my-catalog:headsonly-def456
 func (a *diff) addFunc(cmd *cobra.Command, args []string) error {
 	a.parseArgs(args)
 
-	skipTLS, err := cmd.PersistentFlags().GetBool("skip-tls")
+	skipTLS, err := cmd.Flags().GetBool("skip-tls")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Update the cmd/opm/alpha/diff command package and access the parent
skip-tls flag using cmd.Flags() instead of cmd.PersistentFlags().

Signed-off-by: timflannagan <timflannagan@gmail.com>

Upstream-repository: operator-registry
Upstream-commit: 2add45c7bdebafb3887666eea9d6d6ad8baedeaf