### PR TITLE
Makefile: Remove the duplicate unit/psm target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,10 +96,6 @@ bin/cpb: FORCE
 	CGO_ENABLED=0 go build $(GO_BUILD_OPTS) -ldflags '-extldflags "-static"' -o $@ github.com/operator-framework/operator-lifecycle-manager/util/cpb
 
 unit/olm: bin/kubebuilder
-	# TODO(tflannag): This is placeholder until we can add a dedicated
-	# prow test for this unit check
-	echo "Running the PSM unit tests"
-	$(MAKE) unit/psm
 	echo "Running the OLM unit tests"
 	$(MAKE) unit WHAT=operator-lifecycle-manager
 


### PR DESCRIPTION
Follow-up to https://github.com/openshift/release/pull/27305 which moved the PSM unit tests to it's own dedicated prowjob in 4.11+.

Signed-off-by: timflannagan <timflannagan@gmail.com>