### PR TITLE
[WIP] Add cluster runtime constraints handling

### DIFF
--- a/manifests/0000_50_olm_08-catalog-operator.deployment.ibm-cloud-managed.yaml
+++ b/manifests/0000_50_olm_08-catalog-operator.deployment.ibm-cloud-managed.yaml
@@ -78,6 +78,8 @@ spec:
           env:
             - name: RELEASE_VERSION
               value: "0.0.1-snapshot"
+            - name: RUNTIME_CONSTRAINTS
+              value: "/opt/olm/runtime_constraints.json"
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:

--- a/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -79,6 +79,8 @@ spec:
           env:
             - name: RELEASE_VERSION
               value: "0.0.1-snapshot"
+            - name: RUNTIME_CONSTRAINTS
+              value: "/opt/olm/runtime_constraints.json"
       nodeSelector:
         kubernetes.io/os: linux
         node-role.kubernetes.io/master: ""

--- a/operator-lifecycle-manager.Dockerfile
+++ b/operator-lifecycle-manager.Dockerfile
@@ -27,6 +27,9 @@ COPY --from=builder /build/bin/package-server /bin/package-server
 COPY --from=builder /build/bin/cpb /bin/cpb
 COPY --from=builder /build/bin/psm /bin/psm
 
+# Add runtime constraints
+COPY --from=builder /build/runtime_constraints/runtime_constraints.json /opt/olm/runtime_constraints.json
+
 # This image doesn't need to run as root user.
 USER 1001
 

--- a/runtime_constraints/README.md
+++ b/runtime_constraints/README.md
@@ -1,0 +1,11 @@
+# Cluster Runtime Constraints
+
+Cluster runtime constraints are base constraints that always get applied to the resolution process to avoid installing
+packages that might be unsuitable for the cluster (consumes too many resources, wrong kubernetes/ocp version, etc.). 
+Currently, there's no first class way to do this. Until we design the canonical way to define
+cluster runtime constraints, we are making availing a stopgap solution for IBM and OCP, we:
+  1. Are adding a file to the downstream OLM image that includes the runtime constraints
+  2. Have modified the upstream catalog operator to load the runtime constraints in to the resolver if a `RUNTIME_CONSTRAINTS` environment variable is defined
+  3. Update the deployment manifests for the olm catalog operator deployment to add the `RUNTIME_CONSTRAINTS` environment variable
+
+The upstream PR enabling this behavior is [https://github.com/operator-framework/operator-lifecycle-manager/pull/2498](#2498).

--- a/runtime_constraints/runtime_constraints.json
+++ b/runtime_constraints/runtime_constraints.json
@@ -1,0 +1,11 @@
+{
+  "properties": [
+    {
+      "type": "olm.package",
+      "value": {
+        "packageName": "etcd",
+        "version": "1.0.0"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Signed-off-by: Per G. da Silva <perdasilva@redhat.com>

# Description
This the downstream component of the work being done in https://github.com/operator-framework/operator-lifecycle-manager/pull/2498 to enable side loading of runtime constraints. Here, we add the runtime constratins file the operator image and update the olm catalog operator deployment manifest to include the environment variable (`RUNTIME_CONSTRAINTS`), which points to the runtime constraints file in the local filesystem, and enables the feature
