### PR TITLE
Bug 2016228: Use arguments to configure pprof-secret

### DIFF
--- a/cmd/collect-profiles/main.go
+++ b/cmd/collect-profiles/main.go
@@ -31,7 +31,6 @@ import (
 
 const (
 	profileConfigMapLabelKey = "olm.openshift.io/pprof"
-	olmNamespace             = "openshift-operator-lifecycle-manager"
 	pprofSecretName          = "pprof-cert"
 )
 
@@ -318,7 +317,7 @@ func requestURLBody(httpClient *http.Client, u *url.URL) ([]byte, error) {
 
 func populateServingCert(ctx context.Context, client client.Client) error {
 	secret := &corev1.Secret{}
-	err := client.Get(ctx, types.NamespacedName{Namespace: olmNamespace, Name: pprofSecretName}, secret)
+	err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: pprofSecretName}, secret)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Problem: The secret used to establish a secure connection with
OLM's pprof endpoint is hardcoded to the
openshift-operator-lifecycle-manager namespace. This cannot work
if OLM is not running in that namespace, as is the case on
HyperShift clusters.

Solutions: Allow users to configure the namespace for the pprof
credentials secret.