### PR TITLE
Bug 1975543: Use CVO to delete manifests removed from OLM

### DIFF
--- a/manifests/0000_50_olm_11-olm-operators.configmap.removed.yaml
+++ b/manifests/0000_50_olm_11-olm-operators.configmap.removed.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: olm-operators
+  namespace: openshift-operator-lifecycle-manager
+  annotations:
+    release.openshift.io/delete: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"

--- a/manifests/0000_50_olm_12-olm-operators.catalogsource.removed.yaml
+++ b/manifests/0000_50_olm_12-olm-operators.catalogsource.removed.yaml
@@ -1,0 +1,9 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: olm-operators
+  namespace: openshift-operator-lifecycle-manager
+  annotations:
+    release.openshift.io/delete: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"

--- a/manifests/0000_50_olm_14-packageserver.subscription.removed.yaml
+++ b/manifests/0000_50_olm_14-packageserver.subscription.removed.yaml
@@ -1,0 +1,9 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: packageserver
+  namespace: openshift-operator-lifecycle-manager
+  annotations:
+    release.openshift.io/delete: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"

--- a/scripts/generate_crds_manifests.sh
+++ b/scripts/generate_crds_manifests.sh
@@ -288,6 +288,37 @@ spec:
           restartPolicy: Never
 EOF
 
+cat << EOF > manifests/0000_50_olm_11-olm-operators.configmap.removed.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: olm-operators
+  namespace: openshift-operator-lifecycle-manager
+  annotations:
+    release.openshift.io/delete: "true"
+EOF
+
+cat << EOF > manifests/0000_50_olm_12-olm-operators.catalogsource.removed.yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: olm-operators
+  namespace: openshift-operator-lifecycle-manager
+  annotations:
+    release.openshift.io/delete: "true"
+
+EOF
+
+cat << EOF > manifests/0000_50_olm_14-packageserver.subscription.removed.yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: packageserver
+  namespace: openshift-operator-lifecycle-manager
+  annotations:
+    release.openshift.io/delete: "true"
+EOF
+
 add_ibm_managed_cloud_annotations "${ROOT_DIR}/manifests"
 
 # requires gnu sed if on mac


### PR DESCRIPTION
Problem: Over the course of OLM's lifecycle resources
included in the CVO payload have been removed. CVO does
not automatically removed these resources from the cluster
unless they are properly annotated.

Solution: Reintroduce the removed manifests and include the
annotation that informs CVO to delete the resources.