### PR TITLE
Bug 1994110: fix(openshift): drop z from next calculated y-stream

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/operators/openshift/helpers_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/openshift/helpers_test.go
@@ -250,6 +250,11 @@ func TestIncompatibleOperators(t *testing.T) {
 				{
 					name:                "chestnut",
 					namespace:           "default",
+					maxOpenShiftVersion: "1.2.0-pre+build",
+				},
+				{
+					name:                "drupe",
+					namespace:           "default",
 					maxOpenShiftVersion: "2.0.0",
 				},
 			},
@@ -289,6 +294,11 @@ func TestIncompatibleOperators(t *testing.T) {
 				{
 					name:                "drupe",
 					namespace:           "default",
+					maxOpenShiftVersion: "1.1.0-pre+build",
+				},
+				{
+					name:                "european-hazelnut",
+					namespace:           "default",
 					maxOpenShiftVersion: "0.1.0",
 				},
 			},
@@ -312,6 +322,11 @@ func TestIncompatibleOperators(t *testing.T) {
 					},
 					{
 						name:                "drupe",
+						namespace:           "default",
+						maxOpenShiftVersion: "1.1.0-pre+build",
+					},
+					{
+						name:                "european-hazelnut",
 						namespace:           "default",
 						maxOpenShiftVersion: "0.1.0",
 					},
@@ -412,14 +427,14 @@ func TestIncompatibleOperators(t *testing.T) {
 			},
 		},
 		{
-			description: "Compatible/EmptyVersion",
+			description: "EmptyVersion",
 			cv: configv1.ClusterVersion{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "version",
 				},
 				Status: configv1.ClusterVersionStatus{
 					Desired: configv1.Update{
-						Version: "",
+						Version: "", // This should result in an transient error
 					},
 				},
 			},
@@ -438,6 +453,70 @@ func TestIncompatibleOperators(t *testing.T) {
 			expect: expect{
 				err:          true,
 				incompatible: nil,
+			},
+		},
+		{
+			description: "ClusterZ",
+			cv: configv1.ClusterVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "version",
+				},
+				Status: configv1.ClusterVersionStatus{
+					Desired: configv1.Update{
+						Version: "1.0.1", // Next Y-stream is 1.1.0, NOT 1.1.1
+					},
+				},
+			},
+			in: skews{
+				{
+					name:                "almond",
+					namespace:           "default",
+					maxOpenShiftVersion: "1.1.2",
+				},
+				{
+					name:                "beech",
+					namespace:           "default",
+					maxOpenShiftVersion: "1.1",
+				},
+			},
+			expect: expect{
+				err:          false,
+				incompatible: nil,
+			},
+		},
+		{
+			description: "ClusterPre",
+			cv: configv1.ClusterVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "version",
+				},
+				Status: configv1.ClusterVersionStatus{
+					Desired: configv1.Update{
+						Version: "1.1.0-pre", // Next Y-stream is 1.1.0, NOT 1.2.0
+					},
+				},
+			},
+			in: skews{
+				{
+					name:                "almond",
+					namespace:           "default",
+					maxOpenShiftVersion: "1.1.0",
+				},
+				{
+					name:                "beech",
+					namespace:           "default",
+					maxOpenShiftVersion: "1.1.0-pre",
+				},
+			},
+			expect: expect{
+				err: false,
+				incompatible: skews{
+					{
+						name:                "beech",
+						namespace:           "default",
+						maxOpenShiftVersion: "1.1.0-pre",
+					},
+				},
 			},
 		},
 	} {


### PR DESCRIPTION
When determining operator compatibility, drop z and build
versions in the calculation of the next Y-stream (minor)
release of OpenShift.

e.g. If the current version is v4.9.5+build, the next Y-stream is
calculated as v4.10.0.

If a pre-release is included, drop it as well but don't increment
the minor version.

e.g. If the current version is v4.10.0-rc, the next Y-stream is
calculated as v4.10.0.

Before this change, the next Y-stream was the result of simply
iterating the cluster's minor version. When the cluster was at
a patch version greater than that specified by an operator, upgrades
would be erroneously blocked.

e.g. If the current version was v4.9.5, the next version would be
calculated as v4.10.5, which would block upgrades on operators with
max versions set to v4.10 -- or more explicitly [v4.10.0, v4.10.5) (')'
is read "exclusive").

Signed-off-by: Nick Hale <njohnhale@gmail.com>
Upstream-repository: operator-lifecycle-manager
Upstream-commit: 760c10d78d6f830b5aa773080847b46557c5986a