### PR TITLE
fail gracefully when client-ca file is not set or doesn't exist

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/lib/server/server.go
+++ b/staging/operator-lifecycle-manager/pkg/lib/server/server.go
@@ -32,7 +32,7 @@ func GetListenAndServeFunc(logger *logrus.Logger, tlsCertPath, tlsKeyPath, clien
 
 		certStore, err := filemonitor.NewCertStore(*tlsCertPath, *tlsKeyPath)
 		if err != nil {
-			return nil, fmt.Errorf("Certificate monitoring for metrics (https) failed: %v", err)
+			return nil, fmt.Errorf("certificate monitoring for metrics (https) failed: %v", err)
 		}
 
 		csw, err := filemonitor.NewWatch(logger, []string{filepath.Dir(*tlsCertPath), filepath.Dir(*tlsKeyPath)}, certStore.HandleFilesystemUpdate)
@@ -41,6 +41,9 @@ func GetListenAndServeFunc(logger *logrus.Logger, tlsCertPath, tlsKeyPath, clien
 		}
 		csw.Run(context.Background())
 		certPoolStore, err := filemonitor.NewCertPoolStore(*clientCAPath)
+		if err != nil {
+			return nil, fmt.Errorf("certificate monitoring for client-ca failed: %v", err)
+		}
 		cpsw, err := filemonitor.NewWatch(logger, []string{filepath.Dir(*clientCAPath)}, certPoolStore.HandleCABundleUpdate)
 		if err != nil {
 			return nil, fmt.Errorf("error creating cert file watcher: %v", err)


### PR DESCRIPTION
There is not validation enforcing that the `--client-ca` flag be set.  Even if there was, we are currently eating the error on `NewCertPoolStore` if, for example, the file does not exist.  This results in a nil deref farther down the code path.

The PR returns on error so we gracefully handle the situation.