### PR TITLE
Fix install_kubebuilder.sh script

### DIFF
--- a/scripts/install_kubebuilder.sh
+++ b/scripts/install_kubebuilder.sh
@@ -8,13 +8,18 @@ KUBEBUILDER_BIN=${KUBEBUILDER_BIN:=/usr/local/kubebuilder}
 OS=$(go env GOOS)
 ARCH=$(go env GOARCH)
 KUBEBUILDER_RELEASE=2.3.1
+KUBEBUILDER_DOWNLOAD_URL="https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_RELEASE}/kubebuilder_${KUBEBUILDER_RELEASE}_${OS}_${ARCH}.tar.gz"
+
+# Note: From v3.0.0+ the release assets in the kubebuilder repo change format
+# See: https://github.com/kubernetes-sigs/kubebuilder/releases
+# KUBEBUILDER_DOWNLOAD_URL="https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_RELEASE}/kubebuilder_${OS}_${ARCH}"
 
 if [[ -d ${KUBEBUILDER_BIN} ]]; then
     echo "Not installing kubebuilder as the binary already exists in \$PATH"
     exit 0
 fi
 
-curl -L "https://go.kubebuilder.io/dl/${KUBEBUILDER_RELEASE}/${OS}/${ARCH}" | tar -xz -C /tmp/ && \
+curl -L ${KUBEBUILDER_DOWNLOAD_URL} | tar -xz -C /tmp/ && \
     mv /tmp/kubebuilder_${KUBEBUILDER_RELEASE}_${OS}_${ARCH}/ /usr/local/kubebuilder
 
 echo "Kubebuilder installation complete!"


### PR DESCRIPTION
Signed-off-by: perdasilva <perdasilva@redhat.com>

The  `install_kubebuilder.sh` script no longer seems to be working:

```
 % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    67  100    67    0     0    151      0 --:--:-- --:--:-- --:--:--   151
100 21145  100 21145    0     0  42496      0 --:--:-- --:--:-- --:--:-- 42496

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
Kubebuilder installation complete!
Run the following locally to ensure kubebuilder is added to $PATH
export PATH=/home/perdasilva/sdk/go1.17.7/bin:/home/perdasilva/sdk/go1.16.14/bin:/home/perdasilva/go/bin:/home/perdasilva/bin:/home/perdasilva/miniconda3/bin:/home/perdasilva/.crc/bin/oc:/home/perdasilva/go/go1.17.6/bin:/usr/local/go/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/var/lib/snapd/snap/bin:/usr/local/kubebuilder/bin
```

It seems https://go.kubebuilder.io/releases/2.3.1/linux/amd64 no longer points to the 2.3.1 release, or is down.

This PR updates the script to download the release directly from github.

After fix:

```
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   675  100   675    0     0   2454      0 --:--:-- --:--:-- --:--:--  2454
100 54.8M  100 54.8M    0     0  1769k      0  0:00:31  0:00:31 --:--:-- 1731k
mv: cannot create directory '/usr/local/kubebuilder': Permission denied  # <- Expected download and untaring works ^^

$ find /tmp/kubebuilder_2.3.1_linux_amd64/                                                                                              Wed 02 Mar 2022 12:24:50
/tmp/kubebuilder_2.3.1_linux_amd64/
/tmp/kubebuilder_2.3.1_linux_amd64/bin
/tmp/kubebuilder_2.3.1_linux_amd64/bin/kubebuilder
/tmp/kubebuilder_2.3.1_linux_amd64/bin/kubectl
/tmp/kubebuilder_2.3.1_linux_amd64/bin/kube-apiserver
/tmp/kubebuilder_2.3.1_linux_amd64/bin/etcd
```