### PR TITLE
Sync olm 12-10-21

### DIFF
--- a/staging/operator-lifecycle-manager/.github/workflows/build.yml
+++ b/staging/operator-lifecycle-manager/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: ci
+name: build
 on:
   pull_request:
     paths-ignore:

--- a/staging/operator-lifecycle-manager/.github/workflows/build.yml
+++ b/staging/operator-lifecycle-manager/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: build
 on:
   pull_request:
-    paths-ignore:
-    - '**/*.md'
 jobs:
   image:
     runs-on: ubuntu-latest

--- a/staging/operator-lifecycle-manager/.github/workflows/e2e-tests.yml
+++ b/staging/operator-lifecycle-manager/.github/workflows/e2e-tests.yml
@@ -1,4 +1,4 @@
-name: ci
+name: e2e
 on:
   push:
     branches:

--- a/staging/operator-lifecycle-manager/.github/workflows/e2e-tests.yml
+++ b/staging/operator-lifecycle-manager/.github/workflows/e2e-tests.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - master
   pull_request:
-    paths-ignore:
-    - '**/*.md'
 jobs:
   e2e-tests:
     runs-on: ubuntu-latest

--- a/staging/operator-lifecycle-manager/.github/workflows/goreleaser.yaml
+++ b/staging/operator-lifecycle-manager/.github/workflows/goreleaser.yaml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/staging/operator-lifecycle-manager/.github/workflows/run-kind-local.yml
+++ b/staging/operator-lifecycle-manager/.github/workflows/run-kind-local.yml
@@ -1,8 +1,6 @@
 name: run-olm-kind
 on:
   pull_request:
-    paths-ignore:
-    - '**/*.md'
   schedule:
   - cron: '0 0 * * *' # daily to pick up releases
 jobs:

--- a/staging/operator-lifecycle-manager/.github/workflows/run-kind-local.yml
+++ b/staging/operator-lifecycle-manager/.github/workflows/run-kind-local.yml
@@ -1,4 +1,4 @@
-name: ci
+name: run-olm-kind
 on:
   pull_request:
     paths-ignore:

--- a/staging/operator-lifecycle-manager/.github/workflows/run-minikube-local.yml
+++ b/staging/operator-lifecycle-manager/.github/workflows/run-minikube-local.yml
@@ -1,4 +1,4 @@
-name: ci
+name: run-olm-minikube
 on:
   pull_request:
     paths-ignore:

--- a/staging/operator-lifecycle-manager/.github/workflows/run-minikube-local.yml
+++ b/staging/operator-lifecycle-manager/.github/workflows/run-minikube-local.yml
@@ -1,8 +1,6 @@
 name: run-olm-minikube
 on:
   pull_request:
-    paths-ignore:
-    - '**/*.md'
   schedule:
   - cron: '0 0 * * *' # daily to pick up releases
 jobs:

--- a/staging/operator-lifecycle-manager/.github/workflows/sanity.yaml
+++ b/staging/operator-lifecycle-manager/.github/workflows/sanity.yaml
@@ -1,5 +1,4 @@
-name: ci
-
+name: sanity
 on:
   push:
     branches:
@@ -7,7 +6,6 @@ on:
   pull_request:
     paths-ignore:
     - '**/*.md'
-
 jobs:
   sanity:
     runs-on: ubuntu-latest

--- a/staging/operator-lifecycle-manager/.github/workflows/sanity.yaml
+++ b/staging/operator-lifecycle-manager/.github/workflows/sanity.yaml
@@ -4,8 +4,6 @@ on:
     branches:
       - '**'
   pull_request:
-    paths-ignore:
-    - '**/*.md'
 jobs:
   sanity:
     runs-on: ubuntu-latest

--- a/staging/operator-lifecycle-manager/.github/workflows/unit.yml
+++ b/staging/operator-lifecycle-manager/.github/workflows/unit.yml
@@ -1,4 +1,4 @@
-name: ci
+name: unit
 on:
   push:
     branches:

--- a/staging/operator-lifecycle-manager/.github/workflows/unit.yml
+++ b/staging/operator-lifecycle-manager/.github/workflows/unit.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - master
   pull_request:
-    paths-ignore:
-    - '**/*.md'
 jobs:
   unit:
     runs-on: ubuntu-latest

--- a/staging/operator-lifecycle-manager/.github/workflows/verify.yml
+++ b/staging/operator-lifecycle-manager/.github/workflows/verify.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - master
   pull_request:
-    paths-ignore:
-    - '**/*.md'
 jobs:
   verify:
     runs-on: ubuntu-latest

--- a/staging/operator-lifecycle-manager/.github/workflows/verify.yml
+++ b/staging/operator-lifecycle-manager/.github/workflows/verify.yml
@@ -1,4 +1,4 @@
-name: ci
+name: verify
 on:
   push:
     branches:

--- a/staging/operator-lifecycle-manager/DEVELOPMENT.md
+++ b/staging/operator-lifecycle-manager/DEVELOPMENT.md
@@ -27,6 +27,8 @@
 
 This project uses the built-in testing support for golang.
 
+Envtest is also used and needs to be set up. Follow [controller-runtime instructions] and set `KUBEBUILDER_ASSETS` environment variable to point to the installation directory, for instance: `/usr/local/kubebuilder/bin`.
+
 To run the tests for all go packages outside of the vendor directory, run:
 ```sh
 $ make test
@@ -46,11 +48,14 @@ To run a specific e2e test locally:
 $ make e2e-local TEST=TestCreateInstallPlanManualApproval
 ```
 
+[controller-runtime instructions]: https://pkg.go.dev/sigs.k8s.io/controller-runtime/tools/setup-envtest#section-readme
+
 #### Building
 
-Ensure your version of go is up to date; check that you're running v1.9 with the
-command:
+Ensure your version of go is up to date; check that you're running the same version as in go.mod with the
+commands:
 ```sh
+$ head go.mod
 $ go version
 ```
 

--- a/staging/operator-lifecycle-manager/MAINTAINERS.md
+++ b/staging/operator-lifecycle-manager/MAINTAINERS.md
@@ -1,0 +1,12 @@
+This page lists all active maintainers of this repository.
+
+See [CONTRIBUTING.md](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md)
+for general contribution guidelines.
+
+## Maintainers (in alphabetical order)
+
+- [Alexander Greene](github.com/awgreene), Red Hat
+- [Evan Cordell](github.com/ecordell), Authzed
+- [Kevin Rizza](github.com/kevinrizza), Red Hat
+- [Nick Hale](github.com/njhale), Red Hat
+- [Vu Dinh](github.com/dinhxuanvu), Red Hat

--- a/staging/operator-lifecycle-manager/cmd/catalog/main.go
+++ b/staging/operator-lifecycle-manager/cmd/catalog/main.go
@@ -92,8 +92,6 @@ func main() {
 	// Check if version flag was set
 	if *version {
 		fmt.Print(olmversion.String())
-
-		// Exit early
 		os.Exit(0)
 	}
 
@@ -111,7 +109,7 @@ func main() {
 
 	listenAndServe, err := server.GetListenAndServeFunc(server.WithLogger(logger), server.WithTLS(tlsCertPath, tlsKeyPath, clientCAPath), server.WithDebug(*debug))
 	if err != nil {
-		logger.Fatal("Error setting up health/metric/pprof service: %v", err)
+		logger.Fatalf("Error setting up health/metric/pprof service: %v", err)
 	}
 
 	go func() {
@@ -138,12 +136,12 @@ func main() {
 	// Create a new instance of the operator.
 	op, err := catalog.NewOperator(ctx, *kubeConfigPath, utilclock.RealClock{}, logger, *wakeupInterval, *configmapServerImage, *opmImage, *utilImage, *catalogNamespace, k8sscheme.Scheme, *installPlanTimeout, *bundleUnpackTimeout)
 	if err != nil {
-		log.Panicf("error configuring catalog operator: %s", err.Error())
+		log.Fatalf("error configuring catalog operator: %s", err.Error())
 	}
 
 	opCatalogTemplate, err := catalogtemplate.NewOperator(ctx, *kubeConfigPath, logger, *wakeupInterval, *catalogNamespace)
 	if err != nil {
-		log.Panicf("error configuring catalog template operator: %s", err.Error())
+		log.Fatalf("error configuring catalog template operator: %s", err.Error())
 	}
 
 	op.Run(ctx)

--- a/staging/operator-lifecycle-manager/cmd/olm/main.go
+++ b/staging/operator-lifecycle-manager/cmd/olm/main.go
@@ -120,7 +120,7 @@ func main() {
 
 	listenAndServe, err := server.GetListenAndServeFunc(server.WithLogger(logger), server.WithTLS(tlsCertPath, tlsKeyPath, clientCAPath), server.WithDebug(*debug))
 	if err != nil {
-		logger.Fatal("Error setting up health/metric/pprof service: %v", err)
+		logger.Fatalf("Error setting up health/metric/pprof service: %v", err)
 	}
 
 	go func() {
@@ -131,7 +131,7 @@ func main() {
 
 	mgr, err := Manager(ctx, *debug)
 	if err != nil {
-		logger.WithError(err).Fatalf("error configuring controller manager")
+		logger.WithError(err).Fatal("error configuring controller manager")
 	}
 	config := mgr.GetConfig()
 
@@ -164,7 +164,7 @@ func main() {
 		olm.WithConfigClient(versionedConfigClient),
 	)
 	if err != nil {
-		logger.WithError(err).Fatalf("error configuring operator")
+		logger.WithError(err).Fatal("error configuring operator")
 		return
 	}
 
@@ -182,12 +182,12 @@ func main() {
 			openshift.WithOLMOperator(),
 		)
 		if err != nil {
-			logger.WithError(err).Fatalf("error configuring openshift integration")
+			logger.WithError(err).Fatal("error configuring openshift integration")
 			return
 		}
 
 		if err := reconciler.SetupWithManager(mgr); err != nil {
-			logger.WithError(err).Fatalf("error configuring openshift integration")
+			logger.WithError(err).Fatal("error configuring openshift integration")
 			return
 		}
 	}

--- a/staging/operator-lifecycle-manager/pkg/controller/install/deployment.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/install/deployment.go
@@ -254,7 +254,7 @@ func (i *StrategyDeploymentInstaller) checkForDeployments(deploymentSpecs []v1al
 	// compare deployments to see if any need to be created/updated
 	existingMap := map[string]*appsv1.Deployment{}
 	for _, d := range existingDeployments {
-		existingMap[d.GetName()] = d
+		existingMap[d.GetName()] = d.DeepCopy()
 	}
 	for _, spec := range deploymentSpecs {
 		dep, exists := existingMap[spec.Name]

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilclock "k8s.io/apimachinery/pkg/util/clock"
-	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/apiserver/pkg/storage/names"
 	fakedynamic "k8s.io/client-go/dynamic/fake"
@@ -1302,7 +1301,7 @@ func TestValidateExistingCRs(t *testing.T) {
 	unstructuredForFile := func(file string) *unstructured.Unstructured {
 		data, err := ioutil.ReadFile(file)
 		require.NoError(t, err)
-		dec := k8syaml.NewYAMLOrJSONDecoder(strings.NewReader(string(data)), 30)
+		dec := utilyaml.NewYAMLOrJSONDecoder(strings.NewReader(string(data)), 30)
 		k8sFile := &unstructured.Unstructured{}
 		require.NoError(t, dec.Decode(k8sFile))
 		return k8sFile
@@ -1311,7 +1310,7 @@ func TestValidateExistingCRs(t *testing.T) {
 	unversionedCRDForV1beta1File := func(file string) *apiextensions.CustomResourceDefinition {
 		data, err := ioutil.ReadFile(file)
 		require.NoError(t, err)
-		dec := k8syaml.NewYAMLOrJSONDecoder(strings.NewReader(string(data)), 30)
+		dec := utilyaml.NewYAMLOrJSONDecoder(strings.NewReader(string(data)), 30)
 		k8sFile := &apiextensionsv1beta1.CustomResourceDefinition{}
 		require.NoError(t, dec.Decode(k8sFile))
 		convertedCRD := &apiextensions.CustomResourceDefinition{}

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/labeler.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/labeler.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
-	"github.com/operator-framework/operator-registry/pkg/registry"
 	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	extv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -98,7 +97,7 @@ func labelSetsForCRDv1beta1(crd *extv1beta1.CustomResourceDefinition) ([]labels.
 
 	// Add label sets for each version
 	for _, version := range crd.Spec.Versions {
-		hash, err := cache.APIKeyToGVKHash(registry.APIKey{
+		hash, err := cache.APIKeyToGVKHash(opregistry.APIKey{
 			Group:   crd.Spec.Group,
 			Version: version.Name,
 			Kind:    crd.Spec.Names.Kind,
@@ -129,7 +128,7 @@ func labelSetsForCRDv1(crd *extv1.CustomResourceDefinition) ([]labels.Set, error
 
 	// Add label sets for each version
 	for _, version := range crd.Spec.Versions {
-		hash, err := cache.APIKeyToGVKHash(registry.APIKey{
+		hash, err := cache.APIKeyToGVKHash(opregistry.APIKey{
 			Group:   crd.Spec.Group,
 			Version: version.Name,
 			Kind:    crd.Spec.Names.Kind,

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
@@ -9,7 +9,6 @@ import (
 
 	v1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/sirupsen/logrus"
-	log "github.com/sirupsen/logrus"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -2033,7 +2032,7 @@ func (a *Operator) apiServiceOwnerConflicts(csv *v1alpha1.ClusterServiceVersion)
 
 		adoptable, err := install.IsAPIServiceAdoptable(a.lister, csv, apiService)
 		if err != nil {
-			a.logger.WithFields(log.Fields{"obj": "apiService", "labels": apiService.GetLabels()}).Errorf("adoption check failed - %v", err)
+			a.logger.WithFields(logrus.Fields{"obj": "apiService", "labels": apiService.GetLabels()}).Errorf("adoption check failed - %v", err)
 		}
 
 		if !adoptable {

--- a/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/grpc.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/grpc.go
@@ -9,7 +9,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -326,7 +325,7 @@ func (c *GrpcRegistryReconciler) ensureService(source grpcCatalogSourceDecorator
 	return err
 }
 
-func (c *GrpcRegistryReconciler) ensureSA(source grpcCatalogSourceDecorator) (*v1.ServiceAccount, error) {
+func (c *GrpcRegistryReconciler) ensureSA(source grpcCatalogSourceDecorator) (*corev1.ServiceAccount, error) {
 	sa := source.ServiceAccount()
 	if _, err := c.OpClient.CreateServiceAccount(sa); err != nil {
 		return sa, err

--- a/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/resolver_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/resolver_test.go
@@ -14,7 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
-	"github.com/operator-framework/api/pkg/lib/version"
 	opver "github.com/operator-framework/api/pkg/lib/version"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	listersv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
@@ -1515,7 +1514,7 @@ func TestInferProperties(t *testing.T) {
 					Name: "a",
 				},
 				Spec: v1alpha1.ClusterServiceVersionSpec{
-					Version: version.OperatorVersion{Version: semver.MustParse("1.2.3")},
+					Version: opver.OperatorVersion{Version: semver.MustParse("1.2.3")},
 				},
 			},
 			Subscriptions: []*v1alpha1.Subscription{
@@ -1556,7 +1555,7 @@ func TestInferProperties(t *testing.T) {
 					Name: "a",
 				},
 				Spec: v1alpha1.ClusterServiceVersionSpec{
-					Version: version.OperatorVersion{Version: semver.MustParse("1.2.3")},
+					Version: opver.OperatorVersion{Version: semver.MustParse("1.2.3")},
 				},
 			},
 			Subscriptions: []*v1alpha1.Subscription{
@@ -1585,7 +1584,7 @@ func TestInferProperties(t *testing.T) {
 					Name: "a",
 				},
 				Spec: v1alpha1.ClusterServiceVersionSpec{
-					Version: version.OperatorVersion{Version: semver.MustParse("1.2.3")},
+					Version: opver.OperatorVersion{Version: semver.MustParse("1.2.3")},
 				},
 			},
 			Subscriptions: []*v1alpha1.Subscription{

--- a/staging/operator-lifecycle-manager/test/e2e/collect-ci-artifacts.sh
+++ b/staging/operator-lifecycle-manager/test/e2e/collect-ci-artifacts.sh
@@ -1,0 +1,27 @@
+#! /bin/bash
+
+set -o pipefail
+set -o nounset
+set -o errexit
+
+: "${KUBECONFIG:?}"
+: "${TEST_NAMESPACE:?}"
+: "${TEST_ARTIFACTS_DIR:?}"
+
+mkdir -p "${TEST_ARTIFACTS_DIR}"
+
+commands=()
+commands+=("get catalogsources -o yaml")
+commands+=("get subscriptions -o yaml")
+commands+=("get operatorgroups -o yaml")
+commands+=("get clusterserviceversions -o yaml")
+commands+=("get installplans -o yaml")
+commands+=("get pods -o wide")
+commands+=("get events --sort-by .lastTimestamp")
+
+echo "Storing the test artifact output in the ${TEST_ARTIFACTS_DIR} directory"
+for command in "${commands[@]}"; do
+    echo "Collecting ${command} output..."
+    COMMAND_OUTPUT_FILE=${TEST_ARTIFACTS_DIR}/${command// /_}
+    kubectl -n ${TEST_NAMESPACE} ${command} >> "${COMMAND_OUTPUT_FILE}"
+done

--- a/staging/operator-lifecycle-manager/test/e2e/installplan_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/installplan_e2e_test.go
@@ -37,11 +37,9 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	opver "github.com/operator-framework/api/pkg/lib/version"
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/bundle"
@@ -614,7 +612,7 @@ var _ = Describe("Install Plan", func() {
 			Expect(ctx.Ctx().Client().Create(context.Background(), plan)).To(Succeed())
 			Expect(ctx.Ctx().Client().Status().Update(context.Background(), plan)).To(Succeed())
 
-			key := runtimeclient.ObjectKeyFromObject(plan)
+			key := client.ObjectKeyFromObject(plan)
 
 			Eventually(func() (*operatorsv1alpha1.InstallPlan, error) {
 				return plan, ctx.Ctx().Client().Get(context.Background(), key, plan)
@@ -3198,9 +3196,9 @@ var _ = Describe("Install Plan", func() {
 			fetchedInstallPlan, err := fetchInstallPlanWithNamespace(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseInstalling))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fetchedInstallPlan).NotTo(BeNil())
-			cond := v1alpha1.InstallPlanCondition{Type: v1alpha1.InstallPlanInstalled, Status: corev1.ConditionFalse, Reason: v1alpha1.InstallPlanReasonInstallCheckFailed,
+			cond := operatorsv1alpha1.InstallPlanCondition{Type: operatorsv1alpha1.InstallPlanInstalled, Status: corev1.ConditionFalse, Reason: operatorsv1alpha1.InstallPlanReasonInstallCheckFailed,
 				Message: "no operator group found that is managing this namespace"}
-			Expect(fetchedInstallPlan.Status.Phase).To(Equal(v1alpha1.InstallPlanPhaseInstalling))
+			Expect(fetchedInstallPlan.Status.Phase).To(Equal(operatorsv1alpha1.InstallPlanPhaseInstalling))
 			Expect(hasCondition(fetchedInstallPlan, cond)).To(BeTrue())
 
 			// Create an operatorgroup for the same namespace
@@ -3316,7 +3314,7 @@ var _ = Describe("Install Plan", func() {
 				},
 				Spec: operatorsv1alpha1.InstallPlanSpec{
 					ClusterServiceVersionNames: []string{"foobar"},
-					Approval:                   v1alpha1.ApprovalAutomatic,
+					Approval:                   operatorsv1alpha1.ApprovalAutomatic,
 					Approved:                   true,
 				},
 				Status: operatorsv1alpha1.InstallPlanStatus{
@@ -3676,7 +3674,7 @@ var _ = Describe("Install Plan", func() {
 		Expect(ctx.Ctx().Client().Create(context.Background(), plan)).To(Succeed())
 		Expect(ctx.Ctx().Client().Status().Update(context.Background(), plan)).To(Succeed())
 
-		key := runtimeclient.ObjectKeyFromObject(plan)
+		key := client.ObjectKeyFromObject(plan)
 
 		Eventually(func() (*operatorsv1alpha1.InstallPlan, error) {
 			return plan, ctx.Ctx().Client().Get(context.Background(), key, plan)
@@ -3747,7 +3745,7 @@ var _ = Describe("Install Plan", func() {
 		Expect(ctx.Ctx().Client().Create(context.Background(), newPlan)).To(Succeed())
 		Expect(ctx.Ctx().Client().Status().Update(context.Background(), newPlan)).To(Succeed())
 
-		newKey := runtimeclient.ObjectKeyFromObject(newPlan)
+		newKey := client.ObjectKeyFromObject(newPlan)
 
 		Eventually(func() (*operatorsv1alpha1.InstallPlan, error) {
 			return newPlan, ctx.Ctx().Client().Get(context.Background(), newKey, newPlan)
@@ -3946,7 +3944,7 @@ var _ = Describe("Install Plan", func() {
 		Expect(ctx.Ctx().Client().Create(context.Background(), plan)).To(Succeed())
 		Expect(ctx.Ctx().Client().Status().Update(context.Background(), plan)).To(Succeed())
 
-		key := runtimeclient.ObjectKeyFromObject(plan)
+		key := client.ObjectKeyFromObject(plan)
 
 		Eventually(func() (*operatorsv1alpha1.InstallPlan, error) {
 			return plan, ctx.Ctx().Client().Get(context.Background(), key, plan)
@@ -3992,7 +3990,7 @@ var _ = Describe("Install Plan", func() {
 		Expect(ctx.Ctx().Client().Create(context.Background(), newPlan)).To(Succeed())
 		Expect(ctx.Ctx().Client().Status().Update(context.Background(), newPlan)).To(Succeed())
 
-		newKey := runtimeclient.ObjectKeyFromObject(newPlan)
+		newKey := client.ObjectKeyFromObject(newPlan)
 
 		Eventually(func() (*operatorsv1alpha1.InstallPlan, error) {
 			return newPlan, ctx.Ctx().Client().Get(context.Background(), newKey, newPlan)
@@ -4286,7 +4284,7 @@ func newInstallPlanWithDummySteps(name, namespace string, phase operatorsv1alpha
 	}
 }
 
-func hasCondition(ip *v1alpha1.InstallPlan, expectedCondition v1alpha1.InstallPlanCondition) bool {
+func hasCondition(ip *operatorsv1alpha1.InstallPlan, expectedCondition operatorsv1alpha1.InstallPlanCondition) bool {
 	for _, cond := range ip.Status.Conditions {
 		if cond.Type == expectedCondition.Type && cond.Message == expectedCondition.Message && cond.Status == expectedCondition.Status {
 			return true

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/cmd/catalog/main.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/cmd/catalog/main.go
@@ -92,8 +92,6 @@ func main() {
 	// Check if version flag was set
 	if *version {
 		fmt.Print(olmversion.String())
-
-		// Exit early
 		os.Exit(0)
 	}
 
@@ -111,7 +109,7 @@ func main() {
 
 	listenAndServe, err := server.GetListenAndServeFunc(server.WithLogger(logger), server.WithTLS(tlsCertPath, tlsKeyPath, clientCAPath), server.WithDebug(*debug))
 	if err != nil {
-		logger.Fatal("Error setting up health/metric/pprof service: %v", err)
+		logger.Fatalf("Error setting up health/metric/pprof service: %v", err)
 	}
 
 	go func() {
@@ -138,12 +136,12 @@ func main() {
 	// Create a new instance of the operator.
 	op, err := catalog.NewOperator(ctx, *kubeConfigPath, utilclock.RealClock{}, logger, *wakeupInterval, *configmapServerImage, *opmImage, *utilImage, *catalogNamespace, k8sscheme.Scheme, *installPlanTimeout, *bundleUnpackTimeout)
 	if err != nil {
-		log.Panicf("error configuring catalog operator: %s", err.Error())
+		log.Fatalf("error configuring catalog operator: %s", err.Error())
 	}
 
 	opCatalogTemplate, err := catalogtemplate.NewOperator(ctx, *kubeConfigPath, logger, *wakeupInterval, *catalogNamespace)
 	if err != nil {
-		log.Panicf("error configuring catalog template operator: %s", err.Error())
+		log.Fatalf("error configuring catalog template operator: %s", err.Error())
 	}
 
 	op.Run(ctx)

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/cmd/olm/main.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/cmd/olm/main.go
@@ -120,7 +120,7 @@ func main() {
 
 	listenAndServe, err := server.GetListenAndServeFunc(server.WithLogger(logger), server.WithTLS(tlsCertPath, tlsKeyPath, clientCAPath), server.WithDebug(*debug))
 	if err != nil {
-		logger.Fatal("Error setting up health/metric/pprof service: %v", err)
+		logger.Fatalf("Error setting up health/metric/pprof service: %v", err)
 	}
 
 	go func() {
@@ -131,7 +131,7 @@ func main() {
 
 	mgr, err := Manager(ctx, *debug)
 	if err != nil {
-		logger.WithError(err).Fatalf("error configuring controller manager")
+		logger.WithError(err).Fatal("error configuring controller manager")
 	}
 	config := mgr.GetConfig()
 
@@ -164,7 +164,7 @@ func main() {
 		olm.WithConfigClient(versionedConfigClient),
 	)
 	if err != nil {
-		logger.WithError(err).Fatalf("error configuring operator")
+		logger.WithError(err).Fatal("error configuring operator")
 		return
 	}
 
@@ -182,12 +182,12 @@ func main() {
 			openshift.WithOLMOperator(),
 		)
 		if err != nil {
-			logger.WithError(err).Fatalf("error configuring openshift integration")
+			logger.WithError(err).Fatal("error configuring openshift integration")
 			return
 		}
 
 		if err := reconciler.SetupWithManager(mgr); err != nil {
-			logger.WithError(err).Fatalf("error configuring openshift integration")
+			logger.WithError(err).Fatal("error configuring openshift integration")
 			return
 		}
 	}

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install/deployment.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install/deployment.go
@@ -254,7 +254,7 @@ func (i *StrategyDeploymentInstaller) checkForDeployments(deploymentSpecs []v1al
 	// compare deployments to see if any need to be created/updated
 	existingMap := map[string]*appsv1.Deployment{}
 	for _, d := range existingDeployments {
-		existingMap[d.GetName()] = d
+		existingMap[d.GetName()] = d.DeepCopy()
 	}
 	for _, spec := range deploymentSpecs {
 		dep, exists := existingMap[spec.Name]

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/labeler.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/labeler.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
-	"github.com/operator-framework/operator-registry/pkg/registry"
 	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	extv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -98,7 +97,7 @@ func labelSetsForCRDv1beta1(crd *extv1beta1.CustomResourceDefinition) ([]labels.
 
 	// Add label sets for each version
 	for _, version := range crd.Spec.Versions {
-		hash, err := cache.APIKeyToGVKHash(registry.APIKey{
+		hash, err := cache.APIKeyToGVKHash(opregistry.APIKey{
 			Group:   crd.Spec.Group,
 			Version: version.Name,
 			Kind:    crd.Spec.Names.Kind,
@@ -129,7 +128,7 @@ func labelSetsForCRDv1(crd *extv1.CustomResourceDefinition) ([]labels.Set, error
 
 	// Add label sets for each version
 	for _, version := range crd.Spec.Versions {
-		hash, err := cache.APIKeyToGVKHash(registry.APIKey{
+		hash, err := cache.APIKeyToGVKHash(opregistry.APIKey{
 			Group:   crd.Spec.Group,
 			Version: version.Name,
 			Kind:    crd.Spec.Names.Kind,

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
@@ -9,7 +9,6 @@ import (
 
 	v1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/sirupsen/logrus"
-	log "github.com/sirupsen/logrus"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -2033,7 +2032,7 @@ func (a *Operator) apiServiceOwnerConflicts(csv *v1alpha1.ClusterServiceVersion)
 
 		adoptable, err := install.IsAPIServiceAdoptable(a.lister, csv, apiService)
 		if err != nil {
-			a.logger.WithFields(log.Fields{"obj": "apiService", "labels": apiService.GetLabels()}).Errorf("adoption check failed - %v", err)
+			a.logger.WithFields(logrus.Fields{"obj": "apiService", "labels": apiService.GetLabels()}).Errorf("adoption check failed - %v", err)
 		}
 
 		if !adoptable {

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/grpc.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/grpc.go
@@ -9,7 +9,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -326,7 +325,7 @@ func (c *GrpcRegistryReconciler) ensureService(source grpcCatalogSourceDecorator
 	return err
 }
 
-func (c *GrpcRegistryReconciler) ensureSA(source grpcCatalogSourceDecorator) (*v1.ServiceAccount, error) {
+func (c *GrpcRegistryReconciler) ensureSA(source grpcCatalogSourceDecorator) (*corev1.ServiceAccount, error) {
 	sa := source.ServiceAccount()
 	if _, err := c.OpClient.CreateServiceAccount(sa); err != nil {
 		return sa, err


### PR DESCRIPTION
Note: https://github.com/operator-framework/operator-lifecycle-manager/pull/2216 it yet to make it in this repo due to a failing e2e test. (refer: [bz](https://bugzilla.redhat.com/show_bug.cgi?id=1952576))

[This upstream commit](https://github.com/operator-framework/operator-lifecycle-manager/commit/3949ceb4dc8cb5668c621904a402de4186f4ea26) being introduced in this PR touches a [part of the code](https://github.com/operator-framework/operator-lifecycle-manager/pull/2216/files#diff-52ebf4e1c25c87743e2d504e8015be1767d6140aadf638304142cdbb54216b3eR174-R178) that was introduced in the above mentioned PR. The commit's been amended to keep all other changes in it, with the exception of the change in the code that's missing in this repo.  