### PR TITLE
Bug 2055861: Replace collect-profile jobs that haven't completed

### DIFF
--- a/manifests/0000_50_olm_07-collect-profiles.cronjob.yaml
+++ b/manifests/0000_50_olm_07-collect-profiles.cronjob.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
 spec:
   schedule: "*/15 * * * *"
+  concurrencyPolicy: "Replace"
   jobTemplate:
     spec:
       template:

--- a/scripts/generate_crds_manifests.sh
+++ b/scripts/generate_crds_manifests.sh
@@ -248,6 +248,7 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
 spec:
   schedule: "*/15 * * * *"
+  concurrencyPolicy: "Replace"
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
Problem: The collect-profiles job should only take a few seconds to
run. There are instances, such as when the pod cannot be scheduled,
where the job will not complete in a reasonable amount of time. If
enough jobs are scheduled but unable to run, the number of
scheduled jobs can exceed pod quota limits.

Solution: Given that the collect-profiles job should only take a few
seconds to run and that the job is scheduled to run every 15 minutes,
set the collect-profiles cronJob's spec.concurrencyPolicy to
"Replace" so that only one active collect-profiles pod exists at any
time.