### PR TITLE
[release-4.9] Test Commit - Reduce flake attempts during e2e runs

### DIFF
--- a/staging/operator-lifecycle-manager/Makefile
+++ b/staging/operator-lifecycle-manager/Makefile
@@ -121,7 +121,17 @@ setup-bare: clean e2e.namespace
 
 # e2e test exculding the rh-operators directory which tests rh-operators and their metric cardinality.
 e2e:
-	go test -v $(MOD_FLAGS)  -failfast -timeout 150m ./test/e2e/... -namespace=openshift-operators -kubeconfig=${KUBECONFIG} -olmNamespace=openshift-operator-lifecycle-manager -dummyImage=bitnami/nginx:latest -ginkgo.flakeAttempts=3
+	$(GINKGO) \
+        ./test/e2e \
+        -flakeAttempts 1 \
+        -randomizeAllSpecs \
+        -v \
+        -timeout 120m \
+        $< -- \
+        -namespace=openshift-operators \
+        -kubeconfig=${KUBECONFIG} \
+        -olmNamespace=openshift-operator-lifecycle-manager \
+        -dummyImage=bitnami/nginx:latest
 
 ### Start: End To End Tests ###
 


### PR DESCRIPTION
Test commit to trigger a 4.9 e2e run without any flake attempts being specified.