### PR TITLE
Bug 2022472: opm validate: fail on duplicate packages, channels, and bundles (#824)

### DIFF
--- a/staging/operator-registry/internal/declcfg/declcfg_to_model.go
+++ b/staging/operator-registry/internal/declcfg/declcfg_to_model.go
@@ -17,6 +17,10 @@ func ConvertToModel(cfg DeclarativeConfig) (model.Model, error) {
 			return nil, fmt.Errorf("config contains package with no name")
 		}
 
+		if _, ok := mpkgs[p.Name]; ok {
+			return nil, fmt.Errorf("duplicate package %q", p.Name)
+		}
+
 		mpkg := &model.Package{
 			Name:        p.Name,
 			Description: p.Description,
@@ -41,6 +45,10 @@ func ConvertToModel(cfg DeclarativeConfig) (model.Model, error) {
 
 		if c.Name == "" {
 			return nil, fmt.Errorf("package %q contains channel with no name", c.Package)
+		}
+
+		if _, ok := mpkg.Channels[c.Name]; ok {
+			return nil, fmt.Errorf("package %q has duplicate channel %q", c.Package, c.Name)
 		}
 
 		mch := &model.Channel{
@@ -74,6 +82,10 @@ func ConvertToModel(cfg DeclarativeConfig) (model.Model, error) {
 		}
 	}
 
+	// packageBundles tracks the set of bundle names for each package
+	// and is used to detect duplicate bundles.
+	packageBundles := map[string]sets.String{}
+
 	for _, b := range cfg.Bundles {
 		if b.Package == "" {
 			return nil, fmt.Errorf("package name must be set for bundle %q", b.Name)
@@ -82,6 +94,16 @@ func ConvertToModel(cfg DeclarativeConfig) (model.Model, error) {
 		if !ok {
 			return nil, fmt.Errorf("unknown package %q for bundle %q", b.Package, b.Name)
 		}
+
+		bundles, ok := packageBundles[b.Package]
+		if !ok {
+			bundles = sets.NewString()
+		}
+		if bundles.Has(b.Name) {
+			return nil, fmt.Errorf("package %q has duplicate bundle %q", b.Package, b.Name)
+		}
+		bundles.Insert(b.Name)
+		packageBundles[b.Package] = bundles
 
 		props, err := property.Parse(b.Properties)
 		if err != nil {

--- a/staging/operator-registry/internal/declcfg/declcfg_to_model_test.go
+++ b/staging/operator-registry/internal/declcfg/declcfg_to_model_test.go
@@ -195,6 +195,42 @@ func TestConvertToModel(t *testing.T) {
 			},
 		},
 		{
+			name:      "Error/DuplicatePackage",
+			assertion: hasError(`duplicate package "foo"`),
+			cfg: DeclarativeConfig{
+				Packages: []Package{
+					newTestPackage("foo", "alpha", svgSmallCircle),
+					newTestPackage("foo", "alpha", svgSmallCircle),
+				},
+				Channels: []Channel{newTestChannel("foo", "alpha", ChannelEntry{Name: "foo.v0.1.0"})},
+				Bundles:  []Bundle{newTestBundle("foo", "0.1.0")},
+			},
+		},
+		{
+			name:      "Error/DuplicateChannel",
+			assertion: hasError(`package "foo" has duplicate channel "alpha"`),
+			cfg: DeclarativeConfig{
+				Packages: []Package{newTestPackage("foo", "alpha", svgSmallCircle)},
+				Channels: []Channel{
+					newTestChannel("foo", "alpha", ChannelEntry{Name: "foo.v0.1.0"}),
+					newTestChannel("foo", "alpha", ChannelEntry{Name: "foo.v0.1.0"}),
+				},
+				Bundles: []Bundle{newTestBundle("foo", "0.1.0")},
+			},
+		},
+		{
+			name:      "Error/DuplicateBundle",
+			assertion: hasError(`package "foo" has duplicate bundle "foo.v0.1.0"`),
+			cfg: DeclarativeConfig{
+				Packages: []Package{newTestPackage("foo", "alpha", svgSmallCircle)},
+				Channels: []Channel{newTestChannel("foo", "alpha", ChannelEntry{Name: "foo.v0.1.0"})},
+				Bundles: []Bundle{
+					newTestBundle("foo", "0.1.0"),
+					newTestBundle("foo", "0.1.0"),
+				},
+			},
+		},
+		{
 			name:      "Success/ValidModel",
 			assertion: require.NoError,
 			cfg: DeclarativeConfig{
@@ -233,7 +269,7 @@ func hasError(expectedError string) require.ErrorAssertionFunc {
 		if stdt, ok := t.(*testing.T); ok {
 			stdt.Helper()
 		}
-		if actualError.Error() == expectedError {
+		if actualError != nil && actualError.Error() == expectedError {
 			return
 		}
 		t.Errorf("expected error to be `%s`, got `%s`", expectedError, actualError)

--- a/vendor/github.com/operator-framework/operator-registry/internal/declcfg/declcfg_to_model.go
+++ b/vendor/github.com/operator-framework/operator-registry/internal/declcfg/declcfg_to_model.go
@@ -17,6 +17,10 @@ func ConvertToModel(cfg DeclarativeConfig) (model.Model, error) {
 			return nil, fmt.Errorf("config contains package with no name")
 		}
 
+		if _, ok := mpkgs[p.Name]; ok {
+			return nil, fmt.Errorf("duplicate package %q", p.Name)
+		}
+
 		mpkg := &model.Package{
 			Name:        p.Name,
 			Description: p.Description,
@@ -41,6 +45,10 @@ func ConvertToModel(cfg DeclarativeConfig) (model.Model, error) {
 
 		if c.Name == "" {
 			return nil, fmt.Errorf("package %q contains channel with no name", c.Package)
+		}
+
+		if _, ok := mpkg.Channels[c.Name]; ok {
+			return nil, fmt.Errorf("package %q has duplicate channel %q", c.Package, c.Name)
 		}
 
 		mch := &model.Channel{
@@ -74,6 +82,10 @@ func ConvertToModel(cfg DeclarativeConfig) (model.Model, error) {
 		}
 	}
 
+	// packageBundles tracks the set of bundle names for each package
+	// and is used to detect duplicate bundles.
+	packageBundles := map[string]sets.String{}
+
 	for _, b := range cfg.Bundles {
 		if b.Package == "" {
 			return nil, fmt.Errorf("package name must be set for bundle %q", b.Name)
@@ -82,6 +94,16 @@ func ConvertToModel(cfg DeclarativeConfig) (model.Model, error) {
 		if !ok {
 			return nil, fmt.Errorf("unknown package %q for bundle %q", b.Package, b.Name)
 		}
+
+		bundles, ok := packageBundles[b.Package]
+		if !ok {
+			bundles = sets.NewString()
+		}
+		if bundles.Has(b.Name) {
+			return nil, fmt.Errorf("package %q has duplicate bundle %q", b.Package, b.Name)
+		}
+		bundles.Insert(b.Name)
+		packageBundles[b.Package] = bundles
 
 		props, err := property.Parse(b.Properties)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>

Upstream-repository: operator-registry
Upstream-commit: 7a789fe0bcab1e3116de33089184f4af8b21ce2f
