### PR TITLE
Bug 2003164: Do not modify object from the lister cache (#2562)

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/bundle/bundle_unpacker.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/bundle/bundle_unpacker.go
@@ -647,6 +647,7 @@ func (c *ConfigMapUnpacker) ensureRole(cmRef *corev1.ObjectReference) (role *rba
 			return
 		}
 	}
+	role = role.DeepCopy()
 	role.Rules = append(role.Rules, rule)
 
 	role, err = c.client.RbacV1().Roles(role.GetNamespace()).Update(context.TODO(), role, metav1.UpdateOptions{})

--- a/staging/operator-lifecycle-manager/pkg/controller/install/apiservice.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/install/apiservice.go
@@ -41,6 +41,7 @@ func (i *StrategyDeploymentInstaller) createOrUpdateAPIService(caPEM []byte, des
 		}
 		apiService.SetName(apiServiceName)
 	} else {
+		apiService = apiService.DeepCopy()
 		csv, ok := i.owner.(*v1alpha1.ClusterServiceVersion)
 		if !ok {
 			return fmt.Errorf("APIServices require a CSV Owner.")

--- a/staging/operator-lifecycle-manager/pkg/controller/install/webhook.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/install/webhook.go
@@ -106,6 +106,7 @@ func (i *StrategyDeploymentInstaller) createOrUpdateMutatingWebhook(ogNamespacel
 		}
 	}
 	for _, webhook := range existingWebhooks.Items {
+		webhook = *webhook.DeepCopy()
 		// Update the list of webhooks
 		webhook.Webhooks = []admissionregistrationv1.MutatingWebhook{
 			desc.GetMutatingWebhook(i.owner.GetNamespace(), ogNamespacelabelSelector, caPEM),
@@ -154,6 +155,7 @@ func (i *StrategyDeploymentInstaller) createOrUpdateValidatingWebhook(ogNamespac
 		return nil
 	}
 	for _, webhook := range existingWebhooks.Items {
+		webhook = *webhook.DeepCopy()
 		// Update the list of webhooks
 		webhook.Webhooks = []admissionregistrationv1.ValidatingWebhook{
 			desc.GetValidatingWebhook(i.owner.GetNamespace(), ogNamespacelabelSelector, caPEM),

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
@@ -846,6 +846,7 @@ func (a *Operator) syncObject(obj interface{}) (syncError error) {
 	if related {
 		csvList := a.csvSet(metaObj.GetNamespace(), v1alpha1.CSVPhaseFailed)
 		for _, csv := range csvList {
+			csv = csv.DeepCopy()
 			if csv.Status.Reason != v1alpha1.CSVReasonComponentFailedNoRetry {
 				continue
 			}
@@ -1244,7 +1245,7 @@ func (a *Operator) allNamespaceOperatorGroups() ([]*v1.OperatorGroup, error) {
 	result := []*v1.OperatorGroup{}
 	for _, operatorGroup := range operatorGroups {
 		if NewNamespaceSet(operatorGroup.Status.Namespaces).IsAllNamespaces() {
-			result = append(result, operatorGroup)
+			result = append(result, operatorGroup.DeepCopy())
 		}
 	}
 	return result, nil
@@ -1483,7 +1484,7 @@ func (a *Operator) getCopiedCSVDisabledEventsForCSV(csv *v1alpha1.ClusterService
 			event.InvolvedObject.Name == csv.GetName() &&
 			event.InvolvedObject.UID == csv.GetUID() &&
 			event.Reason == v1.DisabledCopiedCSVsConditionType {
-			result = append(result, event)
+			result = append(result, *event.DeepCopy())
 		}
 	}
 
@@ -1592,7 +1593,7 @@ func (a *Operator) operatorGroupFromAnnotations(logger *logrus.Entry, csv *v1alp
 		return nil
 	}
 
-	return operatorGroup
+	return operatorGroup.DeepCopy()
 }
 
 func (a *Operator) operatorGroupForCSV(csv *v1alpha1.ClusterServiceVersion, logger *logrus.Entry) (*v1.OperatorGroup, error) {
@@ -1633,7 +1634,7 @@ func (a *Operator) operatorGroupForCSV(csv *v1alpha1.ClusterServiceVersion, logg
 			return nil, nil
 		}
 		logger.Debug("csv in operatorgroup")
-		return operatorGroup, nil
+		return operatorGroup.DeepCopy(), nil
 	default:
 		err = fmt.Errorf("csv created in namespace with multiple operatorgroups, can't pick one automatically")
 		logger.WithError(err).Warn("csv failed to become an operatorgroup member")

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/bundle/bundle_unpacker.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/bundle/bundle_unpacker.go
@@ -647,6 +647,7 @@ func (c *ConfigMapUnpacker) ensureRole(cmRef *corev1.ObjectReference) (role *rba
 			return
 		}
 	}
+	role = role.DeepCopy()
 	role.Rules = append(role.Rules, rule)
 
 	role, err = c.client.RbacV1().Roles(role.GetNamespace()).Update(context.TODO(), role, metav1.UpdateOptions{})

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install/apiservice.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install/apiservice.go
@@ -41,6 +41,7 @@ func (i *StrategyDeploymentInstaller) createOrUpdateAPIService(caPEM []byte, des
 		}
 		apiService.SetName(apiServiceName)
 	} else {
+		apiService = apiService.DeepCopy()
 		csv, ok := i.owner.(*v1alpha1.ClusterServiceVersion)
 		if !ok {
 			return fmt.Errorf("APIServices require a CSV Owner.")

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install/webhook.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install/webhook.go
@@ -106,6 +106,7 @@ func (i *StrategyDeploymentInstaller) createOrUpdateMutatingWebhook(ogNamespacel
 		}
 	}
 	for _, webhook := range existingWebhooks.Items {
+		webhook = *webhook.DeepCopy()
 		// Update the list of webhooks
 		webhook.Webhooks = []admissionregistrationv1.MutatingWebhook{
 			desc.GetMutatingWebhook(i.owner.GetNamespace(), ogNamespacelabelSelector, caPEM),
@@ -154,6 +155,7 @@ func (i *StrategyDeploymentInstaller) createOrUpdateValidatingWebhook(ogNamespac
 		return nil
 	}
 	for _, webhook := range existingWebhooks.Items {
+		webhook = *webhook.DeepCopy()
 		// Update the list of webhooks
 		webhook.Webhooks = []admissionregistrationv1.ValidatingWebhook{
 			desc.GetValidatingWebhook(i.owner.GetNamespace(), ogNamespacelabelSelector, caPEM),

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
@@ -846,6 +846,7 @@ func (a *Operator) syncObject(obj interface{}) (syncError error) {
 	if related {
 		csvList := a.csvSet(metaObj.GetNamespace(), v1alpha1.CSVPhaseFailed)
 		for _, csv := range csvList {
+			csv = csv.DeepCopy()
 			if csv.Status.Reason != v1alpha1.CSVReasonComponentFailedNoRetry {
 				continue
 			}
@@ -1244,7 +1245,7 @@ func (a *Operator) allNamespaceOperatorGroups() ([]*v1.OperatorGroup, error) {
 	result := []*v1.OperatorGroup{}
 	for _, operatorGroup := range operatorGroups {
 		if NewNamespaceSet(operatorGroup.Status.Namespaces).IsAllNamespaces() {
-			result = append(result, operatorGroup)
+			result = append(result, operatorGroup.DeepCopy())
 		}
 	}
 	return result, nil
@@ -1483,7 +1484,7 @@ func (a *Operator) getCopiedCSVDisabledEventsForCSV(csv *v1alpha1.ClusterService
 			event.InvolvedObject.Name == csv.GetName() &&
 			event.InvolvedObject.UID == csv.GetUID() &&
 			event.Reason == v1.DisabledCopiedCSVsConditionType {
-			result = append(result, event)
+			result = append(result, *event.DeepCopy())
 		}
 	}
 
@@ -1592,7 +1593,7 @@ func (a *Operator) operatorGroupFromAnnotations(logger *logrus.Entry, csv *v1alp
 		return nil
 	}
 
-	return operatorGroup
+	return operatorGroup.DeepCopy()
 }
 
 func (a *Operator) operatorGroupForCSV(csv *v1alpha1.ClusterServiceVersion, logger *logrus.Entry) (*v1.OperatorGroup, error) {
@@ -1633,7 +1634,7 @@ func (a *Operator) operatorGroupForCSV(csv *v1alpha1.ClusterServiceVersion, logg
 			return nil, nil
 		}
 		logger.Debug("csv in operatorgroup")
-		return operatorGroup, nil
+		return operatorGroup.DeepCopy(), nil
 	default:
 		err = fmt.Errorf("csv created in namespace with multiple operatorgroups, can't pick one automatically")
 		logger.WithError(err).Warn("csv failed to become an operatorgroup member")


### PR DESCRIPTION
Problem: Objects retrieved from the lister should
not be modified.

Solution: In locations where an object originating from the lister
cache must be modified, modify a copy of the object instead.

Signed-off-by: Alexander Greene <greene.al1991@gmail.com>

Upstream-repository: operator-lifecycle-manager
Upstream-commit: 5a7f8033dfc04150d1c21ef4e86fd7bc00bbfa39