### PR TITLE
Bug 1989796: docs(diff): add point about versions that differ

### DIFF
--- a/staging/operator-registry/cmd/opm/alpha/diff/cmd.go
+++ b/staging/operator-registry/cmd/opm/alpha/diff/cmd.go
@@ -44,7 +44,7 @@ func NewCmd() *cobra.Command {
 		Long: templates.LongDesc(`
 Diff a set of old and new catalog references ("refs") to produce a
 declarative config containing only packages channels, and versions not present
-in the old set. This is known as "latest" mode.
+in the old set, and versions that differ between the old and new sets. This is known as "latest" mode.
 These references are passed through 'opm render' to produce a single declarative config.
 
 This command has special behavior when old-refs are omitted, called "heads-only" mode:

--- a/vendor/github.com/operator-framework/operator-registry/cmd/opm/alpha/diff/cmd.go
+++ b/vendor/github.com/operator-framework/operator-registry/cmd/opm/alpha/diff/cmd.go
@@ -44,7 +44,7 @@ func NewCmd() *cobra.Command {
 		Long: templates.LongDesc(`
 Diff a set of old and new catalog references ("refs") to produce a
 declarative config containing only packages channels, and versions not present
-in the old set. This is known as "latest" mode.
+in the old set, and versions that differ between the old and new sets. This is known as "latest" mode.
 These references are passed through 'opm render' to produce a single declarative config.
 
 This command has special behavior when old-refs are omitted, called "heads-only" mode:


### PR DESCRIPTION
docs(diff): add point about versions that differ (#735)

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>

Upstream-repository: operator-registry
Upstream-commit: 3f370e6ce05c19fbd00b5530d90a08568e89063d