### PR TITLE
Adds CRC deployment automation and CI documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -461,3 +461,8 @@ staging/*/vendor
 # Ignore sqlite
 *.db
 *.db-journal
+
+# e2e on crc values file and patches
+values-crc-e2e.yaml
+scripts/**/*.crc.e2e.patch.yaml
+

--- a/docs/downstream-ci.md
+++ b/docs/downstream-ci.md
@@ -1,0 +1,133 @@
+# Downstream CI
+
+The CI configuration for each release branch can be found [here](https://github.com/openshift/release/tree/master/ci-operator/config/openshift/operator-framework-olm).
+From `4.11` (`master` as of this writing) we've updated the configuration to able to influence CI on a PR basis. An overview of the `ci-operator` (the system used for ci)
+can be found [here](https://docs.ci.openshift.org/docs/architecture/ci-operator/).
+
+### Structure
+
+ * `.ci-operator.yaml` defines the `build_root_image`. To be ART compliant, the image should come from the [ocp-build-data](https://github.com/openshift/ocp-build-data/) repo
+ * [openshift-operator-framework-olm-master.yaml](https://github.com/openshift/release/blob/master/ci-operator/config/openshift/operator-framework-olm/openshift-operator-framework-olm-master.yaml) defines the images that are used by ci, produced by ci, and the ci jobs the get executed.
+ * `base.Dockerfile` defines the image used by ci to execute the ci jobs
+
+From [openshift-operator-framework-olm-master.yaml](https://github.com/openshift/release/blob/master/ci-operator/config/openshift/operator-framework-olm/openshift-operator-framework-olm-master.yaml), we see under the `images` stanza the `ci-image` definition.
+It goes from `src` (the `build_root_image`) to `ci-image` by building `base.Dockerfile` with `src` as the base image.
+
+```
+- dockerfile_path: base.Dockerfile
+  from: src
+  to: ci-image
+```
+
+The image is excluded from promotion, to never be posted up anywhere:
+
+```
+promotion:
+  excluded_images:
+  - ci-image
+```
+
+and each `test` references `ci-image` as the image to be used to the test, e.g.:
+
+```
+tests:
+- as: verify
+  commands: make verify
+  container:
+    from: ci-image
+```
+
+### Updating go versions
+
+All we need to do is update the `build_root_image` referenced in `.ci-operator.yaml` and we may also need to update the `base_images` in [openshift-operator-framework-olm-master.yaml](https://github.com/openshift/release/blob/master/ci-operator/config/openshift/operator-framework-olm/openshift-operator-framework-olm-master.yaml). 
+
+**NOTE**: I believe there is some automation that updates the base images, though I don't know. I'll leave this as a questions to the reviewer, and if no one knows, I'll go after it.
+
+### Downstream sync
+
+The complete information about the downstreaming process can be found [here](https://docs.google.com/document/d/139yXeOqAJbV1ndC7Q4NbaOtzbSdNpcuJan0iemORd3g/edit).
+
+TL;DR;
+
+We sync three upstream repositories ([api](https://github.com/operator-framework/api), [registry](https://github.com/operator-framework/operator-registry), [olm](https://github.com/operator-framework/operator-lifecycle-manager)) to the downstream [olm mono-repo](https://github.com/openshift/operator-framework-olm). Commits from the upstream repositories are cherry-picked to the appropriate `staging` directory in the downstream repository. Because this is a monorepo in the `Openshift` GitHub organization, two things need to be remembered:
+ - we don't pull in upstream `vendor` folder changes
+ - we don't pull in changes to `OWNERS` files
+ - after each cherry-pick we execute: `make vendor` and `make manifest` to ensure a) the downstream dependencies are updated b) to ensure any manifest changes are picked up downstream
+
+ While manual changes to the `staging` directory should be avoided, there could be instances where there drift between the downstream `staging` directory and the corresponding upstream repository. This can happen due to applying commits out-of-order, e.g. due to feature freeze, etc.
+
+ Therefore, after a sync, it is important to manually verify the diff of `staging` and the upstream. Please note, though, that some downstream changes are downstream only. These are, however, few and far between and there are comments to indicate that a block of code is downstream only.
+
+ The downstream sync process is facilitated by two scripts: `scripts/sync_get_candidates.sh` and `scripts/sync_pop_candidate.sh`, which compare the upstream remote with the appropriate `staging` directory and gets a stack of commits to sync, and cherry-pick those commits in reverse order. What does this look like in practice:
+
+ ```bash
+# Clone downstream
+git clone git@github.com:openshift/operator-framework-olm.git && cd operator-framework-olm
+
+# Add and fetch upstream remotes
+git remote add api git@github.com:operator-framework/api.git && git fetch api
+git remote add operator-registry git@github.com:operator-framework/operator-registry.git && git fetch operator-registry
+git remote add operator-lifecycle-manager git@github.com:operator-framework/operator-lifecycle-manager.git && git fetch operator-lifecycle-manager
+
+# Get upstream commit candidates: ./scripts/sync_get_candidates.sh <api|operator-registry|operator-lifecycle-manager> <branch>
+# The shas will be found in ./<api|operator-registry|operator-lifecycle-manager>.cherrypick
+./scripts/sync_get_candidates.sh api master 
+./scripts/sync_get_candidates.sh operator-registry master 
+./scripts/sync_get_candidates.sh operator-lifecycle-manager master
+
+# Sync upstream commits: ./scripts/sync_pop_candidate.sh <api|operator-registry|operator-lifecycle-manager> [-a]
+# Without -a, you'll proceed one commit at a time. With -a the process will conclude once there are no more commits.
+# When a cherry pick encounters a conflict the script will stop so you can manually fix it.
+sync_pop_candidate.sh operator-lifecycle-manager -a
+
+# When finished
+sync_pop_candidate.sh api -a
+
+# When finished
+sync_pop_candidate.sh operator-registry -a
+
+# Depending on the changes being pulled in, the order of repos you sync _could_ matter and _could_ leave a commit in an unbuildable state
+ ```
+
+ Example: 
+
+ ```bash
+$ sync_pop_candidate.sh operator-lifecycle-manager -a
+
+.github/workflows: Enable workflow_dispatch event triggers (#2464)
+ Author: Tim Flannagan <timflannagan@gmail.com>
+ Date: Mon Dec 20 15:13:33 2021 -0500
+ 9 files changed, 9 insertions(+), 1 deletion(-)
+66 picks remaining (pop_all=true)
+popping: 4daeb114ccd56cee7132883325da68c80ba70bed
+Auto-merging staging/operator-lifecycle-manager/go.mod
+CONFLICT (content): Merge conflict in staging/operator-lifecycle-manager/go.mod
+Auto-merging staging/operator-lifecycle-manager/go.sum
+CONFLICT (content): Merge conflict in staging/operator-lifecycle-manager/go.sum
+CONFLICT (modify/delete): staging/operator-lifecycle-manager/vendor/github.com/operator-framework/api/pkg/validation/doc.go deleted in HEAD and modified in 4daeb114c (chore(api): Vendor the new version of api repo (#2525)).  Version 4daeb114c (chore(api): Vendor the new version of api repo (#2525)) of staging/operator-lifecycle-manager/vendor/github.com/operator-framework/api/pkg/validation/doc.go left in tree.
+CONFLICT (modify/delete): staging/operator-lifecycle-manager/vendor/modules.txt deleted in HEAD and modified in 4daeb114c (chore(api): Vendor the new version of api repo (#2525)).  Version 4daeb114c (chore(api): Vendor the new version of api repo (#2525)) of staging/operator-lifecycle-manager/vendor/modules.txt left in tree.
+error: could not apply 4daeb114c... chore(api): Vendor the new version of api repo (#2525)
+hint: After resolving the conflicts, mark them with
+hint: "git add/rm <pathspec>", then run
+hint: "git cherry-pick --continue".
+hint: You can instead skip this commit with "git cherry-pick --skip".
+hint: To abort and get back to the state before "git cherry-pick",
+hint: run "git cherry-pick --abort".
+
+$ rm -rf staging/operator-lifecycle-manager/vendor
+
+# make sure there are no conflics in 
+# staging/operator-lifecycle-manager/go.mod and go.sum
+$ cd staging/operator-lifecycle-manager
+$ go mod tidy
+$ cd ../../
+
+# now that the conflict is fixed, advance again
+$ sync_pop_candidate.sh operator-lifecycle-manager -a
+ ```
+
+### Troubleshooting
+
+#### Running console test locally
+
+The [console](https://github.com/openshift/console) repository contains all instructions you need to execute the console tests locally. The olm console tests can be found [here](https://github.com/openshift/console/tree/master/frontend/packages/operator-lifecycle-manager)

--- a/docs/local-testing-with-crc.md
+++ b/docs/local-testing-with-crc.md
@@ -1,0 +1,35 @@
+# Local testing with CRC
+
+We can use CRC as an Openshift-like environment within which to test downstream OLM. [CRC](https://developers.redhat.com/products/codeready-containers/overview) 
+is a tool for deploying a local Openshift cluster on your laptop.
+
+TL;DR
+
+1. Install [CRC](https://developers.redhat.com/products/codeready-containers/overview)
+2. `make crc` to provision a CRC cluster, build OLM, and deploy it on the cluster
+3. `export KUBECONFIG=~/.crc/machines/crc/kubeconfig`
+4. Execute e2e tests as you normally would, e.g., `make e2e/olm`
+
+#### Gosh darn it, how does it work?
+
+`./scripts/crc-start.sh` is used to provision a crc cluster. `./scripts/crc-deploy.sh` pushes the `olm:test` and `opm:test` to
+`image-registry.openshift-image-registry.svc:5000/openshift/olm:test` and `image-registry.openshift-image-registry.svc:5000/openshift/opm:test`
+images to the crc image registry under the global project `openshift` (to be independent from the olm namespace). It also generates an image stream
+from these images. Finally, using the istag for the image. It also generates the olm manifests by applying generated helm values file (`values-crc-e2e.yaml`) 
+and other generated yaml patches (`scripts/*.crc.e2e.patch.yaml`) to make sure the manifests point to the newly pushed images. The generated manifests are
+then applied to the cluster using `kubectl replace` in priority order (lexical sort).
+
+#### Make targets
+
+1. `make crc-start`: provision a crc cluster, if necessary
+   1. `FORCE_CLEAN=1 make crc-start`: nuke any current installation including cache and current cluster instance
+2. `make crc-build`: build olm images with the right tags
+3. `make crc-deploy`: generate manifests, upload olm images, deploy olm
+   1. `SKIP_MANIFESTS=1 make crc-deploy`: skip manifest generation and deployment (only update images)
+   2. `SKIP_WAIT_READY=1 make crc-deploy`: skip waiting for olm deployments to be available at the end
+4. `make crc`: the same as `make crc-start crc-build crc-deploy`
+
+#### Manipulating Resources
+
+If new resources are introduced that require being updated for local deployment (e.g. updating the pod spec image) follow
+the pattern used in `scripts/crc-deploy.sh:make_manifest_patches`

--- a/scripts/crc-deploy.sh
+++ b/scripts/crc-deploy.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+
+set -e
+
+# This script manages the deployment of downstream olm on a local CRC cluster
+# It will deploy the local images: olm:test and opm:test
+# Both built with make build/olm-container and build/registry-container respectively
+
+echo "Deploying OLM to CRC"
+
+# push_images opens a kubectl port-forward session to the crc registry service
+# appropriately tags the locally built olm images
+# and pushes them to the global registry "openshift"
+function push_images {
+  # local images
+  LOCAL_OLM_IMAGE=${1-olm:test}
+  LOCAL_OPM_IMAGE=${2-opm:test}
+
+  # push images to the global crc registry "openshift"
+  # so that they can be pulled from any other namespace in the cluster
+  CRC_GLOBAL_REGISTRY="openshift"
+
+  # CRC destined images
+  CRC_OLM_IMAGE="localhost:5000/${CRC_GLOBAL_REGISTRY}/olm:test"
+  CRC_OPM_IMAGE="localhost:5000/${CRC_GLOBAL_REGISTRY}/opm:test"
+
+  # CRC registry coordinates
+  OPENSHIFT_REGISTRY_NAMESPACE="openshift-image-registry"
+  OLM_NAMESPACE="openshift-operator-lifecycle-manager"
+  IMAGE_REGISTRY_SVC="image-registry"
+  IMAGE_REGISTRY_PORT=5000
+
+  # Create port-forward to CRC registry
+  kubectl port-forward -n ${OPENSHIFT_REGISTRY_NAMESPACE} svc/${IMAGE_REGISTRY_SVC} ${IMAGE_REGISTRY_PORT}:${IMAGE_REGISTRY_PORT} > /dev/null 2>&1 &
+  PORT_FWD_PID=$!
+
+  # Remember to close the port-forward
+  trap 'kill "${PORT_FWD_PID}"' EXIT
+
+  # give port-forward a second
+  # I found that without this docker login would not work
+  # as if it couldn't reach the docker server
+  sleep 1
+
+  # Login to the CRC registry
+  oc whoami -t | docker login localhost:5000 --username user --password-stdin
+
+  # Tag and push olm image
+  echo "Pushing olm image"
+  docker tag "${LOCAL_OLM_IMAGE}" "${CRC_OLM_IMAGE}"
+  docker push "${CRC_OLM_IMAGE}"
+
+  # Tag and push registry image
+  echo "Pushing registry image"
+  docker tag "${LOCAL_OPM_IMAGE}" "${CRC_OPM_IMAGE}"
+  docker push "${CRC_OPM_IMAGE}"
+
+  # Create image streams
+  echo "Creating image streams: ${CRC_OLM_IMAGE} ${CRC_OPM_IMAGE}"
+  OLM_OPENSHIFT=image-registry.openshift-image-registry.svc:5000/openshift/olm:test
+  OPM_OPENSHIFT=image-registry.openshift-image-registry.svc:5000/openshift/opm:test
+  oc import-image olm --from="${OLM_OPENSHIFT}" --confirm
+  oc import-image opm --from="${OPM_OPENSHIFT}" --confirm
+}
+
+# make_manifest_patches takes in two parameters
+# OLM_IMG: the internal registry istag for the olm image
+# OPM_IMG: the internal registry istag for the opm image
+# it creates a helm values files and other manifest patch files applied by
+# scripts/generate_crds_manifests.sh
+function make_manifest_patches {
+  OLM_IMG=${1?Error:\ olm image undefined}
+  OPM_IMG=${2?Error:\ opm image undefined}
+  SED_OPTS=(-e 's#OLM_IMAGE#'"${OLM_IMG}"'#g' -e 's#OPM_IMAGE#'"${OPM_IMG}"'#g')
+
+  # helm values file
+  VALUES_TEMPLATE=$(mktemp)
+  cat << EOF > "${VALUES_TEMPLATE}"
+olm:
+  image:
+    ref: OLM_IMAGE
+catalog:
+  commandArgs: --configmapServerImage=OPM_IMAGE
+  opmImageArgs: --opmImage=OPM_IMAGE
+  image:
+    ref: OLM_IMAGE
+package:
+  image:
+    ref: OLM_IMAGE
+EOF
+
+  sed "${SED_OPTS[@]}" "${VALUES_TEMPLATE}" > "${CRC_E2E_VALUES}"
+
+  # psm operator patch
+  PSM_OPERATOR_PATCH_TEMPLATE=$(mktemp)
+  cat << EOF > "${PSM_OPERATOR_PATCH_TEMPLATE}"
+- command: update
+  path: spec.template.spec.containers[0].image
+  value: OLM_IMAGE
+- command: update
+  path: spec.template.spec.containers[0].env[1].value
+  value: OLM_IMAGE
+EOF
+
+  sed "${SED_OPTS[@]}" "${PSM_OPERATOR_PATCH_TEMPLATE}" > scripts/psm-operator-deployment.crc.e2e.patch.yaml
+
+  # collect-profiles patch
+  COLLECT_PROFILE_PATCH_TEMPLATE=$(mktemp)
+  cat << EOF > "${COLLECT_PROFILE_PATCH_TEMPLATE}"
+- command: update
+  path: spec.jobTemplate.spec.template.spec.containers[0].image
+  value: OLM_IMAGE
+EOF
+
+  sed "${SED_OPTS[@]}" "${COLLECT_PROFILE_PATCH_TEMPLATE}" > scripts/collect-profiles.crc.e2e.patch.yaml
+}
+
+# YQ for applying yaml patches
+YQ="go run ./vendor/github.com/mikefarah/yq/v3/"
+
+# CRC_E2E_VALUES is the name of the help values file
+# used to populate manifest templates with the locally built olm images
+export CRC_E2E_VALUES="values-crc-e2e.yaml"
+
+# Set kubeconfig to CRC if necessary
+export KUBECONFIG=${KUBECONFIG:-${HOME}/.crc/machines/crc/kubeconfig}
+KUBE_ADMIN_USER=$(crc console --credentials -o json | jq -r .clusterConfig.adminCredentials.username)
+KUBE_ADMIN_PASSWORD=$(crc console --credentials -o json | jq -r .clusterConfig.adminCredentials.password)
+
+# login to crc
+echo "Logging in as kubeadmin"
+oc login -u "${KUBE_ADMIN_USER}" -p "${KUBE_ADMIN_PASSWORD}" > /dev/null
+
+# Scale down CVO to stop changes from returning to stock configuration
+echo "Scaling down CVO"
+oc scale --replicas 0 -n openshift-cluster-version deployments/cluster-version-operator
+
+echo "Allow cluster wide access to openshift repository"
+oc policy add-role-to-group system:image-puller system:serviceaccounts --namespace=openshift
+
+# push olm images to crc global repository
+push_images olm:test opm:test
+
+SKIP_MANIFESTS=${SKIP_MANIFESTS:-0}
+if [ "${SKIP_MANIFESTS}" = 0 ]; then
+  # Create values and patches files
+  # Get images with the specific shas
+  OLM_IMG="$(oc get istag/olm:latest -o json | jq -r .image.dockerImageReference)"
+  OPM_IMG="$(oc get istag/opm:latest -o json | jq -r .image.dockerImageReference)"
+
+  make_manifest_patches "${OLM_IMG}" "${OPM_IMG}"
+
+  # Build e2e manifests
+  echo "Generating manifests"
+  # CRC_E2E_VALUES is already set in this script and exported
+  # If set, it will include the file referenced by it in the helm template command
+  # and update the manifests to use the locally built images
+  ./scripts/generate_crds_manifests.sh
+
+  # Apply patches
+  ${YQ} write --inplace -s scripts/psm-operator-deployment.crc.e2e.patch.yaml manifests/0000_50_olm_06-psm-operator.deployment.yaml
+  ${YQ} write --inplace -s scripts/collect-profiles.crc.e2e.patch.yaml manifests/0000_50_olm_07-collect-profiles.cronjob.yaml
+
+  echo "Deploying OLM"
+  find_flags=(-regex ".*\.yaml" -not -regex ".*\.removed\.yaml" -not -regex ".*\.ibm-cloud-managed\.yaml")
+
+  # Use the numbered ordering in the manifest file names to delete and deploy the manifests in order
+  echo "Replacing manifests"
+  find manifests "${find_flags[@]}" | sort | while read -r manifest; do
+    echo "Deleting ${manifest}"
+    set +e
+    kubectl replace -f "${manifest}"
+    set -e
+  done
+fi
+
+# Force recreation of olm pods
+echo "Restarting OLM pods"
+kubectl delete pod --all -n "${OLM_NAMESPACE}"
+
+# Wait for deployments to be available
+SKIP_WAIT_READY=${SKIP_WAIT_READY:-0}
+if [ "${SKIP_WAIT_READY}" = 0 ]; then
+  echo "Waiting on deployments to be ready"
+  for DEPLOYMENT in $(oc get deployments --no-headers=true -n "${OLM_NAMESPACE}" | awk '{ print $1 }'); do
+    echo "Waiting for ${DEPLOYMENT}"
+    kubectl wait --for=condition=available --timeout=120s "deployment/${DEPLOYMENT}" -n "${OLM_NAMESPACE}"
+  done
+fi
+
+echo "Done"
+
+exit 0

--- a/scripts/crc-start.sh
+++ b/scripts/crc-start.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -e
+
+# This script manages the creation of the CRC cluster to be used for testing
+# Usage: crc-start.sh
+# FORCE_CLEAN=1 crc-start.sh will delete any current crc cluster, clear the cache and start a fresh installation
+# If CRC is already running, nothing happens
+
+# Check CRC is installed
+if ! [ -x "$(command -v crc)" ]; then
+  echo "Error: CRC is not installed. Go to: https://developers.redhat.com/products/codeready-containers/overview"
+  exit 1
+fi
+
+# Blast CRC if necessary
+if [ "${FORCE_CLEAN}" = 1 ]; then
+  crc delete --clear-cache --force
+fi
+
+# Start CRC if necessary
+if [ "$(crc status -o json | jq -r .success)" = "false"  ] || [ "$(crc status -o json | jq -r .crcStatus)" = "Stopped" ]; then
+    echo "Setting up CRC"
+    crc setup
+    crc start
+fi
+
+# Check CRC started successfully
+if ! [ "$(crc status -o json | jq -r .crcStatus)" = "Running" ]; then
+  echo "Error: CRC is unreachable. Please try recreating the cluster."
+  exit 1
+fi
+
+echo "SUCCESS! kubeconfig=${HOME}/.crc/machines/crc/kubeconfig"

--- a/scripts/sync_get_candidates.sh
+++ b/scripts/sync_get_candidates.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+
+num_commits=256
+
+set +u
+while getopts 'n:' flag; do
+  case "${flag}" in
+    n) num_commits=${optarg}; shift ;;
+    \?) exit 1 ;;
+    *) echo "unexpected option ${flag}"; exit 1 ;;
+  esac
+
+  shift
+done
+set -u
+
+remote="${1:-api}"
+branch="${2:-master}"
+
+# slurp command output by newline, creating an array
+mapfile -t remote_commits < <(git rev-list --topo-order --no-merges -n "${num_commits}" "${remote}/${branch}" | tac)
+
+picked=0
+cherrypick_set="${remote}.cherrypick"
+: > "${cherrypick_set}" # clear existing file
+for rc in "${remote_commits[@]}"; do
+    if [[ -z $(git log -n 1 --no-merges --grep "${rc}" HEAD) ]]; then
+        printf '%s\n' "${rc}" >> "${cherrypick_set}"
+        (( ++picked ))
+    fi
+done
+
+printf '%d cherry-pick candidate(s) written to %s\n' "${picked}" "${cherrypick_set}"
+printf 'run "pop_candidate.sh -a %s" to cherry-pick all\n' "${remote}"

--- a/scripts/sync_pop_candidate.sh
+++ b/scripts/sync_pop_candidate.sh
@@ -1,0 +1,76 @@
+
+#!/bin/bash
+
+
+cph=$(git rev-list -n 1 CHERRY_PICK_HEAD 2> /dev/null)
+
+set -o errexit
+set -o pipefail
+
+pop_all=true
+
+set +u
+while getopts 'a:' flag; do
+  case "${flag}" in
+    a) pop_all=true; shift ;;
+    \?) exit 1 ;;
+    *) echo "unexpected option ${flag}"; exit 1 ;;
+  esac
+
+  shift
+done
+set -u
+
+remote="${1:-api}"
+subtree_dir="staging/${remote}"
+cherrypick_set="${remote}.cherrypick"
+remaining=$(wc -l < "${cherrypick_set}")
+
+function pop() {
+    rc=$(head -n 1 "${cherrypick_set}")
+    if [[ ! $rc ]]; then
+        printf 'nothing to pick'
+        exit
+    fi
+    printf 'popping: %s\n' "${rc}"
+
+    if [[ ! $cph ]]; then
+        git cherry-pick --allow-empty --keep-redundant-commits -Xsubtree="${subtree_dir}" "${rc}"
+    else
+        if [[ $cph != "${rc}" ]]; then
+            printf 'unexpected CHERRY_PICK_HEAD:\ngot %s\nexpected: %s\n' "${cph}" "${rc}"
+            exit
+        fi
+        printf 'cherry-pick in progress for %s\n' "${cph}"
+        git add .
+
+        if [[ -z $(git status --porcelain) ]]; then
+            git commit --allow-empty
+        else
+            git cherry-pick --continue
+        fi
+    fi
+
+
+    # 1. Pop next commit off cherrypick set
+    # 2. Cherry-pick
+    # 3. Ammend commit
+    # 4. Remove from cherrypick set
+    make vendor
+    make manifests
+    git add .
+    git status
+    git commit --amend --allow-empty --no-edit --trailer "Upstream-repository: ${remote}" --trailer "Upstream-commit: ${rc}"
+
+    tmp_set=$(mktemp)
+    tail -n +2 "${cherrypick_set}" > "${tmp_set}"; cat "${tmp_set}" > "${cherrypick_set}"
+
+    (( --remaining ))
+    printf '%d picks remaining (pop_all=%s)\n' "${remaining}" "${pop_all}"
+
+    if [[ $pop_all == 'true' ]] && ((  remaining >  0 )); then
+        pop
+    fi
+}
+
+pop


### PR DESCRIPTION
This PR:
* Introduces new scripts to provision a crc cluster and deploy olm onto it
* Introduces a new `values-crc-e2e.yaml` to adjust the images, arguments, and ImagePullPolicy of the deployments
* Introduces additional `*.crc.e2e.yaml` yaml patch files to patch additional olm manifests
* Adds new make targets for interacting with th deployment scripts
* Adds documentation on how ci and downstream sync work
* Adds documentation on how to use crc for e2e tests