### PR TITLE
Bug 1994648: fix(sub): Reset ResolutionFailed cond when error is resolved (#2296)

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/subscriptions_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/subscriptions_test.go
@@ -155,6 +155,14 @@ func TestSyncSubscriptions(t *testing.T) {
 						},
 						LastUpdated:           now,
 						InstallPlanGeneration: 1,
+						Conditions: []v1alpha1.SubscriptionCondition{
+							{
+								Type:    "ResolutionFailed",
+								Status:  corev1.ConditionFalse,
+								Reason:  "",
+								Message: "",
+							},
+						},
 					},
 				},
 			},
@@ -298,6 +306,14 @@ func TestSyncSubscriptions(t *testing.T) {
 						},
 						LastUpdated:           now,
 						InstallPlanGeneration: 1,
+						Conditions: []v1alpha1.SubscriptionCondition{
+							{
+								Type:    "ResolutionFailed",
+								Status:  corev1.ConditionFalse,
+								Reason:  "",
+								Message: "",
+							},
+						},
 					},
 				},
 			},
@@ -446,6 +462,14 @@ func TestSyncSubscriptions(t *testing.T) {
 						},
 						InstallPlanGeneration: 1,
 						LastUpdated:           now,
+						Conditions: []v1alpha1.SubscriptionCondition{
+							{
+								Type:    "ResolutionFailed",
+								Status:  corev1.ConditionFalse,
+								Reason:  "",
+								Message: "",
+							},
+						},
 					},
 				},
 			},
@@ -599,6 +623,14 @@ func TestSyncSubscriptions(t *testing.T) {
 						},
 						LastUpdated:           now,
 						InstallPlanGeneration: 1,
+						Conditions: []v1alpha1.SubscriptionCondition{
+							{
+								Type:    "ResolutionFailed",
+								Status:  corev1.ConditionFalse,
+								Reason:  "",
+								Message: "",
+							},
+						},
 					},
 				},
 			},
@@ -775,6 +807,14 @@ func TestSyncSubscriptions(t *testing.T) {
 						},
 						LastUpdated:           now,
 						InstallPlanGeneration: 1,
+						Conditions: []v1alpha1.SubscriptionCondition{
+							{
+								Type:    "ResolutionFailed",
+								Status:  corev1.ConditionFalse,
+								Reason:  "",
+								Message: "",
+							},
+						},
 					},
 				},
 			},
@@ -958,6 +998,14 @@ func TestSyncSubscriptions(t *testing.T) {
 						},
 						LastUpdated:           now,
 						InstallPlanGeneration: 2,
+						Conditions: []v1alpha1.SubscriptionCondition{
+							{
+								Type:    "ResolutionFailed",
+								Status:  corev1.ConditionFalse,
+								Reason:  "",
+								Message: "",
+							},
+						},
 					},
 				},
 			},

--- a/staging/operator-lifecycle-manager/test/e2e/subscription_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/subscription_e2e_test.go
@@ -2113,8 +2113,11 @@ var _ = Describe("Subscription", func() {
 			teardown   func()
 			cleanup    func()
 			packages   []registry.PackageManifest
-			subName    = genName("test-subscription")
-			catSrcName = genName("test-catalog")
+			crd        = newCRD(genName("foo-"))
+			csvA       operatorsv1alpha1.ClusterServiceVersion
+			csvB       operatorsv1alpha1.ClusterServiceVersion
+			subName    = genName("test-subscription-")
+			catSrcName = genName("test-catalog-")
 		)
 
 		BeforeEach(func() {
@@ -2130,10 +2133,9 @@ var _ = Describe("Subscription", func() {
 					DefaultChannelName: "alpha",
 				},
 			}
-			crd := newCRD(genName("foo"))
-			csv := newCSV("csvA", testNamespace, "", semver.MustParse("1.0.0"), nil, []apiextensions.CustomResourceDefinition{crd}, nil)
+			csvA = newCSV("csvA", testNamespace, "", semver.MustParse("1.0.0"), nil, []apiextensions.CustomResourceDefinition{crd}, nil)
 
-			_, teardown = createInternalCatalogSource(c, ctx.Ctx().OperatorClient(), catSrcName, testNamespace, packages, nil, []operatorsv1alpha1.ClusterServiceVersion{csv})
+			_, teardown = createInternalCatalogSource(c, ctx.Ctx().OperatorClient(), catSrcName, testNamespace, packages, nil, []operatorsv1alpha1.ClusterServiceVersion{csvA})
 
 			// Ensure that the catalog source is resolved before we create a subscription.
 			_, err := fetchCatalogSourceOnStatus(crc, catSrcName, testNamespace, catalogSourceRegistryPodSynced)
@@ -2157,6 +2159,31 @@ var _ = Describe("Subscription", func() {
 			}).Should(Equal(corev1.ConditionTrue))
 		})
 
+		When("the required API is made available", func() {
+			BeforeEach(func() {
+				newPkg := registry.PackageManifest{
+					PackageName: "PackageB",
+					Channels: []registry.PackageChannel{
+						{Name: "alpha", CurrentCSVName: "csvB"},
+					},
+					DefaultChannelName: "alpha",
+				}
+				packages = append(packages, newPkg)
+
+				csvB = newCSV("csvB", testNamespace, "", semver.MustParse("1.0.0"), []apiextensions.CustomResourceDefinition{crd}, nil, nil)
+
+				updateInternalCatalog(GinkgoT(), c, crc, catSrcName, testNamespace, []apiextensions.CustomResourceDefinition{crd}, []operatorsv1alpha1.ClusterServiceVersion{csvA, csvB}, packages)
+			})
+			It("the ResolutionFailed condition previously set in it's status that indicated the resolution error is cleared off", func() {
+				Eventually(func() (corev1.ConditionStatus, error) {
+					sub, err := crc.OperatorsV1alpha1().Subscriptions(testNamespace).Get(context.Background(), subName, metav1.GetOptions{})
+					if err != nil {
+						return corev1.ConditionUnknown, err
+					}
+					return sub.Status.GetCondition(operatorsv1alpha1.SubscriptionResolutionFailed).Status, nil
+				}).Should(Equal(corev1.ConditionFalse))
+			})
+		})
 	})
 
 	When("an unannotated ClusterServiceVersion exists with an associated Subscription", func() {


### PR DESCRIPTION
* fix(sub): Reset ResolutionFailed cond when error is resolved

In #2269, a new condition was introduced for Subscription to indicate any
dependency resolution error in it's message. However, when the case of
the error was resolved, the condition status (true) and the message
was sticking around. This PR fixes the issue, and makes sure that the
condition status is set to false, and the message and reason of the
condition are cleared off.

Signed-off-by: Anik Bhattacharjee <anikbhattacharya93@gmail.com>

* refractor updateStatusConditions to split calls to api server into it's own task

Signed-off-by: Anik Bhattacharjee <anikbhattacharya93@gmail.com>

* Reduce number of times subscription statues are updated.

The statuses of the subscriptions are updated multiple number of times
while syncing the resolving namespace. This commit switches to preserving
the state of the subscription statues instead, and only updating the
statuses on cluster only when it's neccessary.

Signed-off-by: Anik Bhattacharjee <anikbhattacharya93@gmail.com>

* remove unnecessary continue from loop

Signed-off-by: Anik Bhattacharjee <anikbhattacharya93@gmail.com>

* pass reference of sub to goroutine

Signed-off-by: Anik Bhattacharjee <anikbhattacharya93@gmail.com>

Upstream-repository: operator-lifecycle-manager
Upstream-commit: dedbbed35a1b80352283ec6050df2de82c798478