### PR TITLE
Bug 1987160: fix(diff): heads-only mode should not attempt to parse old refs

### DIFF
--- a/staging/operator-registry/cmd/opm/alpha/diff/cmd.go
+++ b/staging/operator-registry/cmd/opm/alpha/diff/cmd.go
@@ -153,6 +153,8 @@ func (a *diff) parseArgs(args []string) {
 	default:
 		panic("should never be here, CLI must enforce arg size")
 	}
-	a.oldRefs = strings.Split(old, ",")
+	if old != "" {
+		a.oldRefs = strings.Split(old, ",")
+	}
 	a.newRefs = strings.Split(new, ",")
 }

--- a/vendor/github.com/operator-framework/operator-registry/cmd/opm/alpha/diff/cmd.go
+++ b/vendor/github.com/operator-framework/operator-registry/cmd/opm/alpha/diff/cmd.go
@@ -153,6 +153,8 @@ func (a *diff) parseArgs(args []string) {
 	default:
 		panic("should never be here, CLI must enforce arg size")
 	}
-	a.oldRefs = strings.Split(old, ",")
+	if old != "" {
+		a.oldRefs = strings.Split(old, ",")
+	}
 	a.newRefs = strings.Split(new, ",")
 }


### PR DESCRIPTION
Signed-off-by: Joe Lanford <joe.lanford@gmail.com>

Upstream-repository: operator-registry
Upstream-commit: 70d0f510ba911d44917f80e364dcc92e95363e78