### PR TITLE
Bug 1996306: Update kubebuilder installation in the build root dockerfile

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -4,10 +4,20 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.8
 
 ARG KUBEBUILDER_RELEASE=2.3.1
 # Install test dependencies
+# TODO(tflannag): This is a quick fix to kubebuilder's quick start instructions
+# that were failing e2e tests. We'll want to update our o/release ci-operator
+# configuration to allow build_root changes to be reflected in a PR vs.
+# instead of the CI pipeline always defaulting to building the HEAD version
+# of the dockerfile:
+# - https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image
+# Note(tflannag): We ran into some issues curling from the https://go.kubebuilder.io/dl
+# domain as the output file was HTLM-based, so curl from the github releases
+# until this has been resolved.
 RUN yum install -y skopeo && \
     export OS=$(go env GOOS) && \
     export ARCH=$(go env GOARCH) && \
-    curl -L "https://go.kubebuilder.io/dl/${KUBEBUILDER_RELEASE}/${OS}/${ARCH}" | tar -xz -C /tmp/ && \
+    curl -L "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_RELEASE}/kubebuilder_${KUBEBUILDER_RELEASE}_${OS}_${ARCH}.tar.gz" | tar -xz -C /tmp/ && \
     mv /tmp/kubebuilder_${KUBEBUILDER_RELEASE}_${OS}_${ARCH}/ /usr/local/kubebuilder && \
     export PATH=$PATH:/usr/local/kubebuilder/bin && \
+    kubebuilder version && \
     echo "Kubebuilder installation complete!"


### PR DESCRIPTION
Update the base.Dockerfile (the dockerfile specified in the `build_root`
stanza in the o/release ci-operator configuration) and ensure that
kubebuilder can be successfully installed.

The following errors were identified in recent e2e runs:

```bash
$ curl -L "https://go.kubebuilder.io/dl/${KUBEBUILDER_RELEASE}/${OS}/${ARCH}" | tar -xz -C /tmp/
...
Complete!
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100    68  100    68    0     0    230      0 --:--:-- --:--:-- --:--:--   230

100 20604  100 20604    0     0  60958      0 --:--:-- --:--:-- --:--:-- 60958
gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

When inspecting locally, the output file was HTML-based:

```bash
$ file ./kubebuilder
file kubebuilder
kubebuilder: HTML document, UTF-8 Unicode text, with very long lines
```

Replace the kubebuilder release URL to use the github release download
link, instead of the https://go.kubebuilder.io/dl domain.