### PR TITLE
Bug 1991662: Catalog switcher

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/mikefarah/yq/v3 v3.0.0-20201202084205-8846255d1c37
 	github.com/onsi/ginkgo v1.16.4
 	github.com/openshift/api v0.0.0-20200331152225-585af27e34fd
-	github.com/operator-framework/api v0.10.2
+	github.com/operator-framework/api v0.10.3
 	github.com/operator-framework/operator-lifecycle-manager v0.0.0-00010101000000-000000000000
 	github.com/operator-framework/operator-registry v1.17.5
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -247,6 +247,8 @@ github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dhui/dktest v0.3.0/go.mod h1:cyzIUfGsBEbZ6BT7tnXqAShHSXCZhSNmFl70sZ7c1yc=
+github.com/distribution/distribution v2.7.1+incompatible h1:aGFx4EvJWKEh//lHPLwFhFgwFHKH06TzNVPamrMn04M=
+github.com/distribution/distribution v2.7.1+incompatible/go.mod h1:EgLm2NgWtdKgzF9NpMzUKgzmR7AMmb0VQi2B+ZzDRjc=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/cli v0.0.0-20200130152716-5d0cf8839492/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v20.10.5+incompatible h1:bjflayQbWg+xOkF2WPEAOi4Y7zWhR7ptoPhV/VqLVDE=

--- a/staging/operator-lifecycle-manager/deploy/chart/crds/0000_50_olm_00-catalogsources.crd.yaml
+++ b/staging/operator-lifecycle-manager/deploy/chart/crds/0000_50_olm_00-catalogsources.crd.yaml
@@ -106,6 +106,53 @@ spec:
             status:
               type: object
               properties:
+                conditions:
+                  description: Represents the state of a CatalogSource. Note that Message and Reason represent the original status information, which may be migrated to be conditions based in the future. Any new features introduced will use conditions.
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
                 configMapReference:
                   type: object
                   required:

--- a/staging/operator-lifecycle-manager/go.mod
+++ b/staging/operator-lifecycle-manager/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/bshuster-repo/logrus-logstash-hook v1.0.0 // indirect
 	github.com/coreos/go-semver v0.3.0
 	github.com/davecgh/go-spew v1.1.1
