### PR TITLE
Bug 2070131: Fix a bug in deletion of webhook service for replacement

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/install/certresources.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/install/certresources.go
@@ -246,7 +246,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 
 		// Delete the Service to replace
 		deleteErr := i.strategyClient.GetOpClient().DeleteService(service.GetNamespace(), service.GetName(), &metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(deleteErr) {
+		if deleteErr != nil && !k8serrors.IsNotFound(deleteErr) {
 			return nil, nil, fmt.Errorf("could not delete existing service %s", service.GetName())
 		}
 	}

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install/certresources.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install/certresources.go
@@ -246,7 +246,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 
 		// Delete the Service to replace
 		deleteErr := i.strategyClient.GetOpClient().DeleteService(service.GetNamespace(), service.GetName(), &metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(deleteErr) {
+		if deleteErr != nil && !k8serrors.IsNotFound(deleteErr) {
 			return nil, nil, fmt.Errorf("could not delete existing service %s", service.GetName())
 		}
 	}


### PR DESCRIPTION
The condition that checks for an error with the webhook service deletion is based on the wrong variable, and the return statement is never reached, which leads to a continuous error when OLM tries to replace the webhook service on certain conditions

Signed-off-by: orenc1 <ocohen@redhat.com>
Upstream-repository: operator-lifecycle-manager
Upstream-commit: e9aef37a1f293bbbf833206f2037a2f36ffe2673