### PR TITLE
Remove unsupported project_image from .ci-operator.yaml

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -2,6 +2,3 @@ build_root_image:
   name: release
   namespace: openshift
   tag: rhel-8-release-golang-1.17-openshift-4.11
-project_image:
-  context_dir: .
-  dockerfile_path: base.Dockerfile


### PR DESCRIPTION
Signed-off-by: perdasilva <perdasilva@redhat.com>

Removes project_image from .ci-operator.yaml. `project_image` is not supported there. So, it's dedcode