+	github.com/distribution/distribution v2.7.1+incompatible
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-bindata/go-bindata/v3 v3.1.3
@@ -24,7 +25,7 @@ require (
 	github.com/onsi/gomega v1.13.0
 	github.com/openshift/api v0.0.0-20200331152225-585af27e34fd
 	github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0
-	github.com/operator-framework/api v0.10.2
+	github.com/operator-framework/api v0.10.3
 	github.com/operator-framework/operator-registry v1.17.5
 	github.com/otiai10/copy v1.2.0
 	github.com/pkg/errors v0.9.1

--- a/staging/operator-lifecycle-manager/go.sum
+++ b/staging/operator-lifecycle-manager/go.sum
@@ -256,6 +256,8 @@ github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dhui/dktest v0.3.0/go.mod h1:cyzIUfGsBEbZ6BT7tnXqAShHSXCZhSNmFl70sZ7c1yc=
+github.com/distribution/distribution v2.7.1+incompatible h1:aGFx4EvJWKEh//lHPLwFhFgwFHKH06TzNVPamrMn04M=
+github.com/distribution/distribution v2.7.1+incompatible/go.mod h1:EgLm2NgWtdKgzF9NpMzUKgzmR7AMmb0VQi2B+ZzDRjc=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/cli v0.0.0-20200130152716-5d0cf8839492/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v20.10.5+incompatible h1:bjflayQbWg+xOkF2WPEAOi4Y7zWhR7ptoPhV/VqLVDE=
@@ -876,8 +878,8 @@ github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJ
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/operator-framework/api v0.7.1/go.mod h1:L7IvLd/ckxJEJg/t4oTTlnHKAJIP/p51AvEslW3wYdY=
-github.com/operator-framework/api v0.10.2 h1:fo8Bhyx1v46NdJIz2rUzfzNUpe1KDNPtVpHVpuxZnk0=
-github.com/operator-framework/api v0.10.2/go.mod h1:tV0BUNvly7szq28ZPBXhjp1Sqg5yHCOeX19ui9K4vjI=
+github.com/operator-framework/api v0.10.3 h1:C4DE7Rr3+ztUw3mKiFyfAiUJSVOty/cJmpwE90/kYro=
+github.com/operator-framework/api v0.10.3/go.mod h1:tV0BUNvly7szq28ZPBXhjp1Sqg5yHCOeX19ui9K4vjI=
 github.com/operator-framework/operator-registry v1.17.5 h1:LR8m1rFz5Gcyje8WK6iYt+gIhtzqo52zMRALdmTYHT0=
 github.com/operator-framework/operator-registry v1.17.5/go.mod h1:sRQIgDMZZdUcmHltzyCnM6RUoDF+WS8Arj1BQIARDS8=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
@@ -1619,6 +1621,7 @@ k8s.io/api v0.21.2/go.mod h1:Lv6UGJZ1rlMI1qusN8ruAp9PUBFyBwpEHAdG24vIsiU=
 k8s.io/api v0.22.0-rc.0 h1:LcnCE0nmb2CVpvmlbHkIzjZUHcVpSoNcn8mJkIo4FoQ=
 k8s.io/api v0.22.0-rc.0/go.mod h1:EUcKB6RvpW74HMRUSSNwpUzrIHBdGT1FeAvOV+txic0=
 k8s.io/apiextensions-apiserver v0.18.2/go.mod h1:q3faSnRGmYimiocj6cHQ1I3WpLqmDgJFlKL37fC4ZvY=
+k8s.io/apiextensions-apiserver v0.18.2/go.mod h1:q3faSnRGmYimiocj6cHQ1I3WpLqmDgJFlKL37fC4ZvY=
 k8s.io/apiextensions-apiserver v0.20.1/go.mod h1:ntnrZV+6a3dB504qwC5PN/Yg9PBiDNt1EVqbW2kORVk=
 k8s.io/apiextensions-apiserver v0.20.6/go.mod h1:qO8YMqeMmZH+lV21LUNzV41vfpoE9QVAJRA+MNqj0mo=
 k8s.io/apiextensions-apiserver v0.21.0/go.mod h1:gsQGNtGkc/YoDG9loKI0V+oLZM4ljRPjc/sql5tmvzc=
@@ -1637,6 +1640,7 @@ k8s.io/apimachinery v0.21.1/go.mod h1:jbreFvJo3ov9rj7eWT7+sYiRx+qZuCYXwWT1bcDswP
 k8s.io/apimachinery v0.21.2/go.mod h1:CdTY8fU/BlvAbJ2z/8kBwimGki5Zp8/fbVuLY8gJumM=
 k8s.io/apimachinery v0.22.0-rc.0 h1:boMGWXiuYJl4sAEMTEyWJtX4VLEPf0LZ0nUh+vNALIg=
 k8s.io/apimachinery v0.22.0-rc.0/go.mod h1:O3oNtNadZdeOMxHFVxOreoznohCpy0z6mocxbZr7oJ0=
+k8s.io/apiserver v0.18.2/go.mod h1:Xbh066NqrZO8cbsoenCwyDJ1OSi8Ag8I2lezeHxzwzw=
 k8s.io/apiserver v0.18.2/go.mod h1:Xbh066NqrZO8cbsoenCwyDJ1OSi8Ag8I2lezeHxzwzw=
 k8s.io/apiserver v0.20.1/go.mod h1:ro5QHeQkgMS7ZGpvf4tSMx6bBOgPfE+f52KwvXfScaU=
 k8s.io/apiserver v0.20.4/go.mod h1:Mc80thBKOyy7tbvFtB4kJv1kbdD0eIH8k8vianJcbFM=
@@ -1669,6 +1673,7 @@ k8s.io/code-generator v0.21.1/go.mod h1:hUlps5+9QaTrKx+jiM4rmq7YmH8wPOIko64uZCHD
 k8s.io/code-generator v0.21.2/go.mod h1:8mXJDCB7HcRo1xiEQstcguZkbxZaqeUOrO9SsicWs3U=
 k8s.io/code-generator v0.22.0-rc.0 h1:8ZPtFa3yhlV5mz8DpLZYe7FetNH4qtZGkrDnkl2G1MU=
 k8s.io/code-generator v0.22.0-rc.0/go.mod h1:eV77Y09IopzeXOJzndrDyCI88UBok2h6WxAlBwpxa+o=
+k8s.io/component-base v0.18.2/go.mod h1:kqLlMuhJNHQ9lz8Z7V5bxUUtjFZnrypArGl58gmDfUM=
 k8s.io/component-base v0.18.2/go.mod h1:kqLlMuhJNHQ9lz8Z7V5bxUUtjFZnrypArGl58gmDfUM=
 k8s.io/component-base v0.20.1/go.mod h1:guxkoJnNoh8LNrbtiQOlyp2Y2XFCZQmrcg2n/DeYNLk=
 k8s.io/component-base v0.20.4/go.mod h1:t4p9EdiagbVCJKrQ1RsA5/V4rFQNDfRlevJajlGwgjI=

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
@@ -54,6 +54,7 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/solver"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/catalogsource"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/clients"
 	controllerclient "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/controller-runtime/client"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/event"
@@ -577,9 +578,11 @@ func validateSourceType(logger *logrus.Entry, in *v1alpha1.CatalogSource) (out *
 		return
 	}
 
-	// The sourceType is valid, clear (all) status if there's existing invalid spec reason
+	// The sourceType is valid, clear all status (other than status conditions array) if there's existing invalid spec reason
 	if out.Status.Reason == v1alpha1.CatalogSourceSpecInvalidError {
-		out.Status = v1alpha1.CatalogSourceStatus{}
+		out.Status = v1alpha1.CatalogSourceStatus{
+			Conditions: out.Status.Conditions,
+		}
 	}
 	continueSync = true
 
@@ -785,7 +788,7 @@ func (o *Operator) syncCatalogSources(obj interface{}) (syncError error) {
 	catsrc, ok := obj.(*v1alpha1.CatalogSource)
 	if !ok {
 		o.logger.Debugf("wrong type: %#v", obj)
-		syncError = fmt.Errorf("casting CatalogSource failed")
+		syncError = nil
 		return
 	}
 
@@ -818,24 +821,6 @@ func (o *Operator) syncCatalogSources(obj interface{}) (syncError error) {
 		return reflect.DeepEqual(a, b)
 	}
 
-	updateStatusFunc := func(catsrc *v1alpha1.CatalogSource) error {
-		latest, err := o.client.OperatorsV1alpha1().CatalogSources(catsrc.GetNamespace()).Get(context.TODO(), catsrc.GetName(), metav1.GetOptions{})
-		if err != nil {
-			logger.Errorf("error getting catalogsource - %v", err)
-			return err
-		}
-
-		out := latest.DeepCopy()
-		out.Status = catsrc.Status
-
-		if _, err := o.client.OperatorsV1alpha1().CatalogSources(out.GetNamespace()).UpdateStatus(context.TODO(), out, metav1.UpdateOptions{}); err != nil {
-			logger.Errorf("error while setting catalogsource status condition - %v", err)
-			return err
-		}
-
-		return nil
-	}
-
 	chain := []CatalogSourceSyncFunc{
 		validateSourceType,
 		o.syncConfigMap,
@@ -856,7 +841,7 @@ func (o *Operator) syncCatalogSources(obj interface{}) (syncError error) {
 		return
 	}
 
-	updateErr := updateStatusFunc(out)
+	updateErr := catalogsource.UpdateStatus(logger, o.client, out)
 	if syncError == nil && updateErr != nil {
 		syncError = updateErr
 	}

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/catalogtemplate/operator.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/catalogtemplate/operator.go
@@ -1,0 +1,240 @@
+package catalogtemplate
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/distribution/distribution/reference"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/informers/externalversions"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/catalogsource"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorlister"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
+)
+
+const (
+	StatusTypeTemplatesHaveResolved = "TemplatesHaveResolved"
+	StatusTypeResolvedImage         = "ResolvedImage"
+
+	ReasonUnableToResolve      = "UnableToResolve"
+	ReasonAllTemplatesResolved = "AllTemplatesResolved"
+)
+
+type Operator struct {
+	queueinformer.Operator
+	logger                        *logrus.Logger                  // common logger
+	namespace                     string                          // operator namespace
+	client                        versioned.Interface             // client used for OLM CRs
+	dynamicClient                 dynamic.Interface               // client used to dynamically discover resources
+	discoveryClient               *discovery.DiscoveryClient      // queries the API server to discover resources
+	lister                        operatorlister.OperatorLister   // union of versioned informer listers
+	catalogSourceTemplateQueueSet *queueinformer.ResourceQueueSet // work queues for a catalog source update
+	resyncPeriod                  func() time.Duration            // period of time between resync
+}
+
+func NewOperator(ctx context.Context, kubeconfigPath string, logger *logrus.Logger, resync time.Duration, operatorNamespace string) (*Operator, error) {
+	resyncPeriod := queueinformer.ResyncWithJitter(resync, 0.2)
+
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new client for OLM types (CRs)
+	crClient, err := versioned.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new client for dynamic types
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new queueinformer-based operator.
+	opClient, err := operatorclient.NewClientFromRestConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	queueOperator, err := queueinformer.NewOperator(opClient.KubernetesInterface().Discovery(), queueinformer.WithOperatorLogger(logger))
+	if err != nil {
+		return nil, err
+	}
+
+	// DiscoveryClient queries the API server to discover resources
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create an OperatorLister
+	lister := operatorlister.NewLister()
+
+	op := &Operator{
+		Operator:                      queueOperator,
+		logger:                        logger,
+		namespace:                     operatorNamespace,
+		client:                        crClient,
+		dynamicClient:                 dynamicClient,
+		discoveryClient:               discoveryClient,
+		lister:                        lister,
+		catalogSourceTemplateQueueSet: queueinformer.NewEmptyResourceQueueSet(),
+		resyncPeriod:                  resyncPeriod,
+	}
+
+	// Wire OLM CR sharedIndexInformers
+	crInformerFactory := externalversions.NewSharedInformerFactoryWithOptions(op.client, op.resyncPeriod())
+
+	// Wire CatalogSources
+	catsrcInformer := crInformerFactory.Operators().V1alpha1().CatalogSources()
+	op.lister.OperatorsV1alpha1().RegisterCatalogSourceLister(metav1.NamespaceAll, catsrcInformer.Lister())
+	catalogTemplateSrcQueue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "catalogSourceTemplate")
+	op.catalogSourceTemplateQueueSet.Set(metav1.NamespaceAll, catalogTemplateSrcQueue)
+	catsrcQueueInformer, err := queueinformer.NewQueueInformer(
+		ctx,
+		queueinformer.WithLogger(op.logger),
+		queueinformer.WithQueue(catalogTemplateSrcQueue),
+		queueinformer.WithInformer(catsrcInformer.Informer()),
+		queueinformer.WithSyncer(queueinformer.LegacySyncHandler(op.syncCatalogSources).ToSyncer()),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := op.RegisterQueueInformer(catsrcQueueInformer); err != nil {
+		return nil, err
+	}
+
+	return op, nil
+}
+
+func (o *Operator) syncCatalogSources(obj interface{}) error {
+	// this is an opportunity to update the server version (regardless of any other actions for processing a catalog source)
+	o.updateServerVersion()
+
+	inputCatalogSource, ok := obj.(*v1alpha1.CatalogSource)
+	if !ok {
+		o.logger.Debugf("wrong type: %#v", obj)
+		return nil
+	}
+
+	outputCatalogSource := inputCatalogSource.DeepCopy()
+
+	logger := o.logger.WithFields(logrus.Fields{
+		"catSrcNamespace": outputCatalogSource.GetNamespace(),
+		"catSrcName":      outputCatalogSource.GetName(),
+		"id":              queueinformer.NewLoopID(),
+	})
+	logger.Info("syncing catalog source for annotation templates")
+
+	catalogImageTemplate := catalogsource.GetCatalogTemplateAnnotation(outputCatalogSource)
+	if catalogImageTemplate == "" {
+		logger.Debug("this catalog source is not participating in template replacement")
+		// make sure the conditions are removed
+		return catalogsource.RemoveStatusConditions(logger, o.client, outputCatalogSource, StatusTypeTemplatesHaveResolved, StatusTypeResolvedImage)
+	}
+
+	processedCatalogImageTemplate, unresolvedTemplates := catalogsource.ReplaceTemplates(catalogImageTemplate)
+
+	templatesAreResolved := len(unresolvedTemplates) == 0
+	// curly braces are not allowed in a real image reference (see https://github.com/distribution/distribution/blob/2461543d988979529609e8cb6fca9ca190dc48da/reference/reference.go#L4-L24)
+	// so we need to check for this... bottom line, we want to ensure that the result is valid
+	_, err := reference.Parse(processedCatalogImageTemplate)
+	invalidSyntax := err != nil
+
+	// make sure everything was resolved and valid
+	if templatesAreResolved && !invalidSyntax {
+		// all templates have been resolved
+
+		conditions := []metav1.Condition{
+			{
+				Type:    StatusTypeTemplatesHaveResolved,
+				Status:  metav1.ConditionTrue,
+				Reason:  ReasonAllTemplatesResolved,
+				Message: "catalog image reference was successfully resolved",
+			},
+			{
+				Type:    StatusTypeResolvedImage,
+				Status:  metav1.ConditionTrue,
+				Reason:  ReasonAllTemplatesResolved,
+				Message: processedCatalogImageTemplate,
+			},
+		}
+
+		// make sure that the processed image reference is actually different
+		if outputCatalogSource.Spec.Image != processedCatalogImageTemplate {
+
+			outputCatalogSource.Spec.Image = processedCatalogImageTemplate
+
+			if err := catalogsource.UpdateSpecAndStatusConditions(logger, o.client, outputCatalogSource, conditions...); err != nil {
+				return err
+			}
+			logger.Infof("The catalog image has been updated to %q", processedCatalogImageTemplate)
+		} else {
+			if err := catalogsource.UpdateStatusWithConditions(logger, o.client, outputCatalogSource, conditions...); err != nil {
+				return err
+			}
+			logger.Infof("The catalog image %q does not require an update because the image has not changed", processedCatalogImageTemplate)
+		}
+		return nil
+	}
+
+	// if we get here, at least one template was unresolved because:
+	// - either we explicitly discovered a template without a valid value (as listed in unresolvedTemplates)
+	// - or because a template curly brace was found (which means the user screwed up the syntax)
+	// so update status accordingly
+
+	// quote the values and use comma separator
+	quotedTemplates := fmt.Sprintf(`"%s"`, strings.Join(unresolvedTemplates, `", "`))
+
+	// init to sensible generic message
+	message := "cannot construct catalog image reference"
+	if invalidSyntax && !templatesAreResolved {
+		message = fmt.Sprintf("cannot construct catalog image reference, because variable(s) %s could not be resolved and one or more template(s) has improper syntax", quotedTemplates)
+	} else if invalidSyntax {
+		message = "cannot construct catalog image reference, because one or more template(s) has improper syntax"
+	} else if !templatesAreResolved {
+		message = fmt.Sprintf("cannot construct catalog image reference, because variable(s) %s could not be resolved", quotedTemplates)
+	}
+	err = catalogsource.UpdateStatusWithConditions(logger, o.client, outputCatalogSource,
+		metav1.Condition{
+			Type:    StatusTypeTemplatesHaveResolved,
+			Status:  metav1.ConditionFalse,
+			Reason:  ReasonUnableToResolve,
+			Message: message,
+		},
+		metav1.Condition{
+			Type:    StatusTypeResolvedImage,
+			Status:  metav1.ConditionFalse,
+			Reason:  ReasonUnableToResolve,
+			Message: processedCatalogImageTemplate,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	logger.Infof(message)
+
+	return nil
+}
+
+func (o *Operator) updateServerVersion() {
+	if serverVersion, err := o.discoveryClient.ServerVersion(); err != nil {
+		o.logger.WithError(err).Warn("unable to obtain server version from discovery client")
+	} else {
+		catalogsource.UpdateKubeVersion(serverVersion, o.logger)
+	}
+}

--- a/staging/operator-lifecycle-manager/pkg/lib/catalogsource/catalogsource_update.go
+++ b/staging/operator-lifecycle-manager/pkg/lib/catalogsource/catalogsource_update.go
@@ -1,0 +1,136 @@
+package catalogsource
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+)
+
+/* UpdateStatus can be used to update the status of the provided catalog source. Note that
+the caller is responsible for ensuring accurate status values in the catsrc argument (i.e.
+the status is used as-is).
+
+• logger: used to log errors only
+
+• client: used to fetch / update catalog source status
+
+• catsrc: the CatalogSource to use as a source for status updates. Callers are
+responsible for updating the catalog source status values as necessary.
+*/
+func UpdateStatus(logger *logrus.Entry, client versioned.Interface, catsrc *v1alpha1.CatalogSource) error {
+
+	// make the status update if possible
+	if _, err := client.OperatorsV1alpha1().CatalogSources(catsrc.GetNamespace()).UpdateStatus(context.TODO(), catsrc, metav1.UpdateOptions{}); err != nil {
+		logger.WithError(err).Error("UpdateStatus - error while setting CatalogSource status")
+		return err
+	}
+
+	return nil
+}
+
+/* UpdateStatusWithConditions can be used to update the status conditions for the provided catalog source.
+This function will make no changes to the other status fields (those fields will be used as-is).
+If the provided conditions do not result in any status condition changes, then the API server will not be updated.
+Note that the caller is responsible for ensuring accurate status values for all other fields.
+
+• logger: used to log errors only
+
+• client: used to fetch / update catalog source status
+
+• catsrc: the CatalogSource to use as a source for status updates.
+
+• conditions: condition values to be updated
+*/
+func UpdateStatusWithConditions(logger *logrus.Entry, client versioned.Interface, catsrc *v1alpha1.CatalogSource, conditions ...metav1.Condition) error {
+
+	// make a copy of the status before we make the change
+	statusBefore := catsrc.Status.DeepCopy()
+
+	// update the conditions
+	for _, condition := range conditions {
+		meta.SetStatusCondition(&catsrc.Status.Conditions, condition)
+	}
+
+	// don't bother updating if no changes were made
+	if reflect.DeepEqual(catsrc.Status.Conditions, statusBefore.Conditions) {
+		logger.Debug("UpdateStatusWithConditions - request to update status conditions did not result in any changes, so updates were not made")
+		return nil
+	}
+
+	// make the update if possible
+	if _, err := client.OperatorsV1alpha1().CatalogSources(catsrc.GetNamespace()).UpdateStatus(context.TODO(), catsrc, metav1.UpdateOptions{}); err != nil {
+		logger.WithError(err).Error("UpdateStatusWithConditions - unable to update CatalogSource image reference")
+		return err
+	}
+	return nil
+}
+
+/* UpdateSpecAndStatusConditions can be used to update the catalog source with the provided status conditions.
+This will update the spec and status portions of the catalog source. Calls to the API server will occur
+even if the provided conditions result in no changes.
+
+• logger: used to log errors only
+
+• client: used to fetch / update catalog source
+
+• catsrc: the CatalogSource to use as a source for image and status condition updates.
+
+• conditions: condition values to be updated
+*/
+func UpdateSpecAndStatusConditions(logger *logrus.Entry, client versioned.Interface, catsrc *v1alpha1.CatalogSource, conditions ...metav1.Condition) error {
+
+	// update the conditions
+	for _, condition := range conditions {
+		meta.SetStatusCondition(&catsrc.Status.Conditions, condition)
+	}
+
+	// make the update if possible
+	if _, err := client.OperatorsV1alpha1().CatalogSources(catsrc.GetNamespace()).Update(context.TODO(), catsrc, metav1.UpdateOptions{}); err != nil {
+		logger.WithError(err).Error("UpdateSpecAndStatusConditions - unable to update CatalogSource image reference")
+		return err
+	}
+	return nil
+}
+
+/* RemoveStatusConditions can be used to remove the status conditions for the provided catalog source.
+This function will make no changes to the other status fields (those fields will be used as-is).
+If the provided conditions do not result in any status condition changes, then the API server will not be updated.
+Note that the caller is responsible for ensuring accurate status values for all other fields.
+
+• logger: used to log errors only
+
+• client: used to fetch / update catalog source status
+
+• catsrc: the CatalogSource to use as a source for status condition removal.
+
+• conditionTypes: condition types to be removed
+*/
+func RemoveStatusConditions(logger *logrus.Entry, client versioned.Interface, catsrc *v1alpha1.CatalogSource, conditionTypes ...string) error {
+
+	// make a copy of the status before we make the change
+	statusBefore := catsrc.Status.DeepCopy()
+
+	// remove the conditions
+	for _, conditionType := range conditionTypes {
+		meta.RemoveStatusCondition(&catsrc.Status.Conditions, conditionType)
+	}
+
+	// don't bother updating if no changes were made
+	if reflect.DeepEqual(catsrc.Status.Conditions, statusBefore.Conditions) {
+		logger.Debug("RemoveStatusConditions - request to remove status conditions did not result in any changes, so updates were not made")
+		return nil
+	}
+
+	// make the update if possible
+	if _, err := client.OperatorsV1alpha1().CatalogSources(catsrc.GetNamespace()).UpdateStatus(context.TODO(), catsrc, metav1.UpdateOptions{}); err != nil {
+		logger.WithError(err).Error("RemoveStatusConditions - unable to update CatalogSource image reference")
+		return err
+	}
+	return nil
+}

--- a/staging/operator-lifecycle-manager/pkg/lib/catalogsource/image_template.go
+++ b/staging/operator-lifecycle-manager/pkg/lib/catalogsource/image_template.go
@@ -1,0 +1,184 @@
+package catalogsource
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/blang/semver/v4"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/version"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+)
+
+const (
+
+	// regex capture group names
+
+	// capGrpKubeMajorV is a capture group name for a kube major version
+	capGrpKubeMajorV = "kubemajorv"
+	// capGrpKubeMinorV is a capture group name for a kube minor version
+	capGrpKubeMinorV = "kubeminorv"
+	// capGrpKubePatchV is a capture group name for a kube patch version
+	capGrpKubePatchV = "kubepatchv"
+
+	// static templates
+
+	// TemplKubeMajorV is a template that represents the kube major version
+	TemplKubeMajorV = "{kube_major_version}"
+	// TemplKubeMinorV is a template that represents the kube minor version
+	TemplKubeMinorV = "{kube_minor_version}"
+	// TemplKubePatchV is a template that represents the kube patch version
+	TemplKubePatchV = "{kube_patch_version}"
+
+	// templateMissing represents a value that could not be obtained from the cluster
+	templateMissing = "missing"
+
+	// catalogImageTemplateAnnotation is OLM annotation. The annotation value that corresponds
+	// to this key is used as means to adjust a catalog source image, where templated
+	// values are replaced with values found in the cluster
+	CatalogImageTemplateAnnotation = "olm.catalogImageTemplate"
+)
+
+// templateNameToReplacementValuesMap is storage for templates and their resolved values
+// The values are initialized to variable "templateMissing"
+var templateNameToReplacementValuesMap = map[string]string{}
+
+// templateMutex is a package scoped mutex for synchronizing access to templateNameToReplacementValuesMap
+var templateMutex sync.RWMutex
+
+func init() {
+	// Handle known static templates
+	initializeIfNeeded(TemplKubeMajorV)
+	initializeIfNeeded(TemplKubeMinorV)
+	initializeIfNeeded(TemplKubePatchV)
+}
+
+// initializeIfNeeded sets the map to a "missing" value if its not already present
+func initializeIfNeeded(templateKey string) {
+	templateMutex.Lock()
+	defer templateMutex.Unlock()
+
+	// have we encountered this template already?
+	if _, ok := templateNameToReplacementValuesMap[templateKey]; !ok {
+		// this is a new template, so default to missing value
+		templateNameToReplacementValuesMap[templateKey] = templateMissing
+	}
+}
+
+// resetMaps is only useful for test cases
+func resetMaps() {
+	templateMutex.Lock()
+	templateNameToReplacementValuesMap = map[string]string{}
+	templateMutex.Unlock()
+
+	initializeIfNeeded(TemplKubeMajorV)
+	initializeIfNeeded(TemplKubeMinorV)
+	initializeIfNeeded(TemplKubePatchV)
+}
+
+type regexEntry struct {
+	captureGroup string
+	template     string
+}
+
+func (r *regexEntry) String() string {
+	return fmt.Sprintf(`(?P<%s>%s)`, r.captureGroup, r.template)
+}
+
+type regexEntries []regexEntry
+
+func (r regexEntries) String() string {
+	regexEntryAsString := []string{}
+	for _, regexEntry := range r {
+		regexEntryAsString = append(regexEntryAsString, regexEntry.String())
+	}
+	result := strings.Join(regexEntryAsString, "|")
+	return result
+}
+
+var regexList = regexEntries{
+	{capGrpKubeMajorV, TemplKubeMajorV},
+	{capGrpKubeMinorV, TemplKubeMinorV},
+	{capGrpKubePatchV, TemplKubePatchV},
+}
+
+var regexImageTemplates = regexp.MustCompile(regexList.String())
+
+// ReplaceTemplates takes a catalog image reference containing templates (i.e. catalogImageTemplate)
+// and attempts to replace the templates with actual values (if available).
+// The return value processedCatalogImageTemplate represents the catalog image reference after processing.
+// Callers of this function should check the unresolvedTemplates return value to determine
+// if all values were properly resolved (i.e. empty slice means all items were resolved, and presence
+// of a value in the slice means that the template was either not found in the cache or its value has not been
+// fetched yet). Providing an empty catalogImageTemplate results in empty processedCatalogImageTemplate and
+// zero length unresolvedTemplates
+func ReplaceTemplates(catalogImageTemplate string) (processedCatalogImageTemplate string, unresolvedTemplates []string) {
+	templateMutex.RLock()
+	defer templateMutex.RUnlock()
+
+	// init to empty slice
+	unresolvedTemplates = []string{}
+
+	// templateReplacer function determines the replacement value for the given template
+	var templateReplacer = func(template string) string {
+		replacement, ok := templateNameToReplacementValuesMap[template]
+		if ok {
+			// found a template, but check if the value is missing and keep record of
+			// what templates were unresolved
+			if replacement == templateMissing {
+				unresolvedTemplates = append(unresolvedTemplates, template)
+			}
+			return replacement
+		} else {
+			// probably should not get here, but in case there is no match,
+			// just return template unchanged, but keep record of
+			// what templates were unresolved
+			unresolvedTemplates = append(unresolvedTemplates, template)
+			return template
+		}
+	}
+
+	// if image is present, perform template substitution
+	if catalogImageTemplate != "" {
+		processedCatalogImageTemplate = regexImageTemplates.ReplaceAllStringFunc(catalogImageTemplate, templateReplacer)
+	}
+	return
+}
+
+// GetCatalogTemplateAnnotation is a helper function to extract the catalog image template annotation.
+// Returns empty string if value not set, otherwise returns annotation.
+func GetCatalogTemplateAnnotation(catalogSource *v1alpha1.CatalogSource) string {
+	if catalogSource == nil {
+		return ""
+	}
+	if catalogImageTemplate, ok := catalogSource.GetAnnotations()[CatalogImageTemplateAnnotation]; !ok {
+		return ""
+	} else {
+		return catalogImageTemplate
+	}
+}
+
+func UpdateKubeVersion(serverVersion *version.Info, logger *logrus.Logger) {
+	templateMutex.Lock()
+	defer templateMutex.Unlock()
+
+	if serverVersion == nil {
+		logger.Warn("no server version provided")
+		return
+	}
+
+	templateNameToReplacementValuesMap[TemplKubeMajorV] = serverVersion.Major
+	templateNameToReplacementValuesMap[TemplKubeMinorV] = serverVersion.Minor
+
+	// api server does not explicitly give patch value, so we have to resort to parsing the git version
+	serverGitVersion, err := semver.Parse(serverVersion.GitVersion)
+	if err != nil {
+		templateNameToReplacementValuesMap[TemplKubePatchV] = strconv.FormatUint(serverGitVersion.Patch, 10)
+	} else {
+		logger.WithError(err).Warn("unable to obtain kube server patch value")
+	}
+}

--- a/staging/operator-lifecycle-manager/pkg/lib/catalogsource/image_template_test.go
+++ b/staging/operator-lifecycle-manager/pkg/lib/catalogsource/image_template_test.go
@@ -1,0 +1,147 @@
+package catalogsource
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/version"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+)
+
+func TestImageTemplateRegex(t *testing.T) {
+	var table = []struct {
+		description string
+		imageName   string
+		isMatch     bool
+		foundItems  []string
+	}{
+		{
+			description: "no templates used",
+			imageName:   "foo",
+			isMatch:     false,
+		},
+		{
+			description: "one static template used",
+			imageName:   fmt.Sprintf("foo%s", TemplKubeMajorV),
+			isMatch:     true,
+			foundItems:  []string{TemplKubeMajorV},
+		},
+		{
+			description: "multiple templates used",
+			imageName:   fmt.Sprintf("%sfoo%s", TemplKubeMajorV, TemplKubeMinorV),
+			isMatch:     true,
+			foundItems:  []string{TemplKubeMajorV, TemplKubeMinorV},
+		},
+	}
+
+	for _, tt := range table {
+		t.Run(tt.description, func(t *testing.T) {
+
+			assert.Equal(t, tt.isMatch, regexImageTemplates.MatchString(tt.imageName), "Expected image name %q to find a match", tt.imageName)
+
+			actualFoundItems := regexImageTemplates.FindAllString(tt.imageName, -1)
+			assert.Equal(t, tt.foundItems, actualFoundItems, "Expected to find all strings within image name %q", tt.imageName)
+		})
+	}
+}
+
+// TestImageTemplateFlow simulates the image template process.
+func TestImageTemplateFlow(t *testing.T) {
+
+	defaultServerVersion := version.Info{
+		Major:      "1",
+		Minor:      "20",
+		GitVersion: "v1.20.0+bd9e442",
+	}
+
+	var table = []struct {
+		description                 string                 // description of test case
+		catsrc                      v1alpha1.CatalogSource // fake catalog source for testing
+		serverVersion               *version.Info          // simulated kube version information
+		expectedCatalogTemplate     string                 // expected results after calling api
+		expectedUnresolvedTemplates []string               // expected results after calling api
+	}{
+		{
+			description:                 "no image templates",
+			catsrc:                      v1alpha1.CatalogSource{},
+			serverVersion:               &defaultServerVersion,
+			expectedCatalogTemplate:     "",
+			expectedUnresolvedTemplates: []string{},
+		},
+		{
+			description: "kube image template",
+			catsrc: v1alpha1.CatalogSource{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						CatalogImageTemplateAnnotation: fmt.Sprintf("foo/v%s", TemplKubeMajorV),
+					},
+				},
+			},
+			serverVersion:               &defaultServerVersion,
+			expectedCatalogTemplate:     "foo/v1",
+			expectedUnresolvedTemplates: []string{},
+		},
+		{
+			description: "multiple kube image template",
+			catsrc: v1alpha1.CatalogSource{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						CatalogImageTemplateAnnotation: fmt.Sprintf("foo/v%s.%s", TemplKubeMajorV, TemplKubeMinorV),
+					},
+				},
+			},
+			serverVersion:               &defaultServerVersion,
+			expectedCatalogTemplate:     "foo/v1.20",
+			expectedUnresolvedTemplates: []string{},
+		},
+		{
+			description: "kube image template but no server version",
+			catsrc: v1alpha1.CatalogSource{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						CatalogImageTemplateAnnotation: fmt.Sprintf("foo/v%s", TemplKubeMajorV),
+					},
+				},
+			},
+			serverVersion:               nil,
+			expectedCatalogTemplate:     "foo/vmissing",
+			expectedUnresolvedTemplates: []string{"{kube_major_version}"},
+		},
+		{
+			description: "garbage image template",
+			catsrc: v1alpha1.CatalogSource{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						CatalogImageTemplateAnnotation: fmt.Sprintf("foo/v%s", "{foobar}"),
+					},
+				},
+			},
+			serverVersion:               &defaultServerVersion,
+			expectedCatalogTemplate:     "foo/v{foobar}",
+			expectedUnresolvedTemplates: []string{},
+		},
+	}
+
+	logger := logrus.New()
+
+	for _, tt := range table {
+		t.Run(tt.description, func(t *testing.T) {
+			// make sure test case is initialized to default to simulate real usage when operator starts up
+			resetMaps()
+
+			// simulate kube watch updates
+			UpdateKubeVersion(tt.serverVersion, logger)
+			// get the template
+			catalogImageTemplate := GetCatalogTemplateAnnotation(&tt.catsrc)
+			// perform the template replacement
+			processedCatalogTemplate, unresolveTemplates := ReplaceTemplates(catalogImageTemplate)
+			assert.Equal(t, tt.expectedCatalogTemplate, processedCatalogTemplate, "the processed template did not match expected value")
+			assert.Equal(t, tt.expectedUnresolvedTemplates, unresolveTemplates, "the unresolved templates list did not match expected values")
+
+		})
+	}
+}

--- a/staging/operator-lifecycle-manager/pkg/lib/catalogsource/image_template_test.go
+++ b/staging/operator-lifecycle-manager/pkg/lib/catalogsource/image_template_test.go
@@ -58,6 +58,12 @@ func TestImageTemplateFlow(t *testing.T) {
 		GitVersion: "v1.20.0+bd9e442",
 	}
 
+	serverVersionNonReleaseBuild := version.Info{
+		Major:      "1",
+		Minor:      "20+",
+		GitVersion: "v1.20.1+bd9e442",
+	}
+
 	var table = []struct {
 		description                 string                 // description of test case
 		catsrc                      v1alpha1.CatalogSource // fake catalog source for testing
@@ -122,6 +128,19 @@ func TestImageTemplateFlow(t *testing.T) {
 			},
 			serverVersion:               &defaultServerVersion,
 			expectedCatalogTemplate:     "foo/v{foobar}",
+			expectedUnresolvedTemplates: []string{},
+		},
+		{
+			description: "multiple kube image template with patch and nonrelease build version",
+			catsrc: v1alpha1.CatalogSource{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						CatalogImageTemplateAnnotation: fmt.Sprintf("foo/v%s.%s.%s", TemplKubeMajorV, TemplKubeMinorV, TemplKubePatchV),
+					},
+				},
+			},
+			serverVersion:               &serverVersionNonReleaseBuild,
+			expectedCatalogTemplate:     "foo/v1.20.1",
 			expectedUnresolvedTemplates: []string{},
 		},
 	}

--- a/staging/operator-lifecycle-manager/scripts/copy_crds.sh
+++ b/staging/operator-lifecycle-manager/scripts/copy_crds.sh
@@ -10,5 +10,5 @@ CRD_PATH="${SCRIPT_ROOT}/vendor/github.com/operator-framework/api/crds"
 rm "${SCRIPT_ROOT}"/deploy/chart/crds/*.yaml
 for f in "${CRD_PATH}"/*.yaml ; do
     echo "copying ${f}"
-    cp "${f}" "${SCRIPT_ROOT}/deploy/chart/crds/0000_50_olm_00-$(basename "$f" | sed 's/^.*_\([^.]\+\)\.yaml/\1.crd.yaml/')"
+    cp "${f}" "${SCRIPT_ROOT}/deploy/chart/crds/0000_50_olm_00-$(basename "$f" | sed 's/^.*_\([^.]\{1,\}\)\.yaml/\1.crd.yaml/')"
 done

--- a/staging/operator-lifecycle-manager/test/e2e/catalog_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/catalog_e2e_test.go
@@ -1068,8 +1068,11 @@ var _ = Describe("Catalog represents a store of bundles which OLM can use to ins
 
 		source.SetAnnotations(map[string]string{catalogsource.CatalogImageTemplateAnnotation: fmt.Sprintf("quay.io/olmtest/catsrc-update-test:%s.%s.%s", catalogsource.TemplKubeMajorV, catalogsource.TemplKubeMinorV, catalogsource.TemplKubePatchV)})
 
-		source, err = crc.OperatorsV1alpha1().CatalogSources(source.GetNamespace()).Update(context.TODO(), source, metav1.UpdateOptions{})
-		Expect(err).ShouldNot(HaveOccurred(), "error updating catalog source with template annotation")
+		// Update the catalog image
+		Eventually(func() error {
+			source, err = crc.OperatorsV1alpha1().CatalogSources(source.GetNamespace()).Update(context.TODO(), source, metav1.UpdateOptions{})
+			return err
+		}).Should(Succeed())
 
 		// wait for status condition to show up
 		Eventually(func() (bool, error) {

--- a/vendor/github.com/distribution/distribution/LICENSE
+++ b/vendor/github.com/distribution/distribution/LICENSE
@@ -1,0 +1,202 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/vendor/github.com/distribution/distribution/reference/helpers.go
+++ b/vendor/github.com/distribution/distribution/reference/helpers.go
@@ -1,0 +1,42 @@
+package reference
+
+import "path"
+
+// IsNameOnly returns true if reference only contains a repo name.
+func IsNameOnly(ref Named) bool {
+	if _, ok := ref.(NamedTagged); ok {
+		return false
+	}
+	if _, ok := ref.(Canonical); ok {
+		return false
+	}
+	return true
+}
+
+// FamiliarName returns the familiar name string
+// for the given named, familiarizing if needed.
+func FamiliarName(ref Named) string {
+	if nn, ok := ref.(normalizedNamed); ok {
+		return nn.Familiar().Name()
+	}
+	return ref.Name()
+}
+
+// FamiliarString returns the familiar string representation
+// for the given reference, familiarizing if needed.
+func FamiliarString(ref Reference) string {
+	if nn, ok := ref.(normalizedNamed); ok {
+		return nn.Familiar().String()
+	}
+	return ref.String()
+}
+
+// FamiliarMatch reports whether ref matches the specified pattern.
+// See https://godoc.org/path#Match for supported patterns.
+func FamiliarMatch(pattern string, ref Reference) (bool, error) {
+	matched, err := path.Match(pattern, FamiliarString(ref))
+	if namedRef, isNamed := ref.(Named); isNamed && !matched {
+		matched, _ = path.Match(pattern, FamiliarName(namedRef))
+	}
+	return matched, err
+}

--- a/vendor/github.com/distribution/distribution/reference/normalize.go
+++ b/vendor/github.com/distribution/distribution/reference/normalize.go
@@ -1,0 +1,170 @@
+package reference
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/docker/distribution/digestset"
+	"github.com/opencontainers/go-digest"
+)
+
+var (
+	legacyDefaultDomain = "index.docker.io"
+	defaultDomain       = "docker.io"
+	officialRepoName    = "library"
+	defaultTag          = "latest"
+)
+
+// normalizedNamed represents a name which has been
+// normalized and has a familiar form. A familiar name
+// is what is used in Docker UI. An example normalized
+// name is "docker.io/library/ubuntu" and corresponding
+// familiar name of "ubuntu".
+type normalizedNamed interface {
+	Named
+	Familiar() Named
+}
+
+// ParseNormalizedNamed parses a string into a named reference
+// transforming a familiar name from Docker UI to a fully
+// qualified reference. If the value may be an identifier
+// use ParseAnyReference.
+func ParseNormalizedNamed(s string) (Named, error) {
+	if ok := anchoredIdentifierRegexp.MatchString(s); ok {
+		return nil, fmt.Errorf("invalid repository name (%s), cannot specify 64-byte hexadecimal strings", s)
+	}
+	domain, remainder := splitDockerDomain(s)
+	var remoteName string
+	if tagSep := strings.IndexRune(remainder, ':'); tagSep > -1 {
+		remoteName = remainder[:tagSep]
+	} else {
+		remoteName = remainder
+	}
+	if strings.ToLower(remoteName) != remoteName {
+		return nil, errors.New("invalid reference format: repository name must be lowercase")
+	}
+
+	ref, err := Parse(domain + "/" + remainder)
+	if err != nil {
+		return nil, err
+	}
+	named, isNamed := ref.(Named)
+	if !isNamed {
+		return nil, fmt.Errorf("reference %s has no name", ref.String())
+	}
+	return named, nil
+}
+
+// splitDockerDomain splits a repository name to domain and remotename string.
+// If no valid domain is found, the default domain is used. Repository name
+// needs to be already validated before.
+func splitDockerDomain(name string) (domain, remainder string) {
+	i := strings.IndexRune(name, '/')
+	if i == -1 || (!strings.ContainsAny(name[:i], ".:") && name[:i] != "localhost") {
+		domain, remainder = defaultDomain, name
+	} else {
+		domain, remainder = name[:i], name[i+1:]
+	}
+	if domain == legacyDefaultDomain {
+		domain = defaultDomain
+	}
+	if domain == defaultDomain && !strings.ContainsRune(remainder, '/') {
+		remainder = officialRepoName + "/" + remainder
+	}
+	return
+}
+
+// familiarizeName returns a shortened version of the name familiar
+// to to the Docker UI. Familiar names have the default domain
+// "docker.io" and "library/" repository prefix removed.
+// For example, "docker.io/library/redis" will have the familiar
+// name "redis" and "docker.io/dmcgowan/myapp" will be "dmcgowan/myapp".
+// Returns a familiarized named only reference.
+func familiarizeName(named namedRepository) repository {
+	repo := repository{
+		domain: named.Domain(),
+		path:   named.Path(),
+	}
+
+	if repo.domain == defaultDomain {
+		repo.domain = ""
+		// Handle official repositories which have the pattern "library/<official repo name>"
+		if split := strings.Split(repo.path, "/"); len(split) == 2 && split[0] == officialRepoName {
+			repo.path = split[1]
+		}
+	}
+	return repo
+}
+
+func (r reference) Familiar() Named {
+	return reference{
+		namedRepository: familiarizeName(r.namedRepository),
+		tag:             r.tag,
+		digest:          r.digest,
+	}
+}
+
+func (r repository) Familiar() Named {
+	return familiarizeName(r)
+}
+
+func (t taggedReference) Familiar() Named {
+	return taggedReference{
+		namedRepository: familiarizeName(t.namedRepository),
+		tag:             t.tag,
+	}
+}
+
+func (c canonicalReference) Familiar() Named {
+	return canonicalReference{
+		namedRepository: familiarizeName(c.namedRepository),
+		digest:          c.digest,
+	}
+}
+
+// TagNameOnly adds the default tag "latest" to a reference if it only has
+// a repo name.
+func TagNameOnly(ref Named) Named {
+	if IsNameOnly(ref) {
+		namedTagged, err := WithTag(ref, defaultTag)
+		if err != nil {
+			// Default tag must be valid, to create a NamedTagged
+			// type with non-validated input the WithTag function
+			// should be used instead
+			panic(err)
+		}
+		return namedTagged
+	}
+	return ref
+}
+
+// ParseAnyReference parses a reference string as a possible identifier,
+// full digest, or familiar name.
+func ParseAnyReference(ref string) (Reference, error) {
+	if ok := anchoredIdentifierRegexp.MatchString(ref); ok {
+		return digestReference("sha256:" + ref), nil
+	}
+	if dgst, err := digest.Parse(ref); err == nil {
+		return digestReference(dgst), nil
+	}
+
+	return ParseNormalizedNamed(ref)
+}
+
+// ParseAnyReferenceWithSet parses a reference string as a possible short
+// identifier to be matched in a digest set, a full digest, or familiar name.
+func ParseAnyReferenceWithSet(ref string, ds *digestset.Set) (Reference, error) {
+	if ok := anchoredShortIdentifierRegexp.MatchString(ref); ok {
+		dgst, err := ds.Lookup(ref)
+		if err == nil {
+			return digestReference(dgst), nil
+		}
+	} else {
+		if dgst, err := digest.Parse(ref); err == nil {
+			return digestReference(dgst), nil
+		}
+	}
+
+	return ParseNormalizedNamed(ref)
+}

--- a/vendor/github.com/distribution/distribution/reference/reference.go
+++ b/vendor/github.com/distribution/distribution/reference/reference.go
@@ -1,0 +1,433 @@
+// Package reference provides a general type to represent any way of referencing images within the registry.
+// Its main purpose is to abstract tags and digests (content-addressable hash).
+//
+// Grammar
+//
+// 	reference                       := name [ ":" tag ] [ "@" digest ]
+//	name                            := [domain '/'] path-component ['/' path-component]*
+//	domain                          := domain-component ['.' domain-component]* [':' port-number]
+//	domain-component                := /([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])/
+//	port-number                     := /[0-9]+/
+//	path-component                  := alpha-numeric [separator alpha-numeric]*
+// 	alpha-numeric                   := /[a-z0-9]+/
+//	separator                       := /[_.]|__|[-]*/
+//
+//	tag                             := /[\w][\w.-]{0,127}/
+//
+//	digest                          := digest-algorithm ":" digest-hex
+//	digest-algorithm                := digest-algorithm-component [ digest-algorithm-separator digest-algorithm-component ]*
+//	digest-algorithm-separator      := /[+.-_]/
+//	digest-algorithm-component      := /[A-Za-z][A-Za-z0-9]*/
+//	digest-hex                      := /[0-9a-fA-F]{32,}/ ; At least 128 bit digest value
+//
+//	identifier                      := /[a-f0-9]{64}/
+//	short-identifier                := /[a-f0-9]{6,64}/
+package reference
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/opencontainers/go-digest"
+)
+
+const (
+	// NameTotalLengthMax is the maximum total number of characters in a repository name.
+	NameTotalLengthMax = 255
+)
+
+var (
+	// ErrReferenceInvalidFormat represents an error while trying to parse a string as a reference.
+	ErrReferenceInvalidFormat = errors.New("invalid reference format")
+
+	// ErrTagInvalidFormat represents an error while trying to parse a string as a tag.
+	ErrTagInvalidFormat = errors.New("invalid tag format")
+
+	// ErrDigestInvalidFormat represents an error while trying to parse a string as a tag.
+	ErrDigestInvalidFormat = errors.New("invalid digest format")
+
+	// ErrNameContainsUppercase is returned for invalid repository names that contain uppercase characters.
+	ErrNameContainsUppercase = errors.New("repository name must be lowercase")
+
+	// ErrNameEmpty is returned for empty, invalid repository names.
+	ErrNameEmpty = errors.New("repository name must have at least one component")
+
+	// ErrNameTooLong is returned when a repository name is longer than NameTotalLengthMax.
+	ErrNameTooLong = fmt.Errorf("repository name must not be more than %v characters", NameTotalLengthMax)
+
+	// ErrNameNotCanonical is returned when a name is not canonical.
+	ErrNameNotCanonical = errors.New("repository name must be canonical")
+)
+
+// Reference is an opaque object reference identifier that may include
+// modifiers such as a hostname, name, tag, and digest.
+type Reference interface {
+	// String returns the full reference
+	String() string
+}
+
+// Field provides a wrapper type for resolving correct reference types when
+// working with encoding.
+type Field struct {
+	reference Reference
+}
+
+// AsField wraps a reference in a Field for encoding.
+func AsField(reference Reference) Field {
+	return Field{reference}
+}
+
+// Reference unwraps the reference type from the field to
+// return the Reference object. This object should be
+// of the appropriate type to further check for different
+// reference types.
+func (f Field) Reference() Reference {
+	return f.reference
+}
+
+// MarshalText serializes the field to byte text which
+// is the string of the reference.
+func (f Field) MarshalText() (p []byte, err error) {
+	return []byte(f.reference.String()), nil
+}
+
+// UnmarshalText parses text bytes by invoking the
+// reference parser to ensure the appropriately
+// typed reference object is wrapped by field.
+func (f *Field) UnmarshalText(p []byte) error {
+	r, err := Parse(string(p))
+	if err != nil {
+		return err
+	}
+
+	f.reference = r
+	return nil
+}
+
+// Named is an object with a full name
+type Named interface {
+	Reference
+	Name() string
+}
+
+// Tagged is an object which has a tag
+type Tagged interface {
+	Reference
+	Tag() string
+}
+
+// NamedTagged is an object including a name and tag.
+type NamedTagged interface {
+	Named
+	Tag() string
+}
+
+// Digested is an object which has a digest
+// in which it can be referenced by
+type Digested interface {
+	Reference
+	Digest() digest.Digest
+}
+
+// Canonical reference is an object with a fully unique
+// name including a name with domain and digest
+type Canonical interface {
+	Named
+	Digest() digest.Digest
+}
+
+// namedRepository is a reference to a repository with a name.
+// A namedRepository has both domain and path components.
+type namedRepository interface {
+	Named
+	Domain() string
+	Path() string
+}
+
+// Domain returns the domain part of the Named reference
+func Domain(named Named) string {
+	if r, ok := named.(namedRepository); ok {
+		return r.Domain()
+	}
+	domain, _ := splitDomain(named.Name())
+	return domain
+}
+
+// Path returns the name without the domain part of the Named reference
+func Path(named Named) (name string) {
+	if r, ok := named.(namedRepository); ok {
+		return r.Path()
+	}
+	_, path := splitDomain(named.Name())
+	return path
+}
+
+func splitDomain(name string) (string, string) {
+	match := anchoredNameRegexp.FindStringSubmatch(name)
+	if len(match) != 3 {
+		return "", name
+	}
+	return match[1], match[2]
+}
+
+// SplitHostname splits a named reference into a
+// hostname and name string. If no valid hostname is
+// found, the hostname is empty and the full value
+// is returned as name
+// DEPRECATED: Use Domain or Path
+func SplitHostname(named Named) (string, string) {
+	if r, ok := named.(namedRepository); ok {
+		return r.Domain(), r.Path()
+	}
+	return splitDomain(named.Name())
+}
+
+// Parse parses s and returns a syntactically valid Reference.
+// If an error was encountered it is returned, along with a nil Reference.
+// NOTE: Parse will not handle short digests.
+func Parse(s string) (Reference, error) {
+	matches := ReferenceRegexp.FindStringSubmatch(s)
+	if matches == nil {
+		if s == "" {
+			return nil, ErrNameEmpty
+		}
+		if ReferenceRegexp.FindStringSubmatch(strings.ToLower(s)) != nil {
+			return nil, ErrNameContainsUppercase
+		}
+		return nil, ErrReferenceInvalidFormat
+	}
+
+	if len(matches[1]) > NameTotalLengthMax {
+		return nil, ErrNameTooLong
+	}
+
+	var repo repository
+
+	nameMatch := anchoredNameRegexp.FindStringSubmatch(matches[1])
+	if nameMatch != nil && len(nameMatch) == 3 {
+		repo.domain = nameMatch[1]
+		repo.path = nameMatch[2]
+	} else {
+		repo.domain = ""
+		repo.path = matches[1]
+	}
+
+	ref := reference{
+		namedRepository: repo,
+		tag:             matches[2],
+	}
+	if matches[3] != "" {
+		var err error
+		ref.digest, err = digest.Parse(matches[3])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	r := getBestReferenceType(ref)
+	if r == nil {
+		return nil, ErrNameEmpty
+	}
+
+	return r, nil
+}
+
+// ParseNamed parses s and returns a syntactically valid reference implementing
+// the Named interface. The reference must have a name and be in the canonical
+// form, otherwise an error is returned.
+// If an error was encountered it is returned, along with a nil Reference.
+// NOTE: ParseNamed will not handle short digests.
+func ParseNamed(s string) (Named, error) {
+	named, err := ParseNormalizedNamed(s)
+	if err != nil {
+		return nil, err
+	}
+	if named.String() != s {
+		return nil, ErrNameNotCanonical
+	}
+	return named, nil
+}
+
+// WithName returns a named object representing the given string. If the input
+// is invalid ErrReferenceInvalidFormat will be returned.
+func WithName(name string) (Named, error) {
+	if len(name) > NameTotalLengthMax {
+		return nil, ErrNameTooLong
+	}
+
+	match := anchoredNameRegexp.FindStringSubmatch(name)
+	if match == nil || len(match) != 3 {
+		return nil, ErrReferenceInvalidFormat
+	}
+	return repository{
+		domain: match[1],
+		path:   match[2],
+	}, nil
+}
+
+// WithTag combines the name from "name" and the tag from "tag" to form a
+// reference incorporating both the name and the tag.
+func WithTag(name Named, tag string) (NamedTagged, error) {
+	if !anchoredTagRegexp.MatchString(tag) {
+		return nil, ErrTagInvalidFormat
+	}
+	var repo repository
+	if r, ok := name.(namedRepository); ok {
+		repo.domain = r.Domain()
+		repo.path = r.Path()
+	} else {
+		repo.path = name.Name()
+	}
+	if canonical, ok := name.(Canonical); ok {
+		return reference{
+			namedRepository: repo,
+			tag:             tag,
+			digest:          canonical.Digest(),
+		}, nil
+	}
+	return taggedReference{
+		namedRepository: repo,
+		tag:             tag,
+	}, nil
+}
+
+// WithDigest combines the name from "name" and the digest from "digest" to form
+// a reference incorporating both the name and the digest.
+func WithDigest(name Named, digest digest.Digest) (Canonical, error) {
+	if !anchoredDigestRegexp.MatchString(digest.String()) {
+		return nil, ErrDigestInvalidFormat
+	}
+	var repo repository
+	if r, ok := name.(namedRepository); ok {
+		repo.domain = r.Domain()
+		repo.path = r.Path()
+	} else {
+		repo.path = name.Name()
+	}
+	if tagged, ok := name.(Tagged); ok {
+		return reference{
+			namedRepository: repo,
+			tag:             tagged.Tag(),
+			digest:          digest,
+		}, nil
+	}
+	return canonicalReference{
+		namedRepository: repo,
+		digest:          digest,
+	}, nil
+}
+
+// TrimNamed removes any tag or digest from the named reference.
+func TrimNamed(ref Named) Named {
+	domain, path := SplitHostname(ref)
+	return repository{
+		domain: domain,
+		path:   path,
+	}
+}
+
+func getBestReferenceType(ref reference) Reference {
+	if ref.Name() == "" {
+		// Allow digest only references
+		if ref.digest != "" {
+			return digestReference(ref.digest)
+		}
+		return nil
+	}
+	if ref.tag == "" {
+		if ref.digest != "" {
+			return canonicalReference{
+				namedRepository: ref.namedRepository,
+				digest:          ref.digest,
+			}
+		}
+		return ref.namedRepository
+	}
+	if ref.digest == "" {
+		return taggedReference{
+			namedRepository: ref.namedRepository,
+			tag:             ref.tag,
+		}
+	}
+
+	return ref
+}
+
+type reference struct {
+	namedRepository
+	tag    string
+	digest digest.Digest
+}
+
+func (r reference) String() string {
+	return r.Name() + ":" + r.tag + "@" + r.digest.String()
+}
+
+func (r reference) Tag() string {
+	return r.tag
+}
+
+func (r reference) Digest() digest.Digest {
+	return r.digest
+}
+
+type repository struct {
+	domain string
+	path   string
+}
+
+func (r repository) String() string {
+	return r.Name()
+}
+
+func (r repository) Name() string {
+	if r.domain == "" {
+		return r.path
+	}
+	return r.domain + "/" + r.path
+}
+
+func (r repository) Domain() string {
+	return r.domain
+}
+
+func (r repository) Path() string {
+	return r.path
+}
+
+type digestReference digest.Digest
+
+func (d digestReference) String() string {
+	return digest.Digest(d).String()
+}
+
+func (d digestReference) Digest() digest.Digest {
+	return digest.Digest(d)
+}
+
+type taggedReference struct {
+	namedRepository
+	tag string
+}
+
+func (t taggedReference) String() string {
+	return t.Name() + ":" + t.tag
+}
+
+func (t taggedReference) Tag() string {
+	return t.tag
+}
+
+type canonicalReference struct {
+	namedRepository
+	digest digest.Digest
+}
+
+func (c canonicalReference) String() string {
+	return c.Name() + "@" + c.digest.String()
+}
+
+func (c canonicalReference) Digest() digest.Digest {
+	return c.digest
+}

--- a/vendor/github.com/distribution/distribution/reference/regexp.go
+++ b/vendor/github.com/distribution/distribution/reference/regexp.go
@@ -1,0 +1,143 @@
+package reference
+
+import "regexp"
+
+var (
+	// alphaNumericRegexp defines the alpha numeric atom, typically a
+	// component of names. This only allows lower case characters and digits.
+	alphaNumericRegexp = match(`[a-z0-9]+`)
+
+	// separatorRegexp defines the separators allowed to be embedded in name
+	// components. This allow one period, one or two underscore and multiple
+	// dashes.
+	separatorRegexp = match(`(?:[._]|__|[-]*)`)
+
+	// nameComponentRegexp restricts registry path component names to start
+	// with at least one letter or number, with following parts able to be
+	// separated by one period, one or two underscore and multiple dashes.
+	nameComponentRegexp = expression(
+		alphaNumericRegexp,
+		optional(repeated(separatorRegexp, alphaNumericRegexp)))
+
+	// domainComponentRegexp restricts the registry domain component of a
+	// repository name to start with a component as defined by DomainRegexp
+	// and followed by an optional port.
+	domainComponentRegexp = match(`(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])`)
+
+	// DomainRegexp defines the structure of potential domain components
+	// that may be part of image names. This is purposely a subset of what is
+	// allowed by DNS to ensure backwards compatibility with Docker image
+	// names.
+	DomainRegexp = expression(
+		domainComponentRegexp,
+		optional(repeated(literal(`.`), domainComponentRegexp)),
+		optional(literal(`:`), match(`[0-9]+`)))
+
+	// TagRegexp matches valid tag names. From docker/docker:graph/tags.go.
+	TagRegexp = match(`[\w][\w.-]{0,127}`)
+
+	// anchoredTagRegexp matches valid tag names, anchored at the start and
+	// end of the matched string.
+	anchoredTagRegexp = anchored(TagRegexp)
+
+	// DigestRegexp matches valid digests.
+	DigestRegexp = match(`[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,}`)
+
+	// anchoredDigestRegexp matches valid digests, anchored at the start and
+	// end of the matched string.
+	anchoredDigestRegexp = anchored(DigestRegexp)
+
+	// NameRegexp is the format for the name component of references. The
+	// regexp has capturing groups for the domain and name part omitting
+	// the separating forward slash from either.
+	NameRegexp = expression(
+		optional(DomainRegexp, literal(`/`)),
+		nameComponentRegexp,
+		optional(repeated(literal(`/`), nameComponentRegexp)))
+
+	// anchoredNameRegexp is used to parse a name value, capturing the
+	// domain and trailing components.
+	anchoredNameRegexp = anchored(
+		optional(capture(DomainRegexp), literal(`/`)),
+		capture(nameComponentRegexp,
+			optional(repeated(literal(`/`), nameComponentRegexp))))
+
+	// ReferenceRegexp is the full supported format of a reference. The regexp
+	// is anchored and has capturing groups for name, tag, and digest
+	// components.
+	ReferenceRegexp = anchored(capture(NameRegexp),
+		optional(literal(":"), capture(TagRegexp)),
+		optional(literal("@"), capture(DigestRegexp)))
+
+	// IdentifierRegexp is the format for string identifier used as a
+	// content addressable identifier using sha256. These identifiers
+	// are like digests without the algorithm, since sha256 is used.
+	IdentifierRegexp = match(`([a-f0-9]{64})`)
+
+	// ShortIdentifierRegexp is the format used to represent a prefix
+	// of an identifier. A prefix may be used to match a sha256 identifier
+	// within a list of trusted identifiers.
+	ShortIdentifierRegexp = match(`([a-f0-9]{6,64})`)
+
+	// anchoredIdentifierRegexp is used to check or match an
+	// identifier value, anchored at start and end of string.
+	anchoredIdentifierRegexp = anchored(IdentifierRegexp)
+
+	// anchoredShortIdentifierRegexp is used to check if a value
+	// is a possible identifier prefix, anchored at start and end
+	// of string.
+	anchoredShortIdentifierRegexp = anchored(ShortIdentifierRegexp)
+)
+
+// match compiles the string to a regular expression.
+var match = regexp.MustCompile
+
+// literal compiles s into a literal regular expression, escaping any regexp
+// reserved characters.
+func literal(s string) *regexp.Regexp {
+	re := match(regexp.QuoteMeta(s))
+
+	if _, complete := re.LiteralPrefix(); !complete {
+		panic("must be a literal")
+	}
+
+	return re
+}
+
+// expression defines a full expression, where each regular expression must
+// follow the previous.
+func expression(res ...*regexp.Regexp) *regexp.Regexp {
+	var s string
+	for _, re := range res {
+		s += re.String()
+	}
+
+	return match(s)
+}
+
+// optional wraps the expression in a non-capturing group and makes the
+// production optional.
+func optional(res ...*regexp.Regexp) *regexp.Regexp {
+	return match(group(expression(res...)).String() + `?`)
+}
+
+// repeated wraps the regexp in a non-capturing group to get one or more
+// matches.
+func repeated(res ...*regexp.Regexp) *regexp.Regexp {
+	return match(group(expression(res...)).String() + `+`)
+}
+
+// group wraps the regexp in a non-capturing group.
+func group(res ...*regexp.Regexp) *regexp.Regexp {
+	return match(`(?:` + expression(res...).String() + `)`)
+}
+
+// capture wraps the expression in a capturing group.
+func capture(res ...*regexp.Regexp) *regexp.Regexp {
+	return match(`(` + expression(res...).String() + `)`)
+}
+
+// anchored anchors the regular expression by adding start and end delimiters.
+func anchored(res ...*regexp.Regexp) *regexp.Regexp {
+	return match(`^` + expression(res...).String() + `$`)
+}

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
@@ -54,6 +54,7 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/solver"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/catalogsource"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/clients"
 	controllerclient "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/controller-runtime/client"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/event"
@@ -577,9 +578,11 @@ func validateSourceType(logger *logrus.Entry, in *v1alpha1.CatalogSource) (out *
 		return
 	}
 
-	// The sourceType is valid, clear (all) status if there's existing invalid spec reason
+	// The sourceType is valid, clear all status (other than status conditions array) if there's existing invalid spec reason
 	if out.Status.Reason == v1alpha1.CatalogSourceSpecInvalidError {
-		out.Status = v1alpha1.CatalogSourceStatus{}
+		out.Status = v1alpha1.CatalogSourceStatus{
+			Conditions: out.Status.Conditions,
+		}
 	}
 	continueSync = true
 
@@ -785,7 +788,7 @@ func (o *Operator) syncCatalogSources(obj interface{}) (syncError error) {
 	catsrc, ok := obj.(*v1alpha1.CatalogSource)
 	if !ok {
 		o.logger.Debugf("wrong type: %#v", obj)
-		syncError = fmt.Errorf("casting CatalogSource failed")
+		syncError = nil
 		return
 	}
 
@@ -818,24 +821,6 @@ func (o *Operator) syncCatalogSources(obj interface{}) (syncError error) {
 		return reflect.DeepEqual(a, b)
 	}
 
-	updateStatusFunc := func(catsrc *v1alpha1.CatalogSource) error {
-		latest, err := o.client.OperatorsV1alpha1().CatalogSources(catsrc.GetNamespace()).Get(context.TODO(), catsrc.GetName(), metav1.GetOptions{})
-		if err != nil {
-			logger.Errorf("error getting catalogsource - %v", err)
-			return err
-		}
-
-		out := latest.DeepCopy()
-		out.Status = catsrc.Status
-
-		if _, err := o.client.OperatorsV1alpha1().CatalogSources(out.GetNamespace()).UpdateStatus(context.TODO(), out, metav1.UpdateOptions{}); err != nil {
-			logger.Errorf("error while setting catalogsource status condition - %v", err)
-			return err
-		}
-
-		return nil
-	}
-
 	chain := []CatalogSourceSyncFunc{
 		validateSourceType,
 		o.syncConfigMap,
@@ -856,7 +841,7 @@ func (o *Operator) syncCatalogSources(obj interface{}) (syncError error) {
 		return
 	}
 
-	updateErr := updateStatusFunc(out)
+	updateErr := catalogsource.UpdateStatus(logger, o.client, out)
 	if syncError == nil && updateErr != nil {
 		syncError = updateErr
 	}

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalogtemplate/operator.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalogtemplate/operator.go
@@ -1,0 +1,240 @@
+package catalogtemplate
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/distribution/distribution/reference"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/informers/externalversions"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/catalogsource"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorlister"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
+)
+
+const (
+	StatusTypeTemplatesHaveResolved = "TemplatesHaveResolved"
+	StatusTypeResolvedImage         = "ResolvedImage"
+
+	ReasonUnableToResolve      = "UnableToResolve"
+	ReasonAllTemplatesResolved = "AllTemplatesResolved"
+)
+
+type Operator struct {
+	queueinformer.Operator
+	logger                        *logrus.Logger                  // common logger
+	namespace                     string                          // operator namespace
+	client                        versioned.Interface             // client used for OLM CRs
+	dynamicClient                 dynamic.Interface               // client used to dynamically discover resources
+	discoveryClient               *discovery.DiscoveryClient      // queries the API server to discover resources
+	lister                        operatorlister.OperatorLister   // union of versioned informer listers
+	catalogSourceTemplateQueueSet *queueinformer.ResourceQueueSet // work queues for a catalog source update
+	resyncPeriod                  func() time.Duration            // period of time between resync
+}
+
+func NewOperator(ctx context.Context, kubeconfigPath string, logger *logrus.Logger, resync time.Duration, operatorNamespace string) (*Operator, error) {
+	resyncPeriod := queueinformer.ResyncWithJitter(resync, 0.2)
+
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new client for OLM types (CRs)
+	crClient, err := versioned.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new client for dynamic types
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new queueinformer-based operator.
+	opClient, err := operatorclient.NewClientFromRestConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	queueOperator, err := queueinformer.NewOperator(opClient.KubernetesInterface().Discovery(), queueinformer.WithOperatorLogger(logger))
+	if err != nil {
+		return nil, err
+	}
+
+	// DiscoveryClient queries the API server to discover resources
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create an OperatorLister
+	lister := operatorlister.NewLister()
+
+	op := &Operator{
+		Operator:                      queueOperator,
+		logger:                        logger,
+		namespace:                     operatorNamespace,
+		client:                        crClient,
+		dynamicClient:                 dynamicClient,
+		discoveryClient:               discoveryClient,
+		lister:                        lister,
+		catalogSourceTemplateQueueSet: queueinformer.NewEmptyResourceQueueSet(),
+		resyncPeriod:                  resyncPeriod,
+	}
+
+	// Wire OLM CR sharedIndexInformers
+	crInformerFactory := externalversions.NewSharedInformerFactoryWithOptions(op.client, op.resyncPeriod())
+
+	// Wire CatalogSources
+	catsrcInformer := crInformerFactory.Operators().V1alpha1().CatalogSources()
+	op.lister.OperatorsV1alpha1().RegisterCatalogSourceLister(metav1.NamespaceAll, catsrcInformer.Lister())
+	catalogTemplateSrcQueue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "catalogSourceTemplate")
+	op.catalogSourceTemplateQueueSet.Set(metav1.NamespaceAll, catalogTemplateSrcQueue)
+	catsrcQueueInformer, err := queueinformer.NewQueueInformer(
+		ctx,
+		queueinformer.WithLogger(op.logger),
+		queueinformer.WithQueue(catalogTemplateSrcQueue),
+		queueinformer.WithInformer(catsrcInformer.Informer()),
+		queueinformer.WithSyncer(queueinformer.LegacySyncHandler(op.syncCatalogSources).ToSyncer()),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := op.RegisterQueueInformer(catsrcQueueInformer); err != nil {
+		return nil, err
+	}
+
+	return op, nil
+}
+
+func (o *Operator) syncCatalogSources(obj interface{}) error {
+	// this is an opportunity to update the server version (regardless of any other actions for processing a catalog source)
+	o.updateServerVersion()
+
+	inputCatalogSource, ok := obj.(*v1alpha1.CatalogSource)
+	if !ok {
+		o.logger.Debugf("wrong type: %#v", obj)
+		return nil
+	}
+
+	outputCatalogSource := inputCatalogSource.DeepCopy()
+
+	logger := o.logger.WithFields(logrus.Fields{
+		"catSrcNamespace": outputCatalogSource.GetNamespace(),
+		"catSrcName":      outputCatalogSource.GetName(),
+		"id":              queueinformer.NewLoopID(),
+	})
+	logger.Info("syncing catalog source for annotation templates")
+
+	catalogImageTemplate := catalogsource.GetCatalogTemplateAnnotation(outputCatalogSource)
+	if catalogImageTemplate == "" {
+		logger.Debug("this catalog source is not participating in template replacement")
+		// make sure the conditions are removed
+		return catalogsource.RemoveStatusConditions(logger, o.client, outputCatalogSource, StatusTypeTemplatesHaveResolved, StatusTypeResolvedImage)
+	}
+
+	processedCatalogImageTemplate, unresolvedTemplates := catalogsource.ReplaceTemplates(catalogImageTemplate)
+
+	templatesAreResolved := len(unresolvedTemplates) == 0
+	// curly braces are not allowed in a real image reference (see https://github.com/distribution/distribution/blob/2461543d988979529609e8cb6fca9ca190dc48da/reference/reference.go#L4-L24)
+	// so we need to check for this... bottom line, we want to ensure that the result is valid
+	_, err := reference.Parse(processedCatalogImageTemplate)
+	invalidSyntax := err != nil
+
+	// make sure everything was resolved and valid
+	if templatesAreResolved && !invalidSyntax {
+		// all templates have been resolved
+
+		conditions := []metav1.Condition{
+			{
+				Type:    StatusTypeTemplatesHaveResolved,
+				Status:  metav1.ConditionTrue,
+				Reason:  ReasonAllTemplatesResolved,
+				Message: "catalog image reference was successfully resolved",
+			},
+			{
+				Type:    StatusTypeResolvedImage,
+				Status:  metav1.ConditionTrue,
+				Reason:  ReasonAllTemplatesResolved,
+				Message: processedCatalogImageTemplate,
+			},
+		}
+
+		// make sure that the processed image reference is actually different
+		if outputCatalogSource.Spec.Image != processedCatalogImageTemplate {
+
+			outputCatalogSource.Spec.Image = processedCatalogImageTemplate
+
+			if err := catalogsource.UpdateSpecAndStatusConditions(logger, o.client, outputCatalogSource, conditions...); err != nil {
+				return err
+			}
+			logger.Infof("The catalog image has been updated to %q", processedCatalogImageTemplate)
+		} else {
+			if err := catalogsource.UpdateStatusWithConditions(logger, o.client, outputCatalogSource, conditions...); err != nil {
+				return err
+			}
+			logger.Infof("The catalog image %q does not require an update because the image has not changed", processedCatalogImageTemplate)
+		}
+		return nil
+	}
+
+	// if we get here, at least one template was unresolved because:
+	// - either we explicitly discovered a template without a valid value (as listed in unresolvedTemplates)
+	// - or because a template curly brace was found (which means the user screwed up the syntax)
+	// so update status accordingly
+
+	// quote the values and use comma separator
+	quotedTemplates := fmt.Sprintf(`"%s"`, strings.Join(unresolvedTemplates, `", "`))
+
+	// init to sensible generic message
+	message := "cannot construct catalog image reference"
+	if invalidSyntax && !templatesAreResolved {
+		message = fmt.Sprintf("cannot construct catalog image reference, because variable(s) %s could not be resolved and one or more template(s) has improper syntax", quotedTemplates)
+	} else if invalidSyntax {
+		message = "cannot construct catalog image reference, because one or more template(s) has improper syntax"
+	} else if !templatesAreResolved {
+		message = fmt.Sprintf("cannot construct catalog image reference, because variable(s) %s could not be resolved", quotedTemplates)
+	}
+	err = catalogsource.UpdateStatusWithConditions(logger, o.client, outputCatalogSource,
+		metav1.Condition{
+			Type:    StatusTypeTemplatesHaveResolved,
+			Status:  metav1.ConditionFalse,
+			Reason:  ReasonUnableToResolve,
+			Message: message,
+		},
+		metav1.Condition{
+			Type:    StatusTypeResolvedImage,
+			Status:  metav1.ConditionFalse,
+			Reason:  ReasonUnableToResolve,
+			Message: processedCatalogImageTemplate,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	logger.Infof(message)
+
+	return nil
+}
+
+func (o *Operator) updateServerVersion() {
+	if serverVersion, err := o.discoveryClient.ServerVersion(); err != nil {
+		o.logger.WithError(err).Warn("unable to obtain server version from discovery client")
+	} else {
+		catalogsource.UpdateKubeVersion(serverVersion, o.logger)
+	}
+}

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/lib/catalogsource/catalogsource_update.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/lib/catalogsource/catalogsource_update.go
@@ -1,0 +1,136 @@
+package catalogsource
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+)
+
+/* UpdateStatus can be used to update the status of the provided catalog source. Note that
+the caller is responsible for ensuring accurate status values in the catsrc argument (i.e.
+the status is used as-is).
+
+• logger: used to log errors only
+
+• client: used to fetch / update catalog source status
+
+• catsrc: the CatalogSource to use as a source for status updates. Callers are
+responsible for updating the catalog source status values as necessary.
+*/
+func UpdateStatus(logger *logrus.Entry, client versioned.Interface, catsrc *v1alpha1.CatalogSource) error {
+
+	// make the status update if possible
+	if _, err := client.OperatorsV1alpha1().CatalogSources(catsrc.GetNamespace()).UpdateStatus(context.TODO(), catsrc, metav1.UpdateOptions{}); err != nil {
+		logger.WithError(err).Error("UpdateStatus - error while setting CatalogSource status")
+		return err
+	}
+
+	return nil
+}
+
+/* UpdateStatusWithConditions can be used to update the status conditions for the provided catalog source.
+This function will make no changes to the other status fields (those fields will be used as-is).
+If the provided conditions do not result in any status condition changes, then the API server will not be updated.
+Note that the caller is responsible for ensuring accurate status values for all other fields.
+
+• logger: used to log errors only
+
+• client: used to fetch / update catalog source status
+
+• catsrc: the CatalogSource to use as a source for status updates.
+
+• conditions: condition values to be updated
+*/
+func UpdateStatusWithConditions(logger *logrus.Entry, client versioned.Interface, catsrc *v1alpha1.CatalogSource, conditions ...metav1.Condition) error {
+
+	// make a copy of the status before we make the change
+	statusBefore := catsrc.Status.DeepCopy()
+
+	// update the conditions
+	for _, condition := range conditions {
+		meta.SetStatusCondition(&catsrc.Status.Conditions, condition)
+	}
+
+	// don't bother updating if no changes were made
+	if reflect.DeepEqual(catsrc.Status.Conditions, statusBefore.Conditions) {
+		logger.Debug("UpdateStatusWithConditions - request to update status conditions did not result in any changes, so updates were not made")
+		return nil
+	}
+
+	// make the update if possible
+	if _, err := client.OperatorsV1alpha1().CatalogSources(catsrc.GetNamespace()).UpdateStatus(context.TODO(), catsrc, metav1.UpdateOptions{}); err != nil {
+		logger.WithError(err).Error("UpdateStatusWithConditions - unable to update CatalogSource image reference")
+		return err
+	}
+	return nil
+}
+
+/* UpdateSpecAndStatusConditions can be used to update the catalog source with the provided status conditions.
+This will update the spec and status portions of the catalog source. Calls to the API server will occur
+even if the provided conditions result in no changes.
+
+• logger: used to log errors only
+
+• client: used to fetch / update catalog source
+
+• catsrc: the CatalogSource to use as a source for image and status condition updates.
+
+• conditions: condition values to be updated
+*/
+func UpdateSpecAndStatusConditions(logger *logrus.Entry, client versioned.Interface, catsrc *v1alpha1.CatalogSource, conditions ...metav1.Condition) error {
+
+	// update the conditions
+	for _, condition := range conditions {
+		meta.SetStatusCondition(&catsrc.Status.Conditions, condition)
+	}
+
+	// make the update if possible
+	if _, err := client.OperatorsV1alpha1().CatalogSources(catsrc.GetNamespace()).Update(context.TODO(), catsrc, metav1.UpdateOptions{}); err != nil {
+		logger.WithError(err).Error("UpdateSpecAndStatusConditions - unable to update CatalogSource image reference")
+		return err
+	}
+	return nil
+}
+
+/* RemoveStatusConditions can be used to remove the status conditions for the provided catalog source.
+This function will make no changes to the other status fields (those fields will be used as-is).
+If the provided conditions do not result in any status condition changes, then the API server will not be updated.
+Note that the caller is responsible for ensuring accurate status values for all other fields.
+
+• logger: used to log errors only
+
+• client: used to fetch / update catalog source status
+
+• catsrc: the CatalogSource to use as a source for status condition removal.
+
+• conditionTypes: condition types to be removed
+*/
+func RemoveStatusConditions(logger *logrus.Entry, client versioned.Interface, catsrc *v1alpha1.CatalogSource, conditionTypes ...string) error {
+
+	// make a copy of the status before we make the change
+	statusBefore := catsrc.Status.DeepCopy()
+
+	// remove the conditions
+	for _, conditionType := range conditionTypes {
+		meta.RemoveStatusCondition(&catsrc.Status.Conditions, conditionType)
+	}
+
+	// don't bother updating if no changes were made
+	if reflect.DeepEqual(catsrc.Status.Conditions, statusBefore.Conditions) {
+		logger.Debug("RemoveStatusConditions - request to remove status conditions did not result in any changes, so updates were not made")
+		return nil
+	}
+
+	// make the update if possible
+	if _, err := client.OperatorsV1alpha1().CatalogSources(catsrc.GetNamespace()).UpdateStatus(context.TODO(), catsrc, metav1.UpdateOptions{}); err != nil {
+		logger.WithError(err).Error("RemoveStatusConditions - unable to update CatalogSource image reference")
+		return err
+	}
+	return nil
+}

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/lib/catalogsource/image_template.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/lib/catalogsource/image_template.go
@@ -1,0 +1,184 @@
+package catalogsource
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/blang/semver/v4"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/version"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+)
+
+const (
+
+	// regex capture group names
+
+	// capGrpKubeMajorV is a capture group name for a kube major version
+	capGrpKubeMajorV = "kubemajorv"
+	// capGrpKubeMinorV is a capture group name for a kube minor version
+	capGrpKubeMinorV = "kubeminorv"
+	// capGrpKubePatchV is a capture group name for a kube patch version
+	capGrpKubePatchV = "kubepatchv"
+
+	// static templates
+
+	// TemplKubeMajorV is a template that represents the kube major version
+	TemplKubeMajorV = "{kube_major_version}"
+	// TemplKubeMinorV is a template that represents the kube minor version
+	TemplKubeMinorV = "{kube_minor_version}"
+	// TemplKubePatchV is a template that represents the kube patch version
+	TemplKubePatchV = "{kube_patch_version}"
+
+	// templateMissing represents a value that could not be obtained from the cluster
+	templateMissing = "missing"
+
+	// catalogImageTemplateAnnotation is OLM annotation. The annotation value that corresponds
+	// to this key is used as means to adjust a catalog source image, where templated
+	// values are replaced with values found in the cluster
+	CatalogImageTemplateAnnotation = "olm.catalogImageTemplate"
+)
+
+// templateNameToReplacementValuesMap is storage for templates and their resolved values
+// The values are initialized to variable "templateMissing"
+var templateNameToReplacementValuesMap = map[string]string{}
+
+// templateMutex is a package scoped mutex for synchronizing access to templateNameToReplacementValuesMap
+var templateMutex sync.RWMutex
+
+func init() {
+	// Handle known static templates
+	initializeIfNeeded(TemplKubeMajorV)
+	initializeIfNeeded(TemplKubeMinorV)
+	initializeIfNeeded(TemplKubePatchV)
+}
+
+// initializeIfNeeded sets the map to a "missing" value if its not already present
+func initializeIfNeeded(templateKey string) {
+	templateMutex.Lock()
+	defer templateMutex.Unlock()
+
+	// have we encountered this template already?
+	if _, ok := templateNameToReplacementValuesMap[templateKey]; !ok {
+		// this is a new template, so default to missing value
+		templateNameToReplacementValuesMap[templateKey] = templateMissing
+	}
+}
+
+// resetMaps is only useful for test cases
+func resetMaps() {
+	templateMutex.Lock()
+	templateNameToReplacementValuesMap = map[string]string{}
+	templateMutex.Unlock()
+
+	initializeIfNeeded(TemplKubeMajorV)
+	initializeIfNeeded(TemplKubeMinorV)
+	initializeIfNeeded(TemplKubePatchV)
+}
+
+type regexEntry struct {
+	captureGroup string
+	template     string
+}
+
+func (r *regexEntry) String() string {
+	return fmt.Sprintf(`(?P<%s>%s)`, r.captureGroup, r.template)
+}
+
+type regexEntries []regexEntry
+
+func (r regexEntries) String() string {
+	regexEntryAsString := []string{}
+	for _, regexEntry := range r {
+		regexEntryAsString = append(regexEntryAsString, regexEntry.String())
+	}
+	result := strings.Join(regexEntryAsString, "|")
+	return result
+}
+
+var regexList = regexEntries{
+	{capGrpKubeMajorV, TemplKubeMajorV},
+	{capGrpKubeMinorV, TemplKubeMinorV},
+	{capGrpKubePatchV, TemplKubePatchV},
+}
+
+var regexImageTemplates = regexp.MustCompile(regexList.String())
+
+// ReplaceTemplates takes a catalog image reference containing templates (i.e. catalogImageTemplate)
+// and attempts to replace the templates with actual values (if available).
+// The return value processedCatalogImageTemplate represents the catalog image reference after processing.
+// Callers of this function should check the unresolvedTemplates return value to determine
+// if all values were properly resolved (i.e. empty slice means all items were resolved, and presence
+// of a value in the slice means that the template was either not found in the cache or its value has not been
+// fetched yet). Providing an empty catalogImageTemplate results in empty processedCatalogImageTemplate and
+// zero length unresolvedTemplates
+func ReplaceTemplates(catalogImageTemplate string) (processedCatalogImageTemplate string, unresolvedTemplates []string) {
+	templateMutex.RLock()
+	defer templateMutex.RUnlock()
+
+	// init to empty slice
+	unresolvedTemplates = []string{}
+
+	// templateReplacer function determines the replacement value for the given template
+	var templateReplacer = func(template string) string {
+		replacement, ok := templateNameToReplacementValuesMap[template]
+		if ok {
+			// found a template, but check if the value is missing and keep record of
+			// what templates were unresolved
+			if replacement == templateMissing {
+				unresolvedTemplates = append(unresolvedTemplates, template)
+			}
+			return replacement
+		} else {
+			// probably should not get here, but in case there is no match,
+			// just return template unchanged, but keep record of
+			// what templates were unresolved
+			unresolvedTemplates = append(unresolvedTemplates, template)
+			return template
+		}
+	}
+
+	// if image is present, perform template substitution
+	if catalogImageTemplate != "" {
+		processedCatalogImageTemplate = regexImageTemplates.ReplaceAllStringFunc(catalogImageTemplate, templateReplacer)
+	}
+	return
+}
+
+// GetCatalogTemplateAnnotation is a helper function to extract the catalog image template annotation.
+// Returns empty string if value not set, otherwise returns annotation.
+func GetCatalogTemplateAnnotation(catalogSource *v1alpha1.CatalogSource) string {
+	if catalogSource == nil {
+		return ""
+	}
+	if catalogImageTemplate, ok := catalogSource.GetAnnotations()[CatalogImageTemplateAnnotation]; !ok {
+		return ""
+	} else {
+		return catalogImageTemplate
+	}
+}
+
+func UpdateKubeVersion(serverVersion *version.Info, logger *logrus.Logger) {
+	templateMutex.Lock()
+	defer templateMutex.Unlock()
+
+	if serverVersion == nil {
+		logger.Warn("no server version provided")
+		return
+	}
+
+	templateNameToReplacementValuesMap[TemplKubeMajorV] = serverVersion.Major
+	templateNameToReplacementValuesMap[TemplKubeMinorV] = serverVersion.Minor
+
+	// api server does not explicitly give patch value, so we have to resort to parsing the git version
+	serverGitVersion, err := semver.Parse(serverVersion.GitVersion)
+	if err != nil {
+		templateNameToReplacementValuesMap[TemplKubePatchV] = strconv.FormatUint(serverGitVersion.Patch, 10)
+	} else {
+		logger.WithError(err).Warn("unable to obtain kube server patch value")
+	}
+}

--- a/vendor/k8s.io/apimachinery/pkg/util/version/doc.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/version/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package version provides utilities for version number comparisons
+package version // import "k8s.io/apimachinery/pkg/util/version"

--- a/vendor/k8s.io/apimachinery/pkg/util/version/version.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/version/version.go
@@ -1,0 +1,325 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Version is an opaque representation of a version number
+type Version struct {
+	components    []uint
+	semver        bool
+	preRelease    string
+	buildMetadata string
+}
+
+var (
+	// versionMatchRE splits a version string into numeric and "extra" parts
+	versionMatchRE = regexp.MustCompile(`^\s*v?([0-9]+(?:\.[0-9]+)*)(.*)*$`)
+	// extraMatchRE splits the "extra" part of versionMatchRE into semver pre-release and build metadata; it does not validate the "no leading zeroes" constraint for pre-release
+	extraMatchRE = regexp.MustCompile(`^(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?\s*$`)
+)
+
+func parse(str string, semver bool) (*Version, error) {
+	parts := versionMatchRE.FindStringSubmatch(str)
+	if parts == nil {
+		return nil, fmt.Errorf("could not parse %q as version", str)
+	}
+	numbers, extra := parts[1], parts[2]
+
+	components := strings.Split(numbers, ".")
+	if (semver && len(components) != 3) || (!semver && len(components) < 2) {
+		return nil, fmt.Errorf("illegal version string %q", str)
+	}
+
+	v := &Version{
+		components: make([]uint, len(components)),
+		semver:     semver,
+	}
+	for i, comp := range components {
+		if (i == 0 || semver) && strings.HasPrefix(comp, "0") && comp != "0" {
+			return nil, fmt.Errorf("illegal zero-prefixed version component %q in %q", comp, str)
+		}
+		num, err := strconv.ParseUint(comp, 10, 0)
+		if err != nil {
+			return nil, fmt.Errorf("illegal non-numeric version component %q in %q: %v", comp, str, err)
+		}
+		v.components[i] = uint(num)
+	}
+
+	if semver && extra != "" {
+		extraParts := extraMatchRE.FindStringSubmatch(extra)
+		if extraParts == nil {
+			return nil, fmt.Errorf("could not parse pre-release/metadata (%s) in version %q", extra, str)
+		}
+		v.preRelease, v.buildMetadata = extraParts[1], extraParts[2]
+
+		for _, comp := range strings.Split(v.preRelease, ".") {
+			if _, err := strconv.ParseUint(comp, 10, 0); err == nil {
+				if strings.HasPrefix(comp, "0") && comp != "0" {
+					return nil, fmt.Errorf("illegal zero-prefixed version component %q in %q", comp, str)
+				}
+			}
+		}
+	}
+
+	return v, nil
+}
+
+// ParseGeneric parses a "generic" version string. The version string must consist of two
+// or more dot-separated numeric fields (the first of which can't have leading zeroes),
+// followed by arbitrary uninterpreted data (which need not be separated from the final
+// numeric field by punctuation). For convenience, leading and trailing whitespace is
+// ignored, and the version can be preceded by the letter "v". See also ParseSemantic.
+func ParseGeneric(str string) (*Version, error) {
+	return parse(str, false)
+}
+
+// MustParseGeneric is like ParseGeneric except that it panics on error
+func MustParseGeneric(str string) *Version {
+	v, err := ParseGeneric(str)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// ParseSemantic parses a version string that exactly obeys the syntax and semantics of
+// the "Semantic Versioning" specification (http://semver.org/) (although it ignores
+// leading and trailing whitespace, and allows the version to be preceded by "v"). For
+// version strings that are not guaranteed to obey the Semantic Versioning syntax, use
+// ParseGeneric.
+func ParseSemantic(str string) (*Version, error) {
+	return parse(str, true)
+}
+
+// MustParseSemantic is like ParseSemantic except that it panics on error
+func MustParseSemantic(str string) *Version {
+	v, err := ParseSemantic(str)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// Major returns the major release number
+func (v *Version) Major() uint {
+	return v.components[0]
+}
+
+// Minor returns the minor release number
+func (v *Version) Minor() uint {
+	return v.components[1]
+}
+
+// Patch returns the patch release number if v is a Semantic Version, or 0
+func (v *Version) Patch() uint {
+	if len(v.components) < 3 {
+		return 0
+	}
+	return v.components[2]
+}
+
+// BuildMetadata returns the build metadata, if v is a Semantic Version, or ""
+func (v *Version) BuildMetadata() string {
+	return v.buildMetadata
+}
+
+// PreRelease returns the prerelease metadata, if v is a Semantic Version, or ""
+func (v *Version) PreRelease() string {
+	return v.preRelease
+}
+
+// Components returns the version number components
+func (v *Version) Components() []uint {
+	return v.components
+}
+
+// WithMajor returns copy of the version object with requested major number
+func (v *Version) WithMajor(major uint) *Version {
+	result := *v
+	result.components = []uint{major, v.Minor(), v.Patch()}
+	return &result
+}
+
+// WithMinor returns copy of the version object with requested minor number
+func (v *Version) WithMinor(minor uint) *Version {
+	result := *v
+	result.components = []uint{v.Major(), minor, v.Patch()}
+	return &result
+}
+
+// WithPatch returns copy of the version object with requested patch number
+func (v *Version) WithPatch(patch uint) *Version {
+	result := *v
+	result.components = []uint{v.Major(), v.Minor(), patch}
+	return &result
+}
+
+// WithPreRelease returns copy of the version object with requested prerelease
+func (v *Version) WithPreRelease(preRelease string) *Version {
+	result := *v
+	result.components = []uint{v.Major(), v.Minor(), v.Patch()}
+	result.preRelease = preRelease
+	return &result
+}
+
+// WithBuildMetadata returns copy of the version object with requested buildMetadata
+func (v *Version) WithBuildMetadata(buildMetadata string) *Version {
+	result := *v
+	result.components = []uint{v.Major(), v.Minor(), v.Patch()}
+	result.buildMetadata = buildMetadata
+	return &result
+}
+
+// String converts a Version back to a string; note that for versions parsed with
+// ParseGeneric, this will not include the trailing uninterpreted portion of the version
+// number.
+func (v *Version) String() string {
+	if v == nil {
+		return "<nil>"
+	}
+	var buffer bytes.Buffer
+
+	for i, comp := range v.components {
+		if i > 0 {
+			buffer.WriteString(".")
+		}
+		buffer.WriteString(fmt.Sprintf("%d", comp))
+	}
+	if v.preRelease != "" {
+		buffer.WriteString("-")
+		buffer.WriteString(v.preRelease)
+	}
+	if v.buildMetadata != "" {
+		buffer.WriteString("+")
+		buffer.WriteString(v.buildMetadata)
+	}
+
+	return buffer.String()
+}
+
+// compareInternal returns -1 if v is less than other, 1 if it is greater than other, or 0
+// if they are equal
+func (v *Version) compareInternal(other *Version) int {
+
+	vLen := len(v.components)
+	oLen := len(other.components)
+	for i := 0; i < vLen && i < oLen; i++ {
+		switch {
+		case other.components[i] < v.components[i]:
+			return 1
+		case other.components[i] > v.components[i]:
+			return -1
+		}
+	}
+
+	// If components are common but one has more items and they are not zeros, it is bigger
+	switch {
+	case oLen < vLen && !onlyZeros(v.components[oLen:]):
+		return 1
+	case oLen > vLen && !onlyZeros(other.components[vLen:]):
+		return -1
+	}
+
+	if !v.semver || !other.semver {
+		return 0
+	}
+
+	switch {
+	case v.preRelease == "" && other.preRelease != "":
+		return 1
+	case v.preRelease != "" && other.preRelease == "":
+		return -1
+	case v.preRelease == other.preRelease: // includes case where both are ""
+		return 0
+	}
+
+	vPR := strings.Split(v.preRelease, ".")
+	oPR := strings.Split(other.preRelease, ".")
+	for i := 0; i < len(vPR) && i < len(oPR); i++ {
+		vNum, err := strconv.ParseUint(vPR[i], 10, 0)
+		if err == nil {
+			oNum, err := strconv.ParseUint(oPR[i], 10, 0)
+			if err == nil {
+				switch {
+				case oNum < vNum:
+					return 1
+				case oNum > vNum:
+					return -1
+				default:
+					continue
+				}
+			}
+		}
+		if oPR[i] < vPR[i] {
+			return 1
+		} else if oPR[i] > vPR[i] {
+			return -1
+		}
+	}
+
+	switch {
+	case len(oPR) < len(vPR):
+		return 1
+	case len(oPR) > len(vPR):
+		return -1
+	}
+
+	return 0
+}
+
+// returns false if array contain any non-zero element
+func onlyZeros(array []uint) bool {
+	for _, num := range array {
+		if num != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// AtLeast tests if a version is at least equal to a given minimum version. If both
+// Versions are Semantic Versions, this will use the Semantic Version comparison
+// algorithm. Otherwise, it will compare only the numeric components, with non-present
+// components being considered "0" (ie, "1.4" is equal to "1.4.0").
+func (v *Version) AtLeast(min *Version) bool {
+	return v.compareInternal(min) != -1
+}
+
+// LessThan tests if a version is less than a given version. (It is exactly the opposite
+// of AtLeast, for situations where asking "is v too old?" makes more sense than asking
+// "is v new enough?".)
+func (v *Version) LessThan(other *Version) bool {
+	return v.compareInternal(other) == -1
+}
+
+// Compare compares v against a version string (which will be parsed as either Semantic
+// or non-Semantic depending on v). On success it returns -1 if v is less than other, 1 if
+// it is greater than other, or 0 if they are equal.
+func (v *Version) Compare(other string) (int, error) {
+	ov, err := parse(other, v.semver)
+	if err != nil {
+		return 0, err
+	}
+	return v.compareInternal(ov), nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -124,6 +124,8 @@ github.com/deislabs/oras/pkg/auth/docker
 github.com/deislabs/oras/pkg/content
 github.com/deislabs/oras/pkg/context
 github.com/deislabs/oras/pkg/oras
+# github.com/distribution/distribution v2.7.1+incompatible
+github.com/distribution/distribution/reference
 # github.com/docker/cli v20.10.5+incompatible
 github.com/docker/cli/cli/config
 github.com/docker/cli/cli/config/configfile
@@ -477,7 +479,7 @@ github.com/openshift/client-go/config/informers/externalversions/config
 github.com/openshift/client-go/config/informers/externalversions/config/v1
 github.com/openshift/client-go/config/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/config/listers/config/v1
-# github.com/operator-framework/api v0.10.2 => ./staging/api
+# github.com/operator-framework/api v0.10.3 => ./staging/api
 ## explicit
 github.com/operator-framework/api/crds
 github.com/operator-framework/api/pkg/lib/version
@@ -524,6 +526,7 @@ github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install
 github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators
 github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog
 github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/subscription
+github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalogtemplate
 github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/decorators
 github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/internal/alongside
 github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/internal/pruning
@@ -538,6 +541,7 @@ github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry
 github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/projection
 github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/solver
 github.com/operator-framework/operator-lifecycle-manager/pkg/feature
+github.com/operator-framework/operator-lifecycle-manager/pkg/lib/catalogsource
 github.com/operator-framework/operator-lifecycle-manager/pkg/lib/clients
 github.com/operator-framework/operator-lifecycle-manager/pkg/lib/codec
 github.com/operator-framework/operator-lifecycle-manager/pkg/lib/comparison

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1219,6 +1219,7 @@ k8s.io/apimachinery/pkg/util/strategicpatch
 k8s.io/apimachinery/pkg/util/uuid
 k8s.io/apimachinery/pkg/util/validation
 k8s.io/apimachinery/pkg/util/validation/field
+k8s.io/apimachinery/pkg/util/version
 k8s.io/apimachinery/pkg/util/wait
 k8s.io/apimachinery/pkg/util/waitgroup
 k8s.io/apimachinery/pkg/util/yaml


### PR DESCRIPTION
* Implement catalog switching proposal

- implements catalog switching proposal
See https://github.com/operator-framework/enhancements/blob/master/enhancements/automatic-catalog-switching-annotations.md
- picks up v0.10.3
- change sed command in copy_crds.sh to be posix compliant

The command + in sed is non-portable. The posix compliant version of
this command is {1,}

This change allows this script to run on a mac too (which uses BSD sed)

See https://riptutorial.com/sed/topic/9436/bsd-macos-sed-vs--gnu-sed-vs--the-posix-sed-specification

Note: GVK was implemented but disabled due to security concerns.
Future versions will address these concerns

Signed-off-by: John Hunkins <jhunkins@us.ibm.com>

* Address review comments from ecordell

- reorganize imports
- change logging common case to debug

Signed-off-by: John Hunkins <jhunkins@us.ibm.com>

* removed all watcher related code

- this is the commit that should be reviewed later
when it comes time to re-enable the GVK code

Signed-off-by: John Hunkins <jhunkins@us.ibm.com>

* update vendor to remove dynamic lister code

Signed-off-by: John Hunkins <jhunkins@us.ibm.com>

* fix incorrect names and improper error usage

- fix names that don't match Golang convention
- fix misspelled package name
- return nil for sync function casting

Signed-off-by: John Hunkins <jhunkins@us.ibm.com>

* change code block organization and add mutex

Signed-off-by: John Hunkins <jhunkins@us.ibm.com>

* remove all traces of GVK template feature

- clean up every instance of the GVK templating feature
- add last minute change for RWMutex instead of Mutex

- this is the second commit that should be reviewed later
when it comes time to re-enable the GVK code

Signed-off-by: John Hunkins <jhunkins@us.ibm.com>

* return status update errors and adjust logging

Signed-off-by: John Hunkins <jhunkins@us.ibm.com>

* address review comments

- update logging for clarity
- clean up code blocks
- refactor catalogsource helper functions:
  - remove mutex
  - remove two step get/update* in preference to update* even though
    this may result in more "the object has been modified" errors
  - rename helper functions to clarify usage
  - clarify the update helper function docs

Signed-off-by: John Hunkins <jhunkins@us.ibm.com>

Upstream-repository: operator-lifecycle-manager
Upstream-commit: 5f6fcd14f08a7e2a81b016fa83132ea68242f335