### PR TITLE
Introduce the .ci-operator.yaml file

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,3 @@
+project_image:
+  context_dir: .
+  dockerfile_path: base.Dockerfile


### PR DESCRIPTION
Allows us to control the build_root ci-operator configuration for
o/operator-framework-olm in the repository vs. in o/release. This allows
us to make changes to the build root Dockerfile (base.Dockerfile) and
have those changes get tested in the same PR. Previously, the build root
Dockerfile was always built using the HEAD version, which led to
situations where you would need to first merge (blindly) to master, then
open a PR to test those changes worked.