### PR TITLE
Update the build root Dockerfile base image

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to bootstrap build and test in openshift-ci
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.8
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.11
 
 ARG KUBEBUILDER_RELEASE=2.3.1
 # Install test dependencies


### PR DESCRIPTION
Update the base.Dockerfile build root Dockerfile image, which the unit
and verify checks use as their base image, to use a Go 1.17 image.

Signed-off-by: timflannagan <timflannagan@gmail.com>