### PR TITLE
Bug 2037168: Remove incorrect cvo annotations

### DIFF
--- a/manifests/0000_50_olm_00-catalogsources.crd.yaml
+++ b/manifests/0000_50_olm_00-catalogsources.crd.yaml
@@ -5,7 +5,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.6.2
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: catalogsources.operators.coreos.com
 spec:

--- a/manifests/0000_50_olm_00-clusterserviceversions.crd.yaml
+++ b/manifests/0000_50_olm_00-clusterserviceversions.crd.yaml
@@ -5,7 +5,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.6.2
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: clusterserviceversions.operators.coreos.com
 spec:

--- a/manifests/0000_50_olm_00-installplans.crd.yaml
+++ b/manifests/0000_50_olm_00-installplans.crd.yaml
@@ -5,7 +5,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.6.2
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: installplans.operators.coreos.com
 spec:

--- a/manifests/0000_50_olm_00-namespace.yaml
+++ b/manifests/0000_50_olm_00-namespace.yaml
@@ -7,7 +7,6 @@ metadata:
     workload.openshift.io/allowed: "management"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
   labels:
     openshift.io/scc: "anyuid"
     openshift.io/cluster-monitoring: "true"
@@ -21,6 +20,5 @@ metadata:
     workload.openshift.io/allowed: "management"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
   labels:
     openshift.io/scc: "anyuid"

--- a/manifests/0000_50_olm_00-olmconfigs.crd.yaml
+++ b/manifests/0000_50_olm_00-olmconfigs.crd.yaml
@@ -5,7 +5,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.6.2
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: olmconfigs.operators.coreos.com
 spec:

--- a/manifests/0000_50_olm_00-operatorconditions.crd.yaml
+++ b/manifests/0000_50_olm_00-operatorconditions.crd.yaml
@@ -5,7 +5,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.6.2
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: operatorconditions.operators.coreos.com
 spec:

--- a/manifests/0000_50_olm_00-operatorgroups.crd.yaml
+++ b/manifests/0000_50_olm_00-operatorgroups.crd.yaml
@@ -5,7 +5,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.6.2
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: operatorgroups.operators.coreos.com
 spec:

--- a/manifests/0000_50_olm_00-operators.crd.yaml
+++ b/manifests/0000_50_olm_00-operators.crd.yaml
@@ -5,7 +5,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.6.2
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: operators.operators.coreos.com
 spec:

--- a/manifests/0000_50_olm_00-packageserver.pdb.yaml
+++ b/manifests/0000_50_olm_00-packageserver.pdb.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
 spec:
   maxUnavailable: 1
   selector:

--- a/manifests/0000_50_olm_00-pprof-config.yaml
+++ b/manifests/0000_50_olm_00-pprof-config.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
   name: collect-profiles-config
   namespace: openshift-operator-lifecycle-manager

--- a/manifests/0000_50_olm_00-pprof-rbac.yaml
+++ b/manifests/0000_50_olm_00-pprof-rbac.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
   name: collect-profiles
   namespace: openshift-operator-lifecycle-manager
 rules:
@@ -21,7 +20,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
   name: collect-profiles
   namespace: openshift-operator-lifecycle-manager
 subjects:
@@ -39,6 +37,5 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
   name: collect-profiles
   namespace: openshift-operator-lifecycle-manager

--- a/manifests/0000_50_olm_00-pprof-secret.yaml
+++ b/manifests/0000_50_olm_00-pprof-secret.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
   name: pprof-cert
   namespace: openshift-operator-lifecycle-manager

--- a/manifests/0000_50_olm_00-subscriptions.crd.yaml
+++ b/manifests/0000_50_olm_00-subscriptions.crd.yaml
@@ -5,7 +5,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.6.2
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: subscriptions.operators.coreos.com
 spec:

--- a/manifests/0000_50_olm_01-olm-operator.serviceaccount.yaml
+++ b/manifests/0000_50_olm_01-olm-operator.serviceaccount.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -15,7 +14,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
 rules:
   - apiGroups: ["*"]
     resources: ["*"]
@@ -30,7 +28,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/0000_50_olm_02-olmconfig.yaml
+++ b/manifests/0000_50_olm_02-olmconfig.yaml
@@ -6,4 +6,3 @@ metadata:
     release.openshift.io/create-only: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"

--- a/manifests/0000_50_olm_02-services.yaml
+++ b/manifests/0000_50_olm_02-services.yaml
@@ -7,7 +7,6 @@ metadata:
     service.alpha.openshift.io/serving-cert-secret-name: olm-operator-serving-cert
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
   labels:
     app: olm-operator
 spec:
@@ -29,7 +28,6 @@ metadata:
     service.alpha.openshift.io/serving-cert-secret-name: catalog-operator-serving-cert
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
   labels:
     app: catalog-operator
 spec:

--- a/manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
+++ b/manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
@@ -6,8 +6,6 @@ metadata:
   labels:
     app: package-server-manager
   annotations:
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
 spec:
   strategy:

--- a/manifests/0000_50_olm_06-psm-operator.deployment.yaml
+++ b/manifests/0000_50_olm_06-psm-operator.deployment.yaml
@@ -7,7 +7,6 @@ metadata:
     app: package-server-manager
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
 spec:
   strategy:
     type: RollingUpdate

--- a/manifests/0000_50_olm_07-collect-profiles.cronjob.yaml
+++ b/manifests/0000_50_olm_07-collect-profiles.cronjob.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
   name: collect-profiles
   namespace: openshift-operator-lifecycle-manager
 spec:

--- a/manifests/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/manifests/0000_50_olm_07-olm-operator.deployment.yaml
@@ -7,7 +7,6 @@ metadata:
     app: olm-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
 spec:
   strategy:
     type: RollingUpdate

--- a/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -7,7 +7,6 @@ metadata:
     app: catalog-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
 spec:
   strategy:
     type: RollingUpdate

--- a/manifests/0000_50_olm_09-aggregated.clusterrole.yaml
+++ b/manifests/0000_50_olm_09-aggregated.clusterrole.yaml
@@ -9,7 +9,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
 rules:
   - apiGroups: ["operators.coreos.com"]
     resources: ["subscriptions"]
@@ -30,7 +29,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
 rules:
   - apiGroups: ["operators.coreos.com"]
     resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions", "operatorgroups"]

--- a/manifests/0000_50_olm_13-operatorgroup-default.yaml
+++ b/manifests/0000_50_olm_13-operatorgroup-default.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
 ---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
@@ -16,7 +15,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
 spec:
   targetNamespaces:
     - openshift-operator-lifecycle-manager

--- a/manifests/0000_50_olm_99-operatorstatus.yaml
+++ b/manifests/0000_50_olm_99-operatorstatus.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
 status:
   versions:
     - name: operator
@@ -18,7 +17,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
 status:
   versions:
     - name: operator
@@ -31,7 +29,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
 status:
   versions:
     - name: operator

--- a/manifests/0000_90_olm_00-service-monitor.yaml
+++ b/manifests/0000_90_olm_00-service-monitor.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
 rules:
   - apiGroups:
       - ""
@@ -27,7 +26,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -47,7 +45,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
 spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -80,7 +77,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
 spec:
   jobLabel: k8s-app
   endpoints:

--- a/manifests/0000_90_olm_01-prometheus-rule.yaml
+++ b/manifests/0000_90_olm_01-prometheus-rule.yaml
@@ -9,7 +9,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
 spec:
   groups:
     - name: olm.csv_abnormal.rules

--- a/pkg/manifests/csv.yaml
+++ b/pkg/manifests/csv.yaml
@@ -8,7 +8,6 @@ metadata:
     olm.version: 0.19.0
     olm.clusteroperator.name: operator-lifecycle-manager-packageserver
   annotations:
-    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
 spec:

--- a/scripts/generate_crds_manifests.sh
+++ b/scripts/generate_crds_manifests.sh
@@ -55,7 +55,6 @@ add_ibm_managed_cloud_annotations() {
          ${YQ} d -d'*' --inplace "$g" 'spec.template.spec.nodeSelector."node-role.kubernetes.io/master"'
       fi
       ${YQ} w -d'*' --inplace --style=double "$f" 'metadata.annotations['include.release.openshift.io/self-managed-high-availability']' true
-      ${YQ} w -d'*' --inplace --style=double "$f" 'metadata.annotations['include.release.openshift.io/single-node-developer']' true
    done
 }
 
@@ -92,8 +91,6 @@ metadata:
   labels:
     app: package-server-manager
   annotations:
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
 spec:
   strategy:
     type: RollingUpdate
@@ -172,7 +169,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
   name: collect-profiles-config
   namespace: openshift-operator-lifecycle-manager
@@ -188,7 +184,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
   name: collect-profiles
   namespace: openshift-operator-lifecycle-manager
 rules:
@@ -205,7 +200,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
   name: collect-profiles
   namespace: openshift-operator-lifecycle-manager
 subjects:
@@ -223,7 +217,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
   name: collect-profiles
   namespace: openshift-operator-lifecycle-manager
 EOF
@@ -235,7 +228,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
   name: pprof-cert
   namespace: openshift-operator-lifecycle-manager
@@ -252,7 +244,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
   name: collect-profiles
   namespace: openshift-operator-lifecycle-manager
 spec:

--- a/scripts/packageserver-deployment.patch.yaml
+++ b/scripts/packageserver-deployment.patch.yaml
@@ -19,7 +19,6 @@
 - command: update
   path: metadata.annotations
   value:
-    include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
 - command: update


### PR DESCRIPTION
The single-node-developer profile was ultimately not implemented, and as
a result is ultimately unnecessary. This commit removes it from all
manifests
see  https://github.com/openshift/cluster-version-operator/pull/685

Additionally, the ibm-cloud-managed annotation and self-managed
annotations are applied to both versions of the psm deployment manifest.
Since these are in conflict, in the future they could potentially cause
flapping by the CVO to apply both versions of the manifest to the
cluster.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2037168