### PR TITLE
Bug 1990850: Handle property and dependency values of type BLOB in ListBundles.

### DIFF
--- a/staging/operator-registry/pkg/sqlite/query.go
+++ b/staging/operator-registry/pkg/sqlite/query.go
@@ -991,12 +991,12 @@ tip (depth) AS (
     GROUP BY all_entry.operatorbundle_name, all_entry.package_name, all_entry.channel_name
 ),
 merged_properties (bundle_name, merged) AS (
-  SELECT operatorbundle_name, json_group_array(json_object('type', properties.type, 'value', properties.value))
+  SELECT operatorbundle_name, json_group_array(json_object('type', CAST(properties.type AS TEXT), 'value', CAST(properties.value AS TEXT)))
     FROM properties
     GROUP BY operatorbundle_name
 ),
 merged_dependencies (bundle_name, merged) AS (
-  SELECT operatorbundle_name, json_group_array(json_object('type', dependencies.type, 'value', CAST(dependencies.value AS TEXT)))
+  SELECT operatorbundle_name, json_group_array(json_object('type', CAST(dependencies.type AS TEXT), 'value', CAST(dependencies.value AS TEXT)))
     FROM dependencies
     GROUP BY operatorbundle_name
 )

--- a/vendor/github.com/operator-framework/operator-registry/pkg/sqlite/query.go
+++ b/vendor/github.com/operator-framework/operator-registry/pkg/sqlite/query.go
@@ -991,12 +991,12 @@ tip (depth) AS (
     GROUP BY all_entry.operatorbundle_name, all_entry.package_name, all_entry.channel_name
 ),
 merged_properties (bundle_name, merged) AS (
-  SELECT operatorbundle_name, json_group_array(json_object('type', properties.type, 'value', properties.value))
+  SELECT operatorbundle_name, json_group_array(json_object('type', CAST(properties.type AS TEXT), 'value', CAST(properties.value AS TEXT)))
     FROM properties
     GROUP BY operatorbundle_name
 ),
 merged_dependencies (bundle_name, merged) AS (
-  SELECT operatorbundle_name, json_group_array(json_object('type', dependencies.type, 'value', CAST(dependencies.value AS TEXT)))
+  SELECT operatorbundle_name, json_group_array(json_object('type', CAST(dependencies.type AS TEXT), 'value', CAST(dependencies.value AS TEXT)))
     FROM dependencies
     GROUP BY operatorbundle_name
 )


### PR DESCRIPTION
Per https://www.sqlite.org/datatype3.html#type_affinity:

> In order to maximize compatibility between SQLite and other database
> engines, and so that the example above will work on SQLite as it
> does on other SQL database engines, SQLite supports the concept of
> "type affinity" on columns. The type affinity of a column is the
> recommended type for data stored in that column. The important idea
> here is that the type is recommended, not required. Any column can
> still store any type of data. It is just that some columns, given
> the choice, will prefer to use one storage class over another. The
> preferred storage class for a column is called its "affinity".

Even though the properties and dependencies tables are created with
column affinity TEXT on both their "type" and "value" columns, SQLite
does not require values stored in those columns to have that type.

The query backing the registry.ListBundles API recently began using
the json_object function from the json1 SQLite
extension (https://www.sqlite.org/json1.html#jobj), which does not
support arguments of type BLOB. The docs state:

> If any argument to json_object() is a BLOB then an error is thrown.

But it seems that no error is actually being returned. Instead, the
result set it empty. This may be an issue with the SQLite driver? It
seems to produce an error in sqlite3's interactive mode.
