### PR TITLE
Bug 1989431: fix(opm): clarify that bundle declcfgs are not valid refs alone

### DIFF
--- a/staging/operator-registry/cmd/opm/alpha/diff/cmd.go
+++ b/staging/operator-registry/cmd/opm/alpha/diff/cmd.go
@@ -45,7 +45,10 @@ func NewCmd() *cobra.Command {
 Diff a set of old and new catalog references ("refs") to produce a
 declarative config containing only packages channels, and versions not present
 in the old set, and versions that differ between the old and new sets. This is known as "latest" mode.
+
 These references are passed through 'opm render' to produce a single declarative config.
+Bundle image refs are not supported directly; a valid "olm.package" declarative config object
+referring to the bundle's package must exist in all input refs.
 
 This command has special behavior when old-refs are omitted, called "heads-only" mode:
 instead of the output being that of 'opm render refs...'

--- a/staging/operator-registry/internal/action/diff.go
+++ b/staging/operator-registry/internal/action/diff.go
@@ -2,6 +2,7 @@ package action
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/sirupsen/logrus"
@@ -25,12 +26,18 @@ func (a Diff) Run(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
 		return nil, err
 	}
 
+	// Disallow bundle refs.
+	mask := RefDCDir | RefDCImage | RefSqliteFile | RefSqliteImage
+
 	// Heads-only mode does not require an old ref, so there may be nothing to render.
 	var oldModel model.Model
 	if len(a.OldRefs) != 0 {
-		oldRender := Render{Refs: a.OldRefs, Registry: a.Registry}
+		oldRender := Render{Refs: a.OldRefs, Registry: a.Registry, AllowedRefMask: mask}
 		oldCfg, err := oldRender.Run(ctx)
 		if err != nil {
+			if errors.Is(err, ErrNotAllowed) {
+				return nil, fmt.Errorf("%w (diff does not permit direct bundle references)", err)
+			}
 			return nil, fmt.Errorf("error rendering old refs: %v", err)
 		}
 		oldModel, err = declcfg.ConvertToModel(*oldCfg)
@@ -39,9 +46,12 @@ func (a Diff) Run(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
 		}
 	}
 
-	newRender := Render{Refs: a.NewRefs, Registry: a.Registry}
+	newRender := Render{Refs: a.NewRefs, Registry: a.Registry, AllowedRefMask: mask}
 	newCfg, err := newRender.Run(ctx)
 	if err != nil {
+		if errors.Is(err, ErrNotAllowed) {
+			return nil, fmt.Errorf("%w (diff does not permit direct bundle references)", err)
+		}
 		return nil, fmt.Errorf("error rendering new refs: %v", err)
 	}
 	newModel, err := declcfg.ConvertToModel(*newCfg)

--- a/staging/operator-registry/internal/action/list.go
+++ b/staging/operator-registry/internal/action/list.go
@@ -206,7 +206,7 @@ func indexRefToModel(ctx context.Context, ref string) (model.Model, error) {
 	}
 	cfg, err := render.Run(ctx)
 	if err != nil {
-		if errors.Is(err, &ErrNotAllowed{}) {
+		if errors.Is(err, ErrNotAllowed) {
 			return nil, fmt.Errorf("cannot list non-index %q", ref)
 		}
 		return nil, err

--- a/staging/operator-registry/internal/action/render_test.go
+++ b/staging/operator-registry/internal/action/render_test.go
@@ -448,7 +448,7 @@ func TestAllowRefMask(t *testing.T) {
 				Registry:       reg,
 				AllowedRefMask: action.RefDCImage | action.RefDCDir | action.RefSqliteFile | action.RefBundleImage,
 			},
-			expectErr: &action.ErrNotAllowed{},
+			expectErr: action.ErrNotAllowed,
 		},
 		{
 			name: "SqliteFile/Allowed",
@@ -466,7 +466,7 @@ func TestAllowRefMask(t *testing.T) {
 				Registry:       reg,
 				AllowedRefMask: action.RefDCImage | action.RefDCDir | action.RefSqliteImage | action.RefBundleImage,
 			},
-			expectErr: &action.ErrNotAllowed{},
+			expectErr: action.ErrNotAllowed,
 		},
 		{
 			name: "DeclcfgImage/Allowed",
@@ -484,7 +484,7 @@ func TestAllowRefMask(t *testing.T) {
 				Registry:       reg,
 				AllowedRefMask: action.RefDCDir | action.RefSqliteImage | action.RefSqliteFile | action.RefBundleImage,
 			},
-			expectErr: &action.ErrNotAllowed{},
+			expectErr: action.ErrNotAllowed,
 		},
 		{
 			name: "DeclcfgDir/Allowed",
@@ -502,7 +502,7 @@ func TestAllowRefMask(t *testing.T) {
 				Registry:       reg,
 				AllowedRefMask: action.RefDCImage | action.RefSqliteImage | action.RefSqliteFile | action.RefBundleImage,
 			},
-			expectErr: &action.ErrNotAllowed{},
+			expectErr: action.ErrNotAllowed,
 		},
 		{
 			name: "BundleImage/Allowed",
@@ -520,7 +520,7 @@ func TestAllowRefMask(t *testing.T) {
 				Registry:       reg,
 				AllowedRefMask: action.RefDCImage | action.RefDCDir | action.RefSqliteImage | action.RefSqliteFile,
 			},
-			expectErr: &action.ErrNotAllowed{},
+			expectErr: action.ErrNotAllowed,
 		},
 		{
 			name: "All/Allowed",

--- a/vendor/github.com/operator-framework/operator-registry/cmd/opm/alpha/diff/cmd.go
+++ b/vendor/github.com/operator-framework/operator-registry/cmd/opm/alpha/diff/cmd.go
@@ -45,7 +45,10 @@ func NewCmd() *cobra.Command {
 Diff a set of old and new catalog references ("refs") to produce a
 declarative config containing only packages channels, and versions not present
 in the old set, and versions that differ between the old and new sets. This is known as "latest" mode.
+
 These references are passed through 'opm render' to produce a single declarative config.
+Bundle image refs are not supported directly; a valid "olm.package" declarative config object
+referring to the bundle's package must exist in all input refs.
 
 This command has special behavior when old-refs are omitted, called "heads-only" mode:
 instead of the output being that of 'opm render refs...'

--- a/vendor/github.com/operator-framework/operator-registry/internal/action/diff.go
+++ b/vendor/github.com/operator-framework/operator-registry/internal/action/diff.go
@@ -2,6 +2,7 @@ package action
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/sirupsen/logrus"
@@ -25,12 +26,18 @@ func (a Diff) Run(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
 		return nil, err
 	}
 
+	// Disallow bundle refs.
+	mask := RefDCDir | RefDCImage | RefSqliteFile | RefSqliteImage
+
 	// Heads-only mode does not require an old ref, so there may be nothing to render.
 	var oldModel model.Model
 	if len(a.OldRefs) != 0 {
-		oldRender := Render{Refs: a.OldRefs, Registry: a.Registry}
+		oldRender := Render{Refs: a.OldRefs, Registry: a.Registry, AllowedRefMask: mask}
 		oldCfg, err := oldRender.Run(ctx)
 		if err != nil {
+			if errors.Is(err, ErrNotAllowed) {
+				return nil, fmt.Errorf("%w (diff does not permit direct bundle references)", err)
+			}
 			return nil, fmt.Errorf("error rendering old refs: %v", err)
 		}
 		oldModel, err = declcfg.ConvertToModel(*oldCfg)
@@ -39,9 +46,12 @@ func (a Diff) Run(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
 		}
 	}
 
-	newRender := Render{Refs: a.NewRefs, Registry: a.Registry}
+	newRender := Render{Refs: a.NewRefs, Registry: a.Registry, AllowedRefMask: mask}
 	newCfg, err := newRender.Run(ctx)
 	if err != nil {
+		if errors.Is(err, ErrNotAllowed) {
+			return nil, fmt.Errorf("%w (diff does not permit direct bundle references)", err)
+		}
 		return nil, fmt.Errorf("error rendering new refs: %v", err)
 	}
 	newModel, err := declcfg.ConvertToModel(*newCfg)

--- a/vendor/github.com/operator-framework/operator-registry/internal/action/list.go
+++ b/vendor/github.com/operator-framework/operator-registry/internal/action/list.go
@@ -206,7 +206,7 @@ func indexRefToModel(ctx context.Context, ref string) (model.Model, error) {
 	}
 	cfg, err := render.Run(ctx)
 	if err != nil {
-		if errors.Is(err, &ErrNotAllowed{}) {
+		if errors.Is(err, ErrNotAllowed) {
 			return nil, fmt.Errorf("cannot list non-index %q", ref)
 		}
 		return nil, err


### PR DESCRIPTION
* fix(opm): clarify that bundle declcfgs are not valid refs alone

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>

* internal/action: changed ErrNotAllowed to variable for correct errors.Is() comparison

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>

Upstream-repository: operator-registry
Upstream-commit: 88d4d7633b93a73a2da2bd39348a8ba40b75db24