### PR TITLE
Bug 1954869: Add PriorityClass setting to registry pods for default CatalogSource (#2304)

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/configmap_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/configmap_test.go
@@ -204,8 +204,9 @@ func objectsForCatalogSource(catsrc *v1alpha1.CatalogSource) []runtime.Object {
 		if catsrc.Spec.Image != "" {
 			decorated := grpcCatalogSourceDecorator{catsrc}
 			objs = clientfake.AddSimpleGeneratedNames(
-				decorated.Pod(""),
+				decorated.Pod(catsrc.GetName()),
 				decorated.Service(),
+				decorated.ServiceAccount(),
 			)
 		}
 	}


### PR DESCRIPTION


The registry pods may need to have necessary priorityclass settings.
OLM will set the priorityclass setting for registry pods by using
the priorityclass annotations in the default catalogsources.

Upstream-repository: operator-lifecycle-manager
Upstream-commit: c9ccfd96289c455f75f3ef552a43a1ab9303e77a

Signed-off-by: Vu Dinh <vudinh@outlook.com>