### PR TITLE
Ensure that the $ARTIFACTS_DIR variable is respected

### DIFF
--- a/staging/operator-lifecycle-manager/.gitignore
+++ b/staging/operator-lifecycle-manager/.gitignore
@@ -455,5 +455,5 @@ apiserver.key
 
 !vendor/**
 test/e2e-local.image.tar
-
+test/e2e/.kube
 dist/

--- a/staging/operator-lifecycle-manager/.golangci.yaml
+++ b/staging/operator-lifecycle-manager/.golangci.yaml
@@ -21,6 +21,24 @@ linters:
   disable:
   - errcheck
 
+linters-settings:
+  importas:
+    alias:
+    - pkg: k8s.io/api/core/v1
+      alias: corev1
+    - pkg: k8s.io/api/apps/v1
+      alias: appsv1
+    - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+      alias: metav1
+    - pkg: k8s.io/apimachinery/pkg/api/errors
+      alias: apierrors
+    - pkg: github.com/operator-framework/api/pkg/operators/v1alpha1
+      alias: operatorsv1alpha1
+    - pkg: github.com/operator-framework/api/pkg/operators/v1
+      alias: operatorsv1
+    - pkg: github.com/operator-framework/api/pkg/operators/v2
+      alias: operatorsv2
+
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/staging/operator-lifecycle-manager/Makefile
+++ b/staging/operator-lifecycle-manager/Makefile
@@ -139,11 +139,10 @@ E2E_TEST_NS ?= operators
 e2e:
 	$(GINKGO) $(E2E_OPTS) $(or $(run), ./test/e2e) $< -- -namespace=$(E2E_TEST_NS) -olmNamespace=$(E2E_INSTALL_NS) -dummyImage=bitnami/nginx:latest $(or $(extra_args), -kubeconfig=${KUBECONFIG})
 
-
 # See workflows/e2e-tests.yml See test/e2e/README.md for details.
 .PHONY: e2e-local
 e2e-local: BUILD_TAGS="json1 experimental_metrics"
-e2e-local: extra_args=-kind.images=../test/e2e-local.image.tar -test-data-dir=../test/e2e/testdata
+e2e-local: extra_args=-kind.images=../test/e2e-local.image.tar -test-data-dir=../test/e2e/testdata -gather-artifacts-script-path=../test/e2e/collect-ci-artifacts.sh
 e2e-local: run=bin/e2e-local.test
 e2e-local: bin/e2e-local.test test/e2e-local.image.tar
 e2e-local: e2e

--- a/staging/operator-lifecycle-manager/cmd/olm/main.go
+++ b/staging/operator-lifecycle-manager/cmd/olm/main.go
@@ -13,7 +13,7 @@ import (
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -103,8 +103,8 @@ func main() {
 	// the empty string, the resulting array will be `[]string{""}`.
 	namespaces := strings.Split(*watchedNamespaces, ",")
 	for _, ns := range namespaces {
-		if ns == v1.NamespaceAll {
-			namespaces = []string{v1.NamespaceAll}
+		if ns == corev1.NamespaceAll {
+			namespaces = []string{corev1.NamespaceAll}
 			break
 		}
 	}

--- a/staging/operator-lifecycle-manager/pkg/controller/install/apiservice.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/install/apiservice.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 
@@ -26,7 +26,7 @@ func (i *StrategyDeploymentInstaller) createOrUpdateAPIService(caPEM []byte, des
 	exists := true
 	apiService, err := i.strategyClient.GetOpLister().APIRegistrationV1().APIServiceLister().Get(apiServiceName)
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 
@@ -120,14 +120,14 @@ func IsAPIServiceAdoptable(opLister operatorlister.OperatorLister, target *v1alp
 
 	// Get the CSV that target replaces
 	replacing, replaceGetErr := opLister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(target.GetNamespace()).Get(target.Spec.Replaces)
-	if replaceGetErr != nil && !k8serrors.IsNotFound(replaceGetErr) && !k8serrors.IsGone(replaceGetErr) {
+	if replaceGetErr != nil && !apierrors.IsNotFound(replaceGetErr) && !apierrors.IsGone(replaceGetErr) {
 		err = replaceGetErr
 		return
 	}
 
 	// Get the current owner CSV of the APIService
 	currentOwnerCSV, ownerGetErr := opLister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(ownerNamespace).Get(ownerName)
-	if ownerGetErr != nil && !k8serrors.IsNotFound(ownerGetErr) && !k8serrors.IsGone(ownerGetErr) {
+	if ownerGetErr != nil && !apierrors.IsNotFound(ownerGetErr) && !apierrors.IsGone(ownerGetErr) {
 		err = ownerGetErr
 		return
 	}
@@ -179,13 +179,13 @@ func (i *StrategyDeploymentInstaller) deleteLegacyAPIServiceResources(desc apiSe
 		// Attempt to delete the legacy Service.
 		existingService, err := i.strategyClient.GetOpClient().GetService(namespace, legacyServiceName)
 		if err != nil {
-			if !k8serrors.IsNotFound(err) {
+			if !apierrors.IsNotFound(err) {
 				return err
 			}
 		} else if ownerutil.AdoptableLabels(existingService.GetLabels(), true, i.owner) {
 			logger.Infof("Deleting Service with legacy APIService name %s", existingService.Name)
 			err = i.strategyClient.GetOpClient().DeleteService(namespace, legacyServiceName, &metav1.DeleteOptions{})
-			if err != nil && !k8serrors.IsNotFound(err) {
+			if err != nil && !apierrors.IsNotFound(err) {
 				return err
 			}
 		} else {
@@ -198,13 +198,13 @@ func (i *StrategyDeploymentInstaller) deleteLegacyAPIServiceResources(desc apiSe
 	// Attempt to delete the legacy Secret.
 	existingSecret, err := i.strategyClient.GetOpClient().GetSecret(namespace, SecretName(apiServiceName))
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else if ownerutil.AdoptableLabels(existingSecret.GetLabels(), true, i.owner) {
 		logger.Infof("Deleting Secret with legacy APIService name %s", existingSecret.Name)
 		err = i.strategyClient.GetOpClient().DeleteSecret(namespace, SecretName(apiServiceName), &metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else {
@@ -214,13 +214,13 @@ func (i *StrategyDeploymentInstaller) deleteLegacyAPIServiceResources(desc apiSe
 	// Attempt to delete the legacy Role.
 	existingRole, err := i.strategyClient.GetOpClient().GetRole(namespace, SecretName(apiServiceName))
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else if ownerutil.AdoptableLabels(existingRole.GetLabels(), true, i.owner) {
 		logger.Infof("Deleting Role with legacy APIService name %s", existingRole.Name)
 		err = i.strategyClient.GetOpClient().DeleteRole(namespace, SecretName(apiServiceName), &metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else {
@@ -230,13 +230,13 @@ func (i *StrategyDeploymentInstaller) deleteLegacyAPIServiceResources(desc apiSe
 	// Attempt to delete the legacy secret RoleBinding.
 	existingRoleBinding, err := i.strategyClient.GetOpClient().GetRoleBinding(namespace, SecretName(apiServiceName))
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else if ownerutil.AdoptableLabels(existingRoleBinding.GetLabels(), true, i.owner) {
 		logger.Infof("Deleting RoleBinding with legacy APIService name %s", existingRoleBinding.Name)
 		err = i.strategyClient.GetOpClient().DeleteRoleBinding(namespace, SecretName(apiServiceName), &metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else {
@@ -246,13 +246,13 @@ func (i *StrategyDeploymentInstaller) deleteLegacyAPIServiceResources(desc apiSe
 	// Attempt to delete the legacy ClusterRoleBinding.
 	existingClusterRoleBinding, err := i.strategyClient.GetOpClient().GetClusterRoleBinding(apiServiceName + "-system:auth-delegator")
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else if ownerutil.AdoptableLabels(existingClusterRoleBinding.GetLabels(), true, i.owner) {
 		logger.Infof("Deleting ClusterRoleBinding with legacy APIService name %s", existingClusterRoleBinding.Name)
 		err = i.strategyClient.GetOpClient().DeleteClusterRoleBinding(apiServiceName+"-system:auth-delegator", &metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else {
@@ -262,13 +262,13 @@ func (i *StrategyDeploymentInstaller) deleteLegacyAPIServiceResources(desc apiSe
 	// Attempt to delete the legacy AuthReadingRoleBinding.
 	existingRoleBinding, err = i.strategyClient.GetOpClient().GetRoleBinding(KubeSystem, apiServiceName+"-auth-reader")
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else if ownerutil.AdoptableLabels(existingRoleBinding.GetLabels(), true, i.owner) {
 		logger.Infof("Deleting RoleBinding with legacy APIService name %s", existingRoleBinding.Name)
 		err = i.strategyClient.GetOpClient().DeleteRoleBinding(KubeSystem, apiServiceName+"-auth-reader", &metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else {

--- a/staging/operator-lifecycle-manager/pkg/controller/install/certresources.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/install/certresources.go
@@ -9,7 +9,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -246,7 +246,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 
 		// Delete the Service to replace
 		deleteErr := i.strategyClient.GetOpClient().DeleteService(service.GetNamespace(), service.GetName(), &metav1.DeleteOptions{})
-		if deleteErr != nil && !k8serrors.IsNotFound(deleteErr) {
+		if deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
 			return nil, nil, fmt.Errorf("could not delete existing service %s", service.GetName())
 		}
 	}
@@ -315,11 +315,11 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 			logger.Warnf("could not update secret %s", secret.GetName())
 			return nil, nil, err
 		}
-	} else if k8serrors.IsNotFound(err) {
+	} else if apierrors.IsNotFound(err) {
 		// Create the secret
 		ownerutil.AddNonBlockingOwner(secret, i.owner)
 		if _, err := i.strategyClient.GetOpClient().CreateSecret(secret); err != nil {
-			if !k8serrors.IsAlreadyExists(err) {
+			if !apierrors.IsAlreadyExists(err) {
 				log.Warnf("could not create secret %s: %v", secret.GetName(), err)
 				return nil, nil, err
 			}
@@ -360,7 +360,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 			logger.Warnf("could not update secret role %s", secretRole.GetName())
 			return nil, nil, err
 		}
-	} else if k8serrors.IsNotFound(err) {
+	} else if apierrors.IsNotFound(err) {
 		// Create the role
 		ownerutil.AddNonBlockingOwner(secretRole, i.owner)
 		_, err = i.strategyClient.GetOpClient().CreateRole(secretRole)
@@ -406,7 +406,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 			logger.Warnf("could not update secret rolebinding %s", secretRoleBinding.GetName())
 			return nil, nil, err
 		}
-	} else if k8serrors.IsNotFound(err) {
+	} else if apierrors.IsNotFound(err) {
 		// Create the role
 		ownerutil.AddNonBlockingOwner(secretRoleBinding, i.owner)
 		_, err = i.strategyClient.GetOpClient().CreateRoleBinding(secretRoleBinding)
@@ -451,7 +451,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 			logger.Warnf("could not update auth delegator clusterrolebinding %s", authDelegatorClusterRoleBinding.GetName())
 			return nil, nil, err
 		}
-	} else if k8serrors.IsNotFound(err) {
+	} else if apierrors.IsNotFound(err) {
 		// Create the role.
 		if err := ownerutil.AddOwnerLabels(authDelegatorClusterRoleBinding, i.owner); err != nil {
 			return nil, nil, err
@@ -498,7 +498,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 			logger.Warnf("could not update auth reader role binding %s", authReaderRoleBinding.GetName())
 			return nil, nil, err
 		}
-	} else if k8serrors.IsNotFound(err) {
+	} else if apierrors.IsNotFound(err) {
 		// Create the role.
 		if err := ownerutil.AddOwnerLabels(authReaderRoleBinding, i.owner); err != nil {
 			return nil, nil, err

--- a/staging/operator-lifecycle-manager/pkg/controller/install/deployment.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/install/deployment.go
@@ -7,7 +7,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/utils/pointer"
@@ -192,7 +192,7 @@ func (i *StrategyDeploymentInstaller) Install(s Strategy) error {
 	}
 
 	if err := i.installDeployments(updatedStrategy.DeploymentSpecs); err != nil {
-		if k8serrors.IsForbidden(err) {
+		if apierrors.IsForbidden(err) {
 			return StrategyError{Reason: StrategyErrInsufficientPermissions, Message: fmt.Sprintf("install strategy failed: %s", err)}
 		}
 		return err

--- a/staging/operator-lifecycle-manager/pkg/controller/install/rule_checker_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/install/rule_checker_test.go
@@ -18,12 +18,12 @@ import (
 	"k8s.io/client-go/tools/cache"
 	apiregistrationfake "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake"
 
-	v1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 )
 
 func TestRuleSatisfied(t *testing.T) {
-	csv := &v1alpha1.ClusterServiceVersion{}
+	csv := &operatorsv1alpha1.ClusterServiceVersion{}
 	csv.SetName("barista-operator")
 	csv.SetUID(types.UID("barista-operator"))
 
@@ -572,7 +572,7 @@ func TestRuleSatisfied(t *testing.T) {
 	}
 }
 
-func NewFakeCSVRuleChecker(k8sObjs []runtime.Object, csv *v1alpha1.ClusterServiceVersion, namespace string, stopCh <-chan struct{}) (*CSVRuleChecker, error) {
+func NewFakeCSVRuleChecker(k8sObjs []runtime.Object, csv *operatorsv1alpha1.ClusterServiceVersion, namespace string, stopCh <-chan struct{}) (*CSVRuleChecker, error) {
 	// create client fakes
 	opClientFake := operatorclient.NewClient(k8sfake.NewSimpleClientset(k8sObjs...), apiextensionsfake.NewSimpleClientset(), apiregistrationfake.NewSimpleClientset())
 

--- a/staging/operator-lifecycle-manager/pkg/controller/install/status_viewer_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/install/status_viewer_test.go
@@ -5,24 +5,24 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	apps "k8s.io/api/apps/v1"
-	core "k8s.io/api/core/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestDeploymentStatusViewerStatus(t *testing.T) {
 	tests := []struct {
 		generation int64
-		status     apps.DeploymentStatus
+		status     appsv1.DeploymentStatus
 		err        error
 		msg        string
 		done       bool
 	}{
 		{
-			status: apps.DeploymentStatus{
-				Conditions: []apps.DeploymentCondition{
+			status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{
 					{
-						Type:   apps.DeploymentProgressing,
+						Type:   appsv1.DeploymentProgressing,
 						Reason: TimedOutReason,
 					},
 				},
@@ -31,15 +31,15 @@ func TestDeploymentStatusViewerStatus(t *testing.T) {
 			done: false,
 		},
 		{
-			status: apps.DeploymentStatus{
-				Conditions: []apps.DeploymentCondition{
+			status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{
 					{
-						Type:   apps.DeploymentProgressing,
+						Type:   appsv1.DeploymentProgressing,
 						Reason: "NotTimedOut",
 					},
 					{
-						Type:   apps.DeploymentAvailable,
-						Status: core.ConditionTrue,
+						Type:   appsv1.DeploymentAvailable,
+						Status: corev1.ConditionTrue,
 					},
 				},
 			},
@@ -48,14 +48,14 @@ func TestDeploymentStatusViewerStatus(t *testing.T) {
 		},
 		{
 			generation: 1,
-			status: apps.DeploymentStatus{
+			status: appsv1.DeploymentStatus{
 				ObservedGeneration: 0,
 			},
 			msg:  "waiting for spec update of deployment \"foo\" to be observed...",
 			done: false,
 		},
 		{
-			status: apps.DeploymentStatus{
+			status: appsv1.DeploymentStatus{
 				Replicas:        5,
 				UpdatedReplicas: 3,
 			},
@@ -63,16 +63,16 @@ func TestDeploymentStatusViewerStatus(t *testing.T) {
 			done: false,
 		},
 		{
-			status: apps.DeploymentStatus{},
-			msg:    fmt.Sprintf("deployment \"foo\" not available: missing condition %q", apps.DeploymentAvailable),
+			status: appsv1.DeploymentStatus{},
+			msg:    fmt.Sprintf("deployment \"foo\" not available: missing condition %q", appsv1.DeploymentAvailable),
 			done:   false,
 		},
 		{
-			status: apps.DeploymentStatus{
-				Conditions: []apps.DeploymentCondition{
+			status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{
 					{
-						Type:    apps.DeploymentAvailable,
-						Status:  core.ConditionFalse,
+						Type:    appsv1.DeploymentAvailable,
+						Status:  corev1.ConditionFalse,
 						Message: "test message",
 					},
 				},
@@ -81,11 +81,11 @@ func TestDeploymentStatusViewerStatus(t *testing.T) {
 			done: false,
 		},
 		{
-			status: apps.DeploymentStatus{
-				Conditions: []apps.DeploymentCondition{
+			status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{
 					{
-						Type:    apps.DeploymentAvailable,
-						Status:  core.ConditionUnknown,
+						Type:    appsv1.DeploymentAvailable,
+						Status:  corev1.ConditionUnknown,
 						Message: "test message",
 					},
 				},
@@ -94,11 +94,11 @@ func TestDeploymentStatusViewerStatus(t *testing.T) {
 			done: false,
 		},
 		{
-			status: apps.DeploymentStatus{
-				Conditions: []apps.DeploymentCondition{
+			status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{
 					{
-						Type:   apps.DeploymentAvailable,
-						Status: core.ConditionTrue,
+						Type:   appsv1.DeploymentAvailable,
+						Status: corev1.ConditionTrue,
 					},
 				},
 			},
@@ -109,7 +109,7 @@ func TestDeploymentStatusViewerStatus(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("%d", i+1), func(t *testing.T) {
-			d := &apps.Deployment{
+			d := &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:  "bar",
 					Name:       "foo",

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
@@ -21,7 +21,7 @@ import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
 	extinf "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -629,7 +629,7 @@ func (o *Operator) syncConfigMap(logger *logrus.Entry, in *v1alpha1.CatalogSourc
 	// Get the catalog source's config map
 	configMap, err := o.lister.CoreV1().ConfigMapLister().ConfigMaps(in.GetNamespace()).Get(in.Spec.ConfigMap)
 	// Attempt to look up the CM via api call if there is a cache miss
-	if k8serrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		configMap, err = o.opClient.KubernetesInterface().CoreV1().ConfigMaps(in.GetNamespace()).Get(context.TODO(), in.Spec.ConfigMap, metav1.GetOptions{})
 		// Found cm in the cluster, add managed label to configmap
 		if err == nil {
@@ -2322,7 +2322,7 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 			}
 			return nil
 		}(i, step); err != nil {
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				// Check for APIVersions present in the installplan steps that are not available on the server.
 				// The check is made via discovery per step in the plan. Transient communication failures to the api-server are handled by the plan retry logic.
 				notFoundErr := discoveryQuerier.WithStepResource(step.Resource).QueryForGVK()

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/step_ensurer.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/step_ensurer.go
@@ -8,7 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
@@ -43,7 +43,7 @@ func (o *StepEnsurer) EnsureClusterServiceVersion(csv *v1alpha1.ClusterServiceVe
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating csv %s", csv.GetName())
 		return
 	}
@@ -60,7 +60,7 @@ func (o *StepEnsurer) EnsureSubscription(subscription *v1alpha1.Subscription) (s
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating subscription %s", subscription.GetName())
 		return
 	}
@@ -74,7 +74,7 @@ func (o *StepEnsurer) EnsureSubscription(subscription *v1alpha1.Subscription) (s
 func (o *StepEnsurer) EnsureSecret(operatorNamespace, planNamespace, name string) (status v1alpha1.StepStatus, err error) {
 	secret, getError := o.kubeClient.KubernetesInterface().CoreV1().Secrets(operatorNamespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if getError != nil {
-		if k8serrors.IsNotFound(getError) {
+		if apierrors.IsNotFound(getError) {
 			err = fmt.Errorf("secret %s does not exist - %v", name, getError)
 			return
 		}
@@ -97,7 +97,7 @@ func (o *StepEnsurer) EnsureSecret(operatorNamespace, planNamespace, name string
 	}
 
 	if _, createError := o.kubeClient.KubernetesInterface().CoreV1().Secrets(planNamespace).Create(context.TODO(), newSecret, metav1.CreateOptions{}); createError != nil {
-		if k8serrors.IsAlreadyExists(createError) {
+		if apierrors.IsAlreadyExists(createError) {
 			status = v1alpha1.StepStatusPresent
 			return
 		}
@@ -118,7 +118,7 @@ func (o *StepEnsurer) EnsureBundleSecret(namespace string, secret *corev1.Secret
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error updating secret: %s", secret.GetName())
 		return
 	}
@@ -142,7 +142,7 @@ func (o *StepEnsurer) EnsureServiceAccount(namespace string, sa *corev1.ServiceA
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating service account: %s", sa.GetName())
 		return
 	}
@@ -180,7 +180,7 @@ func (o *StepEnsurer) EnsureService(namespace string, service *corev1.Service) (
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error updating service: %s", service.GetName())
 		return
 	}
@@ -203,7 +203,7 @@ func (o *StepEnsurer) EnsureClusterRole(cr *rbacv1.ClusterRole, step *v1alpha1.S
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating clusterrole %s", cr.GetName())
 		return
 	}
@@ -230,7 +230,7 @@ func (o *StepEnsurer) EnsureClusterRoleBinding(crb *rbacv1.ClusterRoleBinding, s
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating clusterrolebinding %s", crb.GetName())
 		return
 	}
@@ -257,7 +257,7 @@ func (o *StepEnsurer) EnsureRole(namespace string, role *rbacv1.Role) (status v1
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating role %s", role.GetName())
 		return
 	}
@@ -281,7 +281,7 @@ func (o *StepEnsurer) EnsureRoleBinding(namespace string, rb *rbacv1.RoleBinding
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating rolebinding %s", rb.GetName())
 		return
 	}
@@ -304,7 +304,7 @@ func (o *StepEnsurer) EnsureUnstructuredObject(client dynamic.ResourceInterface,
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating unstructured object %s", obj.GetName())
 		return
 	}
@@ -336,7 +336,7 @@ func (o *StepEnsurer) EnsureConfigMap(namespace string, configmap *corev1.Config
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error updating configmap: %s", configmap.GetName())
 		return
 	}

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/apiservices.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/apiservices.go
@@ -7,7 +7,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -148,7 +148,7 @@ func (a *Operator) checkAPIServiceResources(csv *v1alpha1.ClusterServiceVersion,
 
 		// Ensure the existing Deployment has a matching CA hash annotation
 		deployment, err := a.lister.AppsV1().DeploymentLister().Deployments(csv.GetNamespace()).Get(desc.DeploymentName)
-		if k8serrors.IsNotFound(err) || err != nil {
+		if apierrors.IsNotFound(err) || err != nil {
 			logger.WithField("deployment", desc.DeploymentName).Warnf("expected Deployment could not be retrieved")
 			errs = append(errs, err)
 			continue
@@ -227,7 +227,7 @@ func (a *Operator) checkAPIServiceResources(csv *v1alpha1.ClusterServiceVersion,
 func (a *Operator) areAPIServicesAvailable(csv *v1alpha1.ClusterServiceVersion) (bool, error) {
 	for _, desc := range csv.Spec.APIServiceDefinitions.Owned {
 		apiService, err := a.lister.APIRegistrationV1().APIServiceLister().Get(desc.GetName())
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return false, nil
 		}
 
@@ -410,7 +410,7 @@ func (a *Operator) cleanUpRemovedWebhooks(csv *v1alpha1.ClusterServiceVersion) e
 		}
 		if _, ok := csvWebhookGenerateNames[webhookGenerateNameLabel]; !ok {
 			err = a.opClient.KubernetesInterface().AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(context.TODO(), webhook.Name, metav1.DeleteOptions{})
-			if err != nil && k8serrors.IsNotFound(err) {
+			if err != nil && apierrors.IsNotFound(err) {
 				return err
 			}
 		}
@@ -428,7 +428,7 @@ func (a *Operator) cleanUpRemovedWebhooks(csv *v1alpha1.ClusterServiceVersion) e
 		}
 		if _, ok := csvWebhookGenerateNames[webhookGenerateNameLabel]; !ok {
 			err = a.opClient.KubernetesInterface().AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(context.TODO(), webhook.Name, metav1.DeleteOptions{})
-			if err != nil && k8serrors.IsNotFound(err) {
+			if err != nil && apierrors.IsNotFound(err) {
 				return err
 			}
 		}

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/groups.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/groups.go
@@ -3,7 +3,7 @@ package olm
 import (
 	"strings"
 
-	v1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 )
 
@@ -106,14 +106,14 @@ type OperatorGroup struct {
 	providedAPIs cache.APISet
 }
 
-func NewOperatorGroup(group *v1.OperatorGroup) *OperatorGroup {
+func NewOperatorGroup(group *operatorsv1.OperatorGroup) *OperatorGroup {
 	// Add operatorgroup namespace if not NamespaceAll
 	namespaces := group.Status.Namespaces
 	if len(namespaces) >= 1 && namespaces[0] != "" {
 		namespaces = append(namespaces, group.GetNamespace())
 	}
 	// TODO: Sanitize OperatorGroup if len(namespaces) > 1 and contains ""
-	gvksStr := group.GetAnnotations()[v1.OperatorGroupProvidedAPIsAnnotationKey]
+	gvksStr := group.GetAnnotations()[operatorsv1.OperatorGroupProvidedAPIsAnnotationKey]
 
 	return &OperatorGroup{
 		namespace:    group.GetNamespace(),
@@ -123,7 +123,7 @@ func NewOperatorGroup(group *v1.OperatorGroup) *OperatorGroup {
 	}
 }
 
-func NewOperatorGroupSurfaces(groups ...v1.OperatorGroup) []OperatorGroupSurface {
+func NewOperatorGroupSurfaces(groups ...operatorsv1.OperatorGroup) []OperatorGroupSurface {
 	operatorGroups := make([]OperatorGroupSurface, len(groups))
 	for i, group := range groups {
 		operatorGroups[i] = NewOperatorGroup(&group)

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/groups_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/groups_test.go
@@ -4,24 +4,24 @@ import (
 	"strings"
 	"testing"
 
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 )
 
-func buildAPIOperatorGroup(namespace, name string, targets []string, gvks []string) *v1.OperatorGroup {
-	return &v1.OperatorGroup{
+func buildAPIOperatorGroup(namespace, name string, targets []string, gvks []string) *operatorsv1.OperatorGroup {
+	return &operatorsv1.OperatorGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
 			Annotations: map[string]string{
-				v1.OperatorGroupProvidedAPIsAnnotationKey: strings.Join(gvks, ","),
+				operatorsv1.OperatorGroupProvidedAPIsAnnotationKey: strings.Join(gvks, ","),
 			},
 		},
-		Status: v1.OperatorGroupStatus{
+		Status: operatorsv1.OperatorGroupStatus{
 			Namespaces: targets,
 		},
 	}
@@ -29,7 +29,7 @@ func buildAPIOperatorGroup(namespace, name string, targets []string, gvks []stri
 func TestNewOperatorGroup(t *testing.T) {
 	tests := []struct {
 		name string
-		in   *v1.OperatorGroup
+		in   *operatorsv1.OperatorGroup
 		want *OperatorGroup
 	}{
 		{

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operatorconditions.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operatorconditions.go
@@ -3,7 +3,7 @@ package olm
 import (
 	"fmt"
 
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -19,7 +19,7 @@ func (a *Operator) isOperatorUpgradeable(csv *v1alpha1.ClusterServiceVersion) (b
 
 	cond, err := a.lister.OperatorsV2().OperatorConditionLister().OperatorConditions(csv.GetNamespace()).Get(csv.GetName())
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return true, nil
 		}
 		return false, err

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operatorgroup.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operatorgroup.go
@@ -7,17 +7,17 @@ import (
 	"reflect"
 	"strings"
 
-	v1 "github.com/operator-framework/api/pkg/operators/v1"
 	utillabels "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/util/labels"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/errors"
 
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/decorators"
@@ -54,7 +54,7 @@ func aggregationLabelFromAPIKey(k opregistry.APIKey, suffix string) (string, err
 }
 
 func (a *Operator) syncOperatorGroups(obj interface{}) error {
-	op, ok := obj.(*v1.OperatorGroup)
+	op, ok := obj.(*operatorsv1.OperatorGroup)
 	if !ok {
 		a.logger.Debugf("wrong type: %#v\n", obj)
 		return fmt.Errorf("casting OperatorGroup failed")
@@ -74,10 +74,10 @@ func (a *Operator) syncOperatorGroups(obj interface{}) error {
 	// Check if there is a stale multiple OG condition and clear it if existed.
 	if len(groups) == 1 {
 		og := groups[0].DeepCopy()
-		if c := meta.FindStatusCondition(og.Status.Conditions, v1.MutlipleOperatorGroupCondition); c != nil {
-			meta.RemoveStatusCondition(&og.Status.Conditions, v1.MutlipleOperatorGroupCondition)
+		if c := meta.FindStatusCondition(og.Status.Conditions, operatorsv1.MutlipleOperatorGroupCondition); c != nil {
+			meta.RemoveStatusCondition(&og.Status.Conditions, operatorsv1.MutlipleOperatorGroupCondition)
 			if og.GetName() == op.GetName() {
-				meta.RemoveStatusCondition(&op.Status.Conditions, v1.MutlipleOperatorGroupCondition)
+				meta.RemoveStatusCondition(&op.Status.Conditions, operatorsv1.MutlipleOperatorGroupCondition)
 			}
 			_, err = a.client.OperatorsV1().OperatorGroups(op.GetNamespace()).UpdateStatus(context.TODO(), og, metav1.UpdateOptions{})
 			if err != nil {
@@ -88,14 +88,14 @@ func (a *Operator) syncOperatorGroups(obj interface{}) error {
 		// Add to all OG's status conditions to indicate they're multiple OGs in the
 		// same namespace which is not allowed.
 		cond := metav1.Condition{
-			Type:    v1.MutlipleOperatorGroupCondition,
+			Type:    operatorsv1.MutlipleOperatorGroupCondition,
 			Status:  metav1.ConditionTrue,
-			Reason:  v1.MultipleOperatorGroupsReason,
+			Reason:  operatorsv1.MultipleOperatorGroupsReason,
 			Message: "Multiple OperatorGroup found in the same namespace",
 		}
 		for i := range groups {
 			og := groups[i].DeepCopy()
-			if c := meta.FindStatusCondition(og.Status.Conditions, v1.MutlipleOperatorGroupCondition); c != nil {
+			if c := meta.FindStatusCondition(og.Status.Conditions, operatorsv1.MutlipleOperatorGroupCondition); c != nil {
 				continue
 			}
 			meta.SetStatusCondition(&og.Status.Conditions, cond)
@@ -122,7 +122,7 @@ func (a *Operator) syncOperatorGroups(obj interface{}) error {
 		}
 		for i := range csvList {
 			csv := csvList[i].DeepCopy()
-			if group, ok := csv.GetAnnotations()[v1.OperatorGroupAnnotationKey]; !ok || group != op.GetName() {
+			if group, ok := csv.GetAnnotations()[operatorsv1.OperatorGroupAnnotationKey]; !ok || group != op.GetName() {
 				continue
 			}
 			if csv.Status.Reason == v1alpha1.CSVReasonComponentFailedNoRetry {
@@ -152,13 +152,13 @@ func (a *Operator) syncOperatorGroups(obj interface{}) error {
 
 		// Update operatorgroup target namespace selection
 		logger.WithField("targets", targetNamespaces).Debug("namespace change detected")
-		op.Status = v1.OperatorGroupStatus{
+		op.Status = operatorsv1.OperatorGroupStatus{
 			Namespaces:  targetNamespaces,
 			LastUpdated: a.now(),
 			Conditions:  op.Status.Conditions,
 		}
 
-		if _, err = a.client.OperatorsV1().OperatorGroups(op.GetNamespace()).UpdateStatus(context.TODO(), op, metav1.UpdateOptions{}); err != nil && !k8serrors.IsNotFound(err) {
+		if _, err = a.client.OperatorsV1().OperatorGroups(op.GetNamespace()).UpdateStatus(context.TODO(), op, metav1.UpdateOptions{}); err != nil && !apierrors.IsNotFound(err) {
 			logger.WithError(err).Warn("operatorgroup update failed")
 			return err
 		}
@@ -223,7 +223,7 @@ func (a *Operator) syncOperatorGroups(obj interface{}) error {
 }
 
 func (a *Operator) operatorGroupDeleted(obj interface{}) {
-	op, ok := obj.(*v1.OperatorGroup)
+	op, ok := obj.(*operatorsv1.OperatorGroup)
 	if !ok {
 		a.logger.Debugf("casting OperatorGroup failed, wrong type: %#v\n", obj)
 		return
@@ -254,7 +254,7 @@ func (a *Operator) operatorGroupDeleted(obj interface{}) {
 	}
 }
 
-func (a *Operator) annotateCSVs(group *v1.OperatorGroup, targetNamespaces []string, logger *logrus.Entry) error {
+func (a *Operator) annotateCSVs(group *operatorsv1.OperatorGroup, targetNamespaces []string, logger *logrus.Entry) error {
 	updateErrs := []error{}
 	targetNamespaceSet := NewNamespaceSet(targetNamespaces)
 
@@ -264,13 +264,13 @@ func (a *Operator) annotateCSVs(group *v1.OperatorGroup, targetNamespaces []stri
 		}
 		logger := logger.WithField("csv", csv.GetName())
 
-		originalNamespacesAnnotation := a.copyOperatorGroupAnnotations(&csv.ObjectMeta)[v1.OperatorGroupTargetsAnnotationKey]
+		originalNamespacesAnnotation := a.copyOperatorGroupAnnotations(&csv.ObjectMeta)[operatorsv1.OperatorGroupTargetsAnnotationKey]
 		originalNamespaceSet := NewNamespaceSetFromString(originalNamespacesAnnotation)
 
 		if a.operatorGroupAnnotationsDiffer(&csv.ObjectMeta, group) {
 			a.setOperatorGroupAnnotations(&csv.ObjectMeta, group, true)
 			// CRDs don't support strategic merge patching, but in the future if they do this should be updated to patch
-			if _, err := a.client.OperatorsV1alpha1().ClusterServiceVersions(csv.GetNamespace()).Update(context.TODO(), csv, metav1.UpdateOptions{}); err != nil && !k8serrors.IsNotFound(err) {
+			if _, err := a.client.OperatorsV1alpha1().ClusterServiceVersions(csv.GetNamespace()).Update(context.TODO(), csv, metav1.UpdateOptions{}); err != nil && !apierrors.IsNotFound(err) {
 				logger.WithError(err).Warnf("error adding operatorgroup annotations")
 				updateErrs = append(updateErrs, err)
 				continue
@@ -298,7 +298,7 @@ func (a *Operator) annotateCSVs(group *v1.OperatorGroup, targetNamespaces []stri
 	return errors.NewAggregate(updateErrs)
 }
 
-func (a *Operator) providedAPIsFromCSVs(group *v1.OperatorGroup, logger *logrus.Entry) map[opregistry.APIKey]*v1alpha1.ClusterServiceVersion {
+func (a *Operator) providedAPIsFromCSVs(group *operatorsv1.OperatorGroup, logger *logrus.Entry) map[opregistry.APIKey]*v1alpha1.ClusterServiceVersion {
 	set := a.csvSet(group.Namespace, v1alpha1.CSVPhaseAny)
 	providedAPIsFromCSVs := make(map[opregistry.APIKey]*v1alpha1.ClusterServiceVersion)
 	for _, csv := range set {
@@ -323,7 +323,7 @@ func (a *Operator) providedAPIsFromCSVs(group *v1.OperatorGroup, logger *logrus.
 	return providedAPIsFromCSVs
 }
 
-func (a *Operator) pruneProvidedAPIs(group *v1.OperatorGroup, groupProvidedAPIs cache.APISet, providedAPIsFromCSVs map[opregistry.APIKey]*v1alpha1.ClusterServiceVersion, logger *logrus.Entry) {
+func (a *Operator) pruneProvidedAPIs(group *operatorsv1.OperatorGroup, groupProvidedAPIs cache.APISet, providedAPIsFromCSVs map[opregistry.APIKey]*v1alpha1.ClusterServiceVersion, logger *logrus.Entry) {
 	// Don't prune providedAPIsFromCSVs if static
 	if group.Spec.StaticProvidedAPIs {
 		a.logger.Debug("group has static provided apis. skipping provided api pruning")
@@ -337,7 +337,7 @@ func (a *Operator) pruneProvidedAPIs(group *v1.OperatorGroup, groupProvidedAPIs 
 		} else {
 			csv := providedAPIsFromCSVs[api]
 			_, err := a.lister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(csv.GetNamespace()).Get(csv.GetName())
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				continue
 			}
 			if csv.DeletionTimestamp == nil && (csv.Status.Phase == v1alpha1.CSVPhaseNone || csv.Status.Phase == v1alpha1.CSVPhasePending) {
@@ -360,10 +360,10 @@ func (a *Operator) pruneProvidedAPIs(group *v1.OperatorGroup, groupProvidedAPIs 
 
 		// Don't need to check for nil annotations since we already know |annotations| > 0
 		annotations := group.GetAnnotations()
-		annotations[v1.OperatorGroupProvidedAPIsAnnotationKey] = intersection.String()
+		annotations[operatorsv1.OperatorGroupProvidedAPIsAnnotationKey] = intersection.String()
 		group.SetAnnotations(annotations)
 		logger.Debug("removing provided apis from annotation to match cluster state")
-		if _, err := a.client.OperatorsV1().OperatorGroups(group.GetNamespace()).Update(context.TODO(), group, metav1.UpdateOptions{}); err != nil && !k8serrors.IsNotFound(err) {
+		if _, err := a.client.OperatorsV1().OperatorGroups(group.GetNamespace()).Update(context.TODO(), group, metav1.UpdateOptions{}); err != nil && !apierrors.IsNotFound(err) {
 			logger.WithError(err).Warn("could not update provided api annotations")
 		}
 	}
@@ -390,15 +390,15 @@ func (a *Operator) ensureProvidedAPIClusterRole(namePrefix, suffix string, verbs
 	}
 
 	existingCR, err := a.lister.RbacV1().ClusterRoleLister().Get(clusterRole.Name)
-	if err != nil && !k8serrors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
-	if k8serrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		existingCR, err = a.opClient.KubernetesInterface().RbacV1().ClusterRoles().Create(context.TODO(), clusterRole, metav1.CreateOptions{})
 		if err == nil {
 			return nil
 		}
-		if !k8serrors.IsAlreadyExists(err) {
+		if !apierrors.IsAlreadyExists(err) {
 			a.logger.WithError(err).Errorf("Create cluster role failed: %v", clusterRole)
 			return err
 		}
@@ -456,7 +456,7 @@ func (a *Operator) ensureClusterRolesForCSV(csv *v1alpha1.ClusterServiceVersion)
 	return nil
 }
 
-func (a *Operator) ensureRBACInTargetNamespace(csv *v1alpha1.ClusterServiceVersion, operatorGroup *v1.OperatorGroup) error {
+func (a *Operator) ensureRBACInTargetNamespace(csv *v1alpha1.ClusterServiceVersion, operatorGroup *operatorsv1.OperatorGroup) error {
 	targetNamespaces := operatorGroup.Status.Namespaces
 	if targetNamespaces == nil {
 		return nil
@@ -535,7 +535,7 @@ func (a *Operator) ensureSingletonRBAC(operatorNamespace string, csv *v1alpha1.C
 			// TODO: this should do something smarter if the cluster role already exists
 			if cr, err := a.opClient.CreateClusterRole(clusterRole); err != nil {
 				// If the CR already exists, but the label is correct, the cache is just behind
-				if k8serrors.IsAlreadyExists(err) && cr != nil && ownerutil.IsOwnedByLabel(cr, csv) {
+				if apierrors.IsAlreadyExists(err) && cr != nil && ownerutil.IsOwnedByLabel(cr, csv) {
 					continue
 				}
 				return err
@@ -574,7 +574,7 @@ func (a *Operator) ensureSingletonRBAC(operatorNamespace string, csv *v1alpha1.C
 			// TODO: this should do something smarter if the cluster role binding already exists
 			if crb, err := a.opClient.CreateClusterRoleBinding(clusterRoleBinding); err != nil {
 				// If the CRB already exists, but the label is correct, the cache is just behind
-				if k8serrors.IsAlreadyExists(err) && crb != nil && ownerutil.IsOwnedByLabel(crb, csv) {
+				if apierrors.IsAlreadyExists(err) && crb != nil && ownerutil.IsOwnedByLabel(crb, csv) {
 					continue
 				}
 				return err
@@ -688,7 +688,7 @@ func (a *Operator) ensureTenantRBAC(operatorNamespace, targetNamespace string, c
 	return nil
 }
 
-func (a *Operator) ensureCSVsInNamespaces(csv *v1alpha1.ClusterServiceVersion, operatorGroup *v1.OperatorGroup, targets NamespaceSet) error {
+func (a *Operator) ensureCSVsInNamespaces(csv *v1alpha1.ClusterServiceVersion, operatorGroup *operatorsv1.OperatorGroup, targets NamespaceSet) error {
 	namespaces, err := a.lister.CoreV1().NamespaceLister().List(labels.Everything())
 	if err != nil {
 		return err
@@ -798,7 +798,7 @@ func (a *Operator) copyToNamespace(prototype *v1alpha1.ClusterServiceVersion, ns
 	prototype.UID = ""
 
 	existing, err := a.copiedCSVLister.ClusterServiceVersions(nsTo).Get(prototype.GetName())
-	if k8serrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		created, err := a.client.OperatorsV1alpha1().ClusterServiceVersions(nsTo).Create(context.TODO(), prototype, metav1.CreateOptions{})
 		if err != nil {
 			return nil, err
@@ -855,7 +855,7 @@ func (a *Operator) pruneFromNamespace(operatorGroupName, namespace string) error
 	}
 
 	for _, csv := range fetchedCSVs {
-		if csv.IsCopied() && csv.GetAnnotations()[v1.OperatorGroupAnnotationKey] == operatorGroupName {
+		if csv.IsCopied() && csv.GetAnnotations()[operatorsv1.OperatorGroupAnnotationKey] == operatorGroupName {
 			a.logger.Debugf("Found CSV '%v' in namespace %v to delete", csv.GetName(), namespace)
 			if err := a.copiedCSVGCQueueSet.Requeue(csv.GetNamespace(), csv.GetName()); err != nil {
 				return err
@@ -865,36 +865,36 @@ func (a *Operator) pruneFromNamespace(operatorGroupName, namespace string) error
 	return nil
 }
 
-func (a *Operator) setOperatorGroupAnnotations(obj *metav1.ObjectMeta, op *v1.OperatorGroup, addTargets bool) {
-	metav1.SetMetaDataAnnotation(obj, v1.OperatorGroupNamespaceAnnotationKey, op.GetNamespace())
-	metav1.SetMetaDataAnnotation(obj, v1.OperatorGroupAnnotationKey, op.GetName())
+func (a *Operator) setOperatorGroupAnnotations(obj *metav1.ObjectMeta, op *operatorsv1.OperatorGroup, addTargets bool) {
+	metav1.SetMetaDataAnnotation(obj, operatorsv1.OperatorGroupNamespaceAnnotationKey, op.GetNamespace())
+	metav1.SetMetaDataAnnotation(obj, operatorsv1.OperatorGroupAnnotationKey, op.GetName())
 
 	if addTargets && op.Status.Namespaces != nil {
-		metav1.SetMetaDataAnnotation(obj, v1.OperatorGroupTargetsAnnotationKey, op.BuildTargetNamespaces())
+		metav1.SetMetaDataAnnotation(obj, operatorsv1.OperatorGroupTargetsAnnotationKey, op.BuildTargetNamespaces())
 	}
 }
 
-func (a *Operator) operatorGroupAnnotationsDiffer(obj *metav1.ObjectMeta, op *v1.OperatorGroup) bool {
+func (a *Operator) operatorGroupAnnotationsDiffer(obj *metav1.ObjectMeta, op *operatorsv1.OperatorGroup) bool {
 	annotations := obj.GetAnnotations()
 	if annotations == nil {
 		return true
 	}
-	if operatorGroupNamespace, ok := annotations[v1.OperatorGroupNamespaceAnnotationKey]; !ok || operatorGroupNamespace != op.GetNamespace() {
+	if operatorGroupNamespace, ok := annotations[operatorsv1.OperatorGroupNamespaceAnnotationKey]; !ok || operatorGroupNamespace != op.GetNamespace() {
 		return true
 	}
-	if operatorGroup, ok := annotations[v1.OperatorGroupAnnotationKey]; !ok || operatorGroup != op.GetName() {
+	if operatorGroup, ok := annotations[operatorsv1.OperatorGroupAnnotationKey]; !ok || operatorGroup != op.GetName() {
 		return true
 	}
-	if targets, ok := annotations[v1.OperatorGroupTargetsAnnotationKey]; !ok || targets != op.BuildTargetNamespaces() {
+	if targets, ok := annotations[operatorsv1.OperatorGroupTargetsAnnotationKey]; !ok || targets != op.BuildTargetNamespaces() {
 		a.logger.WithFields(logrus.Fields{
-			"annotationTargets": annotations[v1.OperatorGroupTargetsAnnotationKey],
+			"annotationTargets": annotations[operatorsv1.OperatorGroupTargetsAnnotationKey],
 			"opgroupTargets":    op.BuildTargetNamespaces(),
 		}).Debug("annotations different")
 		return true
 	}
 
 	a.logger.WithFields(logrus.Fields{
-		"annotationTargets": annotations[v1.OperatorGroupTargetsAnnotationKey],
+		"annotationTargets": annotations[operatorsv1.OperatorGroupTargetsAnnotationKey],
 		"opgroupTargets":    op.BuildTargetNamespaces(),
 	}).Debug("annotations correct")
 	return false
@@ -904,11 +904,11 @@ func (a *Operator) copyOperatorGroupAnnotations(obj *metav1.ObjectMeta) map[stri
 	copiedAnnotations := make(map[string]string)
 	for k, v := range obj.GetAnnotations() {
 		switch k {
-		case v1.OperatorGroupNamespaceAnnotationKey:
+		case operatorsv1.OperatorGroupNamespaceAnnotationKey:
 			fallthrough
-		case v1.OperatorGroupAnnotationKey:
+		case operatorsv1.OperatorGroupAnnotationKey:
 			fallthrough
-		case v1.OperatorGroupTargetsAnnotationKey:
+		case operatorsv1.OperatorGroupTargetsAnnotationKey:
 			copiedAnnotations[k] = v
 		}
 	}
@@ -932,7 +932,7 @@ func namespacesChanged(clusterNamespaces []string, statusNamespaces []string) bo
 	return false
 }
 
-func (a *Operator) getOperatorGroupTargets(op *v1.OperatorGroup) (map[string]struct{}, error) {
+func (a *Operator) getOperatorGroupTargets(op *operatorsv1.OperatorGroup) (map[string]struct{}, error) {
 	selector, err := metav1.LabelSelectorAsSelector(op.Spec.Selector)
 
 	if err != nil {
@@ -964,7 +964,7 @@ func (a *Operator) getOperatorGroupTargets(op *v1.OperatorGroup) (map[string]str
 	return namespaceSet, nil
 }
 
-func (a *Operator) updateNamespaceList(op *v1.OperatorGroup) ([]string, error) {
+func (a *Operator) updateNamespaceList(op *operatorsv1.OperatorGroup) ([]string, error) {
 	namespaceSet, err := a.getOperatorGroupTargets(op)
 	if err != nil {
 		return nil, err
@@ -977,7 +977,7 @@ func (a *Operator) updateNamespaceList(op *v1.OperatorGroup) ([]string, error) {
 	return namespaceList, nil
 }
 
-func (a *Operator) ensureOpGroupClusterRole(op *v1.OperatorGroup, suffix string, apis cache.APISet) error {
+func (a *Operator) ensureOpGroupClusterRole(op *operatorsv1.OperatorGroup, suffix string, apis cache.APISet) error {
 	clusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: strings.Join([]string{op.GetName(), suffix}, "-"),
@@ -1006,15 +1006,15 @@ func (a *Operator) ensureOpGroupClusterRole(op *v1.OperatorGroup, suffix string,
 	}
 
 	existingRole, err := a.lister.RbacV1().ClusterRoleLister().Get(clusterRole.Name)
-	if err != nil && !k8serrors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
-	if k8serrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		existingRole, err = a.opClient.KubernetesInterface().RbacV1().ClusterRoles().Create(context.TODO(), clusterRole, metav1.CreateOptions{})
 		if err == nil {
 			return nil
 		}
-		if !k8serrors.IsAlreadyExists(err) {
+		if !apierrors.IsAlreadyExists(err) {
 			a.logger.WithError(err).Errorf("Create cluster role failed: %v", clusterRole)
 			return err
 		}
@@ -1031,7 +1031,7 @@ func (a *Operator) ensureOpGroupClusterRole(op *v1.OperatorGroup, suffix string,
 	return nil
 }
 
-func (a *Operator) ensureOpGroupClusterRoles(op *v1.OperatorGroup, apis cache.APISet) error {
+func (a *Operator) ensureOpGroupClusterRoles(op *operatorsv1.OperatorGroup, apis cache.APISet) error {
 	for _, suffix := range Suffices {
 		if err := a.ensureOpGroupClusterRole(op, suffix, apis); err != nil {
 			return err
@@ -1107,7 +1107,7 @@ func csvCopyPrototype(src, dst *v1alpha1.ClusterServiceVersion) {
 		Status: src.Status,
 	}
 	for k, v := range src.Annotations {
-		if k == v1.OperatorGroupTargetsAnnotationKey {
+		if k == operatorsv1.OperatorGroupTargetsAnnotationKey {
 			continue
 		}
 		if k == "kubectl.kubernetes.io/last-applied-configuration" {

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/operatorcondition_controller.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/operatorcondition_controller.go
@@ -8,7 +8,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -147,7 +147,7 @@ func (r *OperatorConditionReconciler) ensureOperatorConditionRole(operatorCondit
 	existingRole := &rbacv1.Role{}
 	err := r.Client.Get(context.TODO(), client.ObjectKey{Name: role.GetName(), Namespace: role.GetNamespace()}, existingRole)
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 		return r.Client.Create(context.TODO(), role)
@@ -193,7 +193,7 @@ func (r *OperatorConditionReconciler) ensureOperatorConditionRoleBinding(operato
 	existingRoleBinding := &rbacv1.RoleBinding{}
 	err := r.Client.Get(context.TODO(), client.ObjectKey{Name: roleBinding.GetName(), Namespace: roleBinding.GetNamespace()}, existingRoleBinding)
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 		return r.Client.Create(context.TODO(), roleBinding)

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/operatorconditiongenerator_controller.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/operatorconditiongenerator_controller.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 
 	"github.com/go-logr/logr"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -156,7 +156,7 @@ func (r *OperatorConditionGeneratorReconciler) ensureOperatorCondition(operatorC
 	existingOperatorCondition := &operatorsv2.OperatorCondition{}
 	err := r.Client.Get(context.TODO(), client.ObjectKey{Name: operatorCondition.GetName(), Namespace: operatorCondition.GetNamespace()}, existingOperatorCondition)
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 		return r.Client.Create(context.TODO(), &operatorCondition)

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/operatorconditiongenerator_controller_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/operatorconditiongenerator_controller_test.go
@@ -8,7 +8,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -147,7 +147,7 @@ var _ = Describe("The OperatorConditionsGenerator Controller", func() {
 		time.Sleep(time.Second * 10)
 		err := k8sClient.Get(ctx, namespacedName, operatorCondition)
 		Expect(err).ToNot(BeNil())
-		Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
 	})
 
 	It("creates an OperatorCondition for a CSV with multiple ServiceAccounts and Deployments", func() {

--- a/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/grpc_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/grpc_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -360,7 +360,7 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 				require.NoError(t, podErr)
 				require.Len(t, outPods.Items, 0)
 				require.NoError(t, err)
-				require.True(t, k8serrors.IsNotFound(serviceErr))
+				require.True(t, apierrors.IsNotFound(serviceErr))
 			}
 		})
 	}

--- a/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
@@ -6,12 +6,12 @@ import (
 	"hash/fnv"
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	controllerclient "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/controller-runtime/client"
 	hashutil "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/util/hash"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
@@ -32,13 +32,13 @@ const (
 // RegistryEnsurer describes methods for ensuring a registry exists.
 type RegistryEnsurer interface {
 	// EnsureRegistryServer ensures a registry server exists for the given CatalogSource.
-	EnsureRegistryServer(catalogSource *v1alpha1.CatalogSource) error
+	EnsureRegistryServer(catalogSource *operatorsv1alpha1.CatalogSource) error
 }
 
 // RegistryChecker describes methods for checking a registry.
 type RegistryChecker interface {
 	// CheckRegistryServer returns true if the given CatalogSource is considered healthy; false otherwise.
-	CheckRegistryServer(catalogSource *v1alpha1.CatalogSource) (healthy bool, err error)
+	CheckRegistryServer(catalogSource *operatorsv1alpha1.CatalogSource) (healthy bool, err error)
 }
 
 // RegistryReconciler knows how to reconcile a registry.
@@ -49,7 +49,7 @@ type RegistryReconciler interface {
 
 // RegistryReconcilerFactory describes factory methods for RegistryReconcilers.
 type RegistryReconcilerFactory interface {
-	ReconcilerForSource(source *v1alpha1.CatalogSource) RegistryReconciler
+	ReconcilerForSource(source *operatorsv1alpha1.CatalogSource) RegistryReconciler
 }
 
 // RegistryReconcilerFactory is a factory for RegistryReconcilers.
@@ -62,17 +62,17 @@ type registryReconcilerFactory struct {
 }
 
 // ReconcilerForSource returns a RegistryReconciler based on the configuration of the given CatalogSource.
-func (r *registryReconcilerFactory) ReconcilerForSource(source *v1alpha1.CatalogSource) RegistryReconciler {
+func (r *registryReconcilerFactory) ReconcilerForSource(source *operatorsv1alpha1.CatalogSource) RegistryReconciler {
 	// TODO: add memoization by source type
 	switch source.Spec.SourceType {
-	case v1alpha1.SourceTypeInternal, v1alpha1.SourceTypeConfigmap:
+	case operatorsv1alpha1.SourceTypeInternal, operatorsv1alpha1.SourceTypeConfigmap:
 		return &ConfigMapRegistryReconciler{
 			now:      r.now,
 			Lister:   r.Lister,
 			OpClient: r.OpClient,
 			Image:    r.ConfigMapServerImage,
 		}
-	case v1alpha1.SourceTypeGrpc:
+	case operatorsv1alpha1.SourceTypeGrpc:
 		if source.Spec.Image != "" {
 			return &GrpcRegistryReconciler{
 				now:       r.now,
@@ -100,66 +100,66 @@ func NewRegistryReconcilerFactory(lister operatorlister.OperatorLister, opClient
 	}
 }
 
-func Pod(source *v1alpha1.CatalogSource, name string, image string, saName string, labels map[string]string, annotations map[string]string, readinessDelay int32, livenessDelay int32) *v1.Pod {
+func Pod(source *operatorsv1alpha1.CatalogSource, name string, image string, saName string, labels map[string]string, annotations map[string]string, readinessDelay int32, livenessDelay int32) *corev1.Pod {
 	// Ensure the catalog image is always pulled if the image is not based on a digest, measured by whether an "@" is included.
 	// See https://github.com/docker/distribution/blob/master/reference/reference.go for more info.
 	// This means recreating non-digest based catalog pods will result in the latest version of the catalog content being delivered on-cluster.
-	var pullPolicy v1.PullPolicy
+	var pullPolicy corev1.PullPolicy
 	if strings.Contains(image, "@") {
-		pullPolicy = v1.PullIfNotPresent
+		pullPolicy = corev1.PullIfNotPresent
 	} else {
-		pullPolicy = v1.PullAlways
+		pullPolicy = corev1.PullAlways
 	}
 
 	readOnlyRootFilesystem := false
 
-	pod := &v1.Pod{
+	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: source.GetName() + "-",
 			Namespace:    source.GetNamespace(),
 			Labels:       labels,
 			Annotations:  annotations,
 		},
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
 				{
 					Name:  name,
 					Image: image,
-					Ports: []v1.ContainerPort{
+					Ports: []corev1.ContainerPort{
 						{
 							Name:          "grpc",
 							ContainerPort: 50051,
 						},
 					},
-					ReadinessProbe: &v1.Probe{
-						ProbeHandler: v1.ProbeHandler{
-							Exec: &v1.ExecAction{
+					ReadinessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							Exec: &corev1.ExecAction{
 								Command: []string{"grpc_health_probe", "-addr=:50051"},
 							},
 						},
 						InitialDelaySeconds: readinessDelay,
 						TimeoutSeconds:      5,
 					},
-					LivenessProbe: &v1.Probe{
-						ProbeHandler: v1.ProbeHandler{
-							Exec: &v1.ExecAction{
+					LivenessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							Exec: &corev1.ExecAction{
 								Command: []string{"grpc_health_probe", "-addr=:50051"},
 							},
 						},
 						InitialDelaySeconds: livenessDelay,
 						TimeoutSeconds:      5,
 					},
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceCPU:    resource.MustParse("10m"),
-							v1.ResourceMemory: resource.MustParse("50Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("10m"),
+							corev1.ResourceMemory: resource.MustParse("50Mi"),
 						},
 					},
-					SecurityContext: &v1.SecurityContext{
+					SecurityContext: &corev1.SecurityContext{
 						ReadOnlyRootFilesystem: &readOnlyRootFilesystem,
 					},
 					ImagePullPolicy:          pullPolicy,
-					TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 				},
 			},
 			NodeSelector: map[string]string{
@@ -188,7 +188,7 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, saName strin
 
 		// Override tolerations
 		if grpcPodConfig.Tolerations != nil {
-			pod.Spec.Tolerations = make([]v1.Toleration, len(grpcPodConfig.Tolerations))
+			pod.Spec.Tolerations = make([]corev1.Toleration, len(grpcPodConfig.Tolerations))
 			for index, toleration := range grpcPodConfig.Tolerations {
 				pod.Spec.Tolerations[index] = *toleration.DeepCopy()
 			}
@@ -211,7 +211,7 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, saName strin
 }
 
 // hashPodSpec calculates a hash given a copy of the pod spec
-func hashPodSpec(spec v1.PodSpec) string {
+func hashPodSpec(spec corev1.PodSpec) string {
 	hasher := fnv.New32a()
 	hashutil.DeepHashObject(hasher, &spec)
 	return rand.SafeEncodeString(fmt.Sprint(hasher.Sum32()))

--- a/staging/operator-lifecycle-manager/pkg/lib/operatorstatus/clusteroperatorwriter.go
+++ b/staging/operator-lifecycle-manager/pkg/lib/operatorstatus/clusteroperatorwriter.go
@@ -7,7 +7,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -36,7 +36,7 @@ func (w *Writer) EnsureExists(name string) (existing *configv1.ClusterOperator, 
 		return
 	}
 
-	if !k8serrors.IsNotFound(err) {
+	if !apierrors.IsNotFound(err) {
 		return
 	}
 

--- a/staging/operator-lifecycle-manager/pkg/lib/operatorstatus/status.go
+++ b/staging/operator-lifecycle-manager/pkg/lib/operatorstatus/status.go
@@ -12,7 +12,7 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/diff"
@@ -88,7 +88,7 @@ func MonitorClusterStatus(name string, syncCh <-chan error, stopCh <-chan struct
 
 		// create the cluster operator in an initial state if it does not exist
 		existing, err := configClient.ClusterOperators().Get(context.TODO(), name, metav1.GetOptions{})
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.Info("Existing operator status not found, creating")
 			created, createErr := configClient.ClusterOperators().Create(context.TODO(), &configv1.ClusterOperator{
 				ObjectMeta: metav1.ObjectMeta{

--- a/staging/operator-lifecycle-manager/pkg/lib/proxy/syncer.go
+++ b/staging/operator-lifecycle-manager/pkg/lib/proxy/syncer.go
@@ -11,7 +11,7 @@ import (
 	listers "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/discovery"
 )
 
@@ -49,7 +49,7 @@ type Syncer struct {
 func (w *Syncer) QueryProxyConfig() (proxy []corev1.EnvVar, err error) {
 	global, getErr := w.lister.Get(globalProxyName)
 	if getErr != nil {
-		if !k8serrors.IsNotFound(getErr) {
+		if !apierrors.IsNotFound(getErr) {
 			err = getErr
 			return
 		}

--- a/staging/operator-lifecycle-manager/pkg/lib/scoped/syncer.go
+++ b/staging/operator-lifecycle-manager/pkg/lib/scoped/syncer.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -79,7 +79,7 @@ func (s *UserDefinedServiceAccountSyncer) SyncOperatorGroup(in *v1.OperatorGroup
 	// A service account has been specified, we need to update the status.
 	sa, err := s.client.KubernetesInterface().CoreV1().ServiceAccounts(namespace).Get(context.TODO(), serviceAccountName, metav1.GetOptions{})
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			// Set OG's status condition to indicate SA is not found
 			cond := metav1.Condition{
 				Type:    v1.OperatorGroupServiceAccountCondition,

--- a/staging/operator-lifecycle-manager/pkg/lib/scoped/token_retriever.go
+++ b/staging/operator-lifecycle-manager/pkg/lib/scoped/token_retriever.go
@@ -7,7 +7,7 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -54,7 +54,7 @@ func getAPISecret(logger logrus.FieldLogger, kubeclient operatorclient.ClientInt
 		// corev1.ObjectReference only has Name populated.
 		secret, getErr := kubeclient.KubernetesInterface().CoreV1().Secrets(sa.GetNamespace()).Get(context.TODO(), ref.Name, metav1.GetOptions{})
 		if getErr != nil {
-			if k8serrors.IsNotFound(getErr) {
+			if apierrors.IsNotFound(getErr) {
 				logger.Warnf("skipping secret %s - %v", ref.Name, getErr)
 				continue
 			}

--- a/staging/operator-lifecycle-manager/pkg/metrics/metrics.go
+++ b/staging/operator-lifecycle-manager/pkg/metrics/metrics.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
-	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	v1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
 )
 
@@ -246,19 +246,19 @@ func DeleteCatalogSourceStateMetric(name, namespace string) {
 	catalogSourceReady.DeleteLabelValues(namespace, name)
 }
 
-func DeleteCSVMetric(oldCSV *olmv1alpha1.ClusterServiceVersion) {
+func DeleteCSVMetric(oldCSV *operatorsv1alpha1.ClusterServiceVersion) {
 	// Delete the old CSV metrics
 	csvAbnormal.DeleteLabelValues(oldCSV.Namespace, oldCSV.Name, oldCSV.Spec.Version.String(), string(oldCSV.Status.Phase), string(oldCSV.Status.Reason))
 	csvSucceeded.DeleteLabelValues(oldCSV.Namespace, oldCSV.Name, oldCSV.Spec.Version.String())
 }
 
-func EmitCSVMetric(oldCSV *olmv1alpha1.ClusterServiceVersion, newCSV *olmv1alpha1.ClusterServiceVersion) {
+func EmitCSVMetric(oldCSV *operatorsv1alpha1.ClusterServiceVersion, newCSV *operatorsv1alpha1.ClusterServiceVersion) {
 	if oldCSV == nil || newCSV == nil {
 		return
 	}
 
 	// Don't update the metric for copies
-	if newCSV.Status.Reason == olmv1alpha1.CSVReasonCopied {
+	if newCSV.Status.Reason == operatorsv1alpha1.CSVReasonCopied {
 		return
 	}
 
@@ -268,7 +268,7 @@ func EmitCSVMetric(oldCSV *olmv1alpha1.ClusterServiceVersion, newCSV *olmv1alpha
 	// Get the phase of the new CSV
 	newCSVPhase := string(newCSV.Status.Phase)
 	csvSucceededGauge := csvSucceeded.WithLabelValues(newCSV.Namespace, newCSV.Name, newCSV.Spec.Version.String())
-	if newCSVPhase == string(olmv1alpha1.CSVPhaseSucceeded) {
+	if newCSVPhase == string(operatorsv1alpha1.CSVPhaseSucceeded) {
 		csvSucceededGauge.Set(1)
 	} else {
 		csvSucceededGauge.Set(0)
@@ -276,7 +276,7 @@ func EmitCSVMetric(oldCSV *olmv1alpha1.ClusterServiceVersion, newCSV *olmv1alpha
 	}
 }
 
-func EmitSubMetric(sub *olmv1alpha1.Subscription) {
+func EmitSubMetric(sub *operatorsv1alpha1.Subscription) {
 	if sub.Spec == nil {
 		return
 	}
@@ -291,14 +291,14 @@ func EmitSubMetric(sub *olmv1alpha1.Subscription) {
 	}
 }
 
-func DeleteSubsMetric(sub *olmv1alpha1.Subscription) {
+func DeleteSubsMetric(sub *operatorsv1alpha1.Subscription) {
 	if sub.Spec == nil {
 		return
 	}
 	SubscriptionSyncCount.DeleteLabelValues(sub.GetName(), sub.Status.InstalledCSV, sub.Spec.Channel, sub.Spec.Package, string(sub.Spec.InstallPlanApproval))
 }
 
-func UpdateSubsSyncCounterStorage(sub *olmv1alpha1.Subscription) {
+func UpdateSubsSyncCounterStorage(sub *operatorsv1alpha1.Subscription) {
 	if sub.Spec == nil {
 		return
 	}

--- a/staging/operator-lifecycle-manager/pkg/package-server/storage/reststorage.go
+++ b/staging/operator-lifecycle-manager/pkg/package-server/storage/reststorage.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/printers"
 	printerstorage "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/printers/storage"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -76,7 +76,7 @@ func (m *PackageManifestStorage) List(ctx context.Context, options *metainternal
 
 	res, err := m.prov.List(namespace, labelSelector)
 	if err != nil {
-		return nil, k8serrors.NewInternalError(err)
+		return nil, apierrors.NewInternalError(err)
 	}
 
 	filtered := []operators.PackageManifest{}
@@ -101,7 +101,7 @@ func (m *PackageManifestStorage) Get(ctx context.Context, name string, opts *met
 	namespace := genericreq.NamespaceValue(ctx)
 	manifest, err := m.prov.Get(namespace, name)
 	if err != nil || manifest == nil {
-		return nil, k8serrors.NewNotFound(m.groupResource, name)
+		return nil, apierrors.NewNotFound(m.groupResource, name)
 	}
 	// Strip logo icons
 	for i := range manifest.Status.Channels {

--- a/staging/operator-lifecycle-manager/test/e2e/bundle_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/bundle_e2e_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ghodss/yaml"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	. "github.com/onsi/ginkgo"
@@ -73,7 +73,7 @@ var _ = Describe("Installing bundles with new object types", func() {
 			Eventually(func() error {
 				err := ctx.Ctx().Client().Create(context.Background(), &vpaCRD)
 				if err != nil {
-					if !k8serrors.IsAlreadyExists(err) {
+					if !apierrors.IsAlreadyExists(err) {
 						return err
 					}
 				}
@@ -167,7 +167,7 @@ var _ = Describe("Installing bundles with new object types", func() {
 			By("Deleting the VPA CRD")
 			Eventually(func() error {
 				err := ctx.Ctx().Client().Delete(context.Background(), &vpaCRD)
-				if k8serrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					return nil
 				}
 				return err

--- a/staging/operator-lifecycle-manager/test/e2e/copied_csv_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/copied_csv_e2e_test.go
@@ -1,0 +1,266 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/ctx"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Disabling copied CSVs", func() {
+	var (
+		ns                              corev1.Namespace
+		csv                             operatorsv1alpha1.ClusterServiceVersion
+		nonTerminatingNamespaceSelector = fields.ParseSelectorOrDie("status.phase!=Terminating")
+	)
+
+	BeforeEach(func() {
+		nsname := genName("csv-toggle-test-")
+		og := operatorsv1.OperatorGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-operatorgroup", nsname),
+				Namespace: nsname,
+			},
+		}
+		ns = SetupGeneratedTestNamespaceWithOperatorGroup(nsname, og)
+
+		csv = operatorsv1alpha1.ClusterServiceVersion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      genName("csv-toggle-test-"),
+				Namespace: nsname,
+			},
+			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+				InstallStrategy: newNginxInstallStrategy(genName("csv-toggle-test-"), nil, nil),
+				InstallModes: []operatorsv1alpha1.InstallMode{
+					{
+						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+						Supported: true,
+					},
+				},
+			},
+		}
+		err := ctx.Ctx().Client().Create(context.Background(), &csv)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Eventually(func() error {
+			err := ctx.Ctx().Client().Delete(context.Background(), &csv)
+			if err != nil && k8serrors.IsNotFound(err) {
+				return err
+			}
+
+			return nil
+		}).Should(Succeed())
+		TeardownNamespace(ns.GetName())
+	})
+
+	When("an operator is installed in AllNamespace mode", func() {
+		It("should have Copied CSVs in all other namespaces", func() {
+			Eventually(func() error {
+				requirement, err := k8slabels.NewRequirement(operatorsv1alpha1.CopiedLabelKey, selection.Equals, []string{csv.GetNamespace()})
+				if err != nil {
+					return err
+				}
+
+				var copiedCSVs operatorsv1alpha1.ClusterServiceVersionList
+				err = ctx.Ctx().Client().List(context.TODO(), &copiedCSVs, &client.ListOptions{
+					LabelSelector: k8slabels.NewSelector().Add(*requirement),
+				})
+				if err != nil {
+					return err
+				}
+
+				var namespaces corev1.NamespaceList
+				if err := ctx.Ctx().Client().List(context.TODO(), &namespaces, &client.ListOptions{
+					FieldSelector: nonTerminatingNamespaceSelector,
+				}); err != nil {
+					return err
+				}
+
+				if len(namespaces.Items)-1 != len(copiedCSVs.Items) {
+					return fmt.Errorf("%d copied CSVs found, expected %d", len(copiedCSVs.Items), len(namespaces.Items)-1)
+				}
+
+				return nil
+			}).Should(Succeed())
+		})
+	})
+
+	When("Copied CSVs are disabled", func() {
+		BeforeEach(func() {
+			Eventually(func() error {
+				var olmConfig operatorsv1.OLMConfig
+				if err := ctx.Ctx().Client().Get(context.TODO(), apitypes.NamespacedName{Name: "cluster"}, &olmConfig); err != nil {
+					ctx.Ctx().Logf("Error getting olmConfig %v", err)
+					return err
+				}
+
+				// Exit early if copied CSVs are disabled.
+				if !olmConfig.CopiedCSVsAreEnabled() {
+					return nil
+				}
+
+				olmConfig.Spec = operatorsv1.OLMConfigSpec{
+					Features: &operatorsv1.Features{
+						DisableCopiedCSVs: getPointer(true),
+					},
+				}
+
+				if err := ctx.Ctx().Client().Update(context.TODO(), &olmConfig); err != nil {
+					ctx.Ctx().Logf("Error setting olmConfig %v", err)
+					return err
+				}
+
+				return nil
+			}).Should(Succeed())
+		})
+
+		It("should not have any copied CSVs", func() {
+			Eventually(func() error {
+				requirement, err := k8slabels.NewRequirement(operatorsv1alpha1.CopiedLabelKey, selection.Equals, []string{csv.GetNamespace()})
+				if err != nil {
+					return err
+				}
+
+				var copiedCSVs operatorsv1alpha1.ClusterServiceVersionList
+				err = ctx.Ctx().Client().List(context.TODO(), &copiedCSVs, &client.ListOptions{
+					LabelSelector: k8slabels.NewSelector().Add(*requirement),
+				})
+				if err != nil {
+					return err
+				}
+
+				if numCSVs := len(copiedCSVs.Items); numCSVs != 0 {
+					return fmt.Errorf("Found %d copied CSVs, should be 0", numCSVs)
+				}
+				return nil
+			}).Should(Succeed())
+		})
+
+		It("should be reflected in the olmConfig.Status.Condition array that the expected number of copied CSVs exist", func() {
+			Eventually(func() error {
+				var olmConfig operatorsv1.OLMConfig
+				if err := ctx.Ctx().Client().Get(context.TODO(), apitypes.NamespacedName{Name: "cluster"}, &olmConfig); err != nil {
+					return err
+				}
+
+				foundCondition := meta.FindStatusCondition(olmConfig.Status.Conditions, operatorsv1.DisabledCopiedCSVsConditionType)
+				if foundCondition == nil {
+					return fmt.Errorf("%s condition not found", operatorsv1.DisabledCopiedCSVsConditionType)
+				}
+
+				expectedCondition := metav1.Condition{
+					Reason:  "NoCopiedCSVsFound",
+					Message: "Copied CSVs are disabled and none were found for operators installed in AllNamespace mode",
+					Status:  metav1.ConditionTrue,
+				}
+
+				if foundCondition.Reason != expectedCondition.Reason ||
+					foundCondition.Message != expectedCondition.Message ||
+					foundCondition.Status != expectedCondition.Status {
+					return fmt.Errorf("condition does not have expected reason, message, and status. Expected %v, got %v", expectedCondition, foundCondition)
+				}
+
+				return nil
+			}).Should(Succeed())
+		})
+	})
+
+	When("Copied CSVs are toggled back on", func() {
+		BeforeEach(func() {
+			Eventually(func() error {
+				var olmConfig operatorsv1.OLMConfig
+				if err := ctx.Ctx().Client().Get(context.TODO(), apitypes.NamespacedName{Name: "cluster"}, &olmConfig); err != nil {
+					return err
+				}
+
+				// Exit early if copied CSVs are enabled.
+				if olmConfig.CopiedCSVsAreEnabled() {
+					return nil
+				}
+
+				olmConfig.Spec = operatorsv1.OLMConfigSpec{
+					Features: &operatorsv1.Features{
+						DisableCopiedCSVs: getPointer(false),
+					},
+				}
+
+				if err := ctx.Ctx().Client().Update(context.TODO(), &olmConfig); err != nil {
+					return err
+				}
+
+				return nil
+			}).Should(Succeed())
+		})
+
+		It("should have copied CSVs in all other Namespaces", func() {
+			Eventually(func() error {
+				// find copied csvs...
+				requirement, err := k8slabels.NewRequirement(operatorsv1alpha1.CopiedLabelKey, selection.Equals, []string{csv.GetNamespace()})
+				if err != nil {
+					return err
+				}
+
+				var copiedCSVs operatorsv1alpha1.ClusterServiceVersionList
+				err = ctx.Ctx().Client().List(context.TODO(), &copiedCSVs, &client.ListOptions{
+					LabelSelector: k8slabels.NewSelector().Add(*requirement),
+				})
+				if err != nil {
+					return err
+				}
+
+				var namespaces corev1.NamespaceList
+				if err := ctx.Ctx().Client().List(context.TODO(), &namespaces, &client.ListOptions{FieldSelector: nonTerminatingNamespaceSelector}); err != nil {
+					return err
+				}
+
+				if len(namespaces.Items)-1 != len(copiedCSVs.Items) {
+					return fmt.Errorf("%d copied CSVs found, expected %d", len(copiedCSVs.Items), len(namespaces.Items)-1)
+				}
+
+				return nil
+			}).Should(Succeed())
+		})
+
+		It("should be reflected in the olmConfig.Status.Condition array that the expected number of copied CSVs exist", func() {
+			Eventually(func() error {
+				var olmConfig operatorsv1.OLMConfig
+				if err := ctx.Ctx().Client().Get(context.TODO(), apitypes.NamespacedName{Name: "cluster"}, &olmConfig); err != nil {
+					return err
+				}
+				foundCondition := meta.FindStatusCondition(olmConfig.Status.Conditions, operatorsv1.DisabledCopiedCSVsConditionType)
+				if foundCondition == nil {
+					return fmt.Errorf("%s condition not found", operatorsv1.DisabledCopiedCSVsConditionType)
+				}
+
+				expectedCondition := metav1.Condition{
+					Reason:  "CopiedCSVsEnabled",
+					Message: "Copied CSVs are enabled and present across the cluster",
+					Status:  metav1.ConditionFalse,
+				}
+
+				if foundCondition.Reason != expectedCondition.Reason ||
+					foundCondition.Message != expectedCondition.Message ||
+					foundCondition.Status != expectedCondition.Status {
+					return fmt.Errorf("condition does not have expected reason, message, and status. Expected %v, got %v", expectedCondition, foundCondition)
+				}
+
+				return nil
+			}).Should(Succeed())
+		})
+	})
+})

--- a/staging/operator-lifecycle-manager/test/e2e/crd_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/crd_e2e_test.go
@@ -15,7 +15,7 @@ import (
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -487,7 +487,7 @@ var _ = Describe("CRD Versions", func() {
 		Eventually(func() bool {
 			sub, _ := crc.OperatorsV1alpha1().Subscriptions(ns.GetName()).Get(context.TODO(), subscription.GetName(), metav1.GetOptions{})
 			ip, err := crc.OperatorsV1alpha1().InstallPlans(ns.GetName()).Get(context.TODO(), sub.Status.InstallPlanRef.Name, metav1.GetOptions{})
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				return false
 			}
 			GinkgoT().Logf("waiting for installplan to succeed...currently %s", ip.Status.Phase)

--- a/staging/operator-lifecycle-manager/test/e2e/csv_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/csv_e2e_test.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -133,15 +133,15 @@ var _ = Describe("ClusterServiceVersion", func() {
 		AfterEach(func() {
 			Eventually(func() error {
 				return ctx.Ctx().Client().Delete(context.Background(), &crd)
-			}).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
+			}).Should(WithTransform(apierrors.IsNotFound, BeTrue()))
 
 			Eventually(func() error {
 				return ctx.Ctx().Client().Delete(context.Background(), &og)
-			}).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
+			}).Should(WithTransform(apierrors.IsNotFound, BeTrue()))
 
 			Eventually(func() error {
 				return ctx.Ctx().Client().Delete(context.Background(), &ns)
-			}).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
+			}).Should(WithTransform(apierrors.IsNotFound, BeTrue()))
 		})
 
 		// issue: https://github.com/operator-framework/operator-lifecycle-manager/issues/2646
@@ -255,7 +255,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 
 			Eventually(func() error {
 				return ctx.Ctx().Client().Get(context.Background(), client.ObjectKeyFromObject(&unassociated), &unassociated)
-			}).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
+			}).Should(WithTransform(apierrors.IsNotFound, BeTrue()))
 
 			Eventually(func() error {
 				return ctx.Ctx().Client().Delete(context.Background(), &associated)
@@ -345,7 +345,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			AfterEach(func() {
 				Eventually(func() error {
 					return ctx.Ctx().Client().Delete(context.Background(), &ns)
-				}).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
+				}).Should(WithTransform(apierrors.IsNotFound, BeTrue()))
 			})
 
 			It("can satisfy the unassociated ClusterServiceVersion's ownership requirement", func() {
@@ -777,7 +777,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 		// Shouldn't create deployment
 		Consistently(func() bool {
 			_, err := c.GetDeployment(testNamespace, depName)
-			return k8serrors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}).Should(BeTrue())
 	})
 	// TODO: same test but missing serviceaccount instead
@@ -837,7 +837,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 		// Shouldn't create deployment
 		Consistently(func() bool {
 			_, err := c.GetDeployment(testNamespace, depName)
-			return k8serrors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}).Should(BeTrue())
 	})
 
@@ -957,7 +957,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 		// Shouldn't create deployment
 		Consistently(func() bool {
 			_, err := c.GetDeployment(testNamespace, depName)
-			return k8serrors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}).Should(BeTrue())
 	})
 	It("create with unmet requirements API service", func() {
@@ -1016,7 +1016,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 		// Shouldn't create deployment
 		Consistently(func() bool {
 			_, err := c.GetDeployment(testNamespace, depName)
-			return k8serrors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}).Should(BeTrue())
 	})
 	It("create with unmet permissions API service", func() {
@@ -1103,7 +1103,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 		// Shouldn't create deployment
 		Consistently(func() bool {
 			_, err := c.GetDeployment(testNamespace, depName)
-			return k8serrors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}).Should(BeTrue())
 	})
 	It("create with unmet requirements native API", func() {
@@ -1152,7 +1152,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 		// Shouldn't create deployment
 		Consistently(func() bool {
 			_, err := c.GetDeployment(testNamespace, depName)
-			return k8serrors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}).Should(BeTrue())
 	})
 	// TODO: same test but create serviceaccount instead
@@ -1395,7 +1395,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 		// Poll for deployment to be ready
 		Eventually(func() (bool, error) {
 			dep, err := c.GetDeployment(testNamespace, depName)
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				ctx.Ctx().Logf("deployment %s not found\n", depName)
 				return false, nil
 			} else if err != nil {
@@ -4243,7 +4243,7 @@ var _ = Describe("Disabling copied CSVs", func() {
 	AfterEach(func() {
 		Eventually(func() error {
 			err := ctx.Ctx().Client().Delete(context.Background(), &csv)
-			if err != nil && k8serrors.IsNotFound(err) {
+			if err != nil && apierrors.IsNotFound(err) {
 				return err
 			}
 
@@ -4253,7 +4253,7 @@ var _ = Describe("Disabling copied CSVs", func() {
 		Eventually(func() error {
 			var namespace corev1.Namespace
 			return ctx.Ctx().Client().Get(context.Background(), client.ObjectKeyFromObject(&ns), &namespace)
-		}).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
+		}).Should(WithTransform(apierrors.IsNotFound, BeTrue()))
 	})
 
 	When("an operator is installed in AllNamespace mode", func() {
@@ -4730,7 +4730,7 @@ func awaitCSV(c versioned.Interface, namespace, name string, checker csvConditio
 	Eventually(func() (bool, error) {
 		fetched, err = c.OperatorsV1alpha1().ClusterServiceVersions(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				return false, nil
 			}
 			return false, err
@@ -4749,7 +4749,7 @@ func waitForDeployment(c operatorclient.ClientInterface, name string) error {
 	return wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 		_, err := c.GetDeployment(testNamespace, name)
 		if err != nil {
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				return false, nil
 			}
 			return false, err
@@ -4764,7 +4764,7 @@ func waitForDeploymentToDelete(c operatorclient.ClientInterface, name string) er
 	Eventually(func() (bool, error) {
 		ctx.Ctx().Logf("waiting for deployment %s to delete", name)
 		_, err := c.GetDeployment(testNamespace, name)
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			ctx.Ctx().Logf("deleted %s", name)
 			return true, nil
 		}
@@ -4779,7 +4779,7 @@ func waitForDeploymentToDelete(c operatorclient.ClientInterface, name string) er
 
 func csvExists(c versioned.Interface, name string) bool {
 	fetched, err := c.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Get(context.TODO(), name, metav1.GetOptions{})
-	if k8serrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		return false
 	}
 	ctx.Ctx().Logf("%s (%s): %s", fetched.Status.Phase, fetched.Status.Reason, fetched.Status.Message)
@@ -4841,7 +4841,7 @@ func createLegacyAPIResources(csv *operatorsv1alpha1.ClusterServiceVersion, desc
 	}
 
 	_, err = c.CreateSecret(&secret)
-	if err != nil && !k8serrors.IsAlreadyExists(err) {
+	if err != nil && !apierrors.IsAlreadyExists(err) {
 		Expect(err).ShouldNot(HaveOccurred())
 	}
 
@@ -4906,25 +4906,25 @@ func checkLegacyAPIResources(desc operatorsv1alpha1.APIServiceDescription, expec
 
 	// Attempt to create the legacy service
 	_, err := c.GetService(testNamespace, strings.Replace(apiServiceName, ".", "-", -1))
-	Expect(k8serrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
+	Expect(apierrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy secret
 	_, err = c.GetSecret(testNamespace, apiServiceName+"-cert")
-	Expect(k8serrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
+	Expect(apierrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy secret role
 	_, err = c.GetRole(testNamespace, apiServiceName+"-cert")
-	Expect(k8serrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
+	Expect(apierrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy secret role binding
 	_, err = c.GetRoleBinding(testNamespace, apiServiceName+"-cert")
-	Expect(k8serrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
+	Expect(apierrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy authDelegatorClusterRoleBinding
 	_, err = c.GetClusterRoleBinding(apiServiceName + "-system:auth-delegator")
-	Expect(k8serrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
+	Expect(apierrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy authReadingRoleBinding
 	_, err = c.GetRoleBinding("kube-system", apiServiceName+"-auth-reader")
-	Expect(k8serrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
+	Expect(apierrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 }

--- a/staging/operator-lifecycle-manager/test/e2e/csv_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/csv_e2e_test.go
@@ -9,8 +9,11 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/types"
-
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -18,13 +21,9 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/selection"
-	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -32,23 +31,14 @@ import (
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/ctx"
 )
 
 var _ = Describe("ClusterServiceVersion", func() {
-	HavePhase := func(goal operatorsv1alpha1.ClusterServiceVersionPhase) types.GomegaMatcher {
-		return WithTransform(func(csv *operatorsv1alpha1.ClusterServiceVersion) operatorsv1alpha1.ClusterServiceVersionPhase {
-			return csv.Status.Phase
-		}, Equal(goal))
-	}
 
 	var (
+		ns  corev1.Namespace
 		c   operatorclient.ClientInterface
 		crc versioned.Interface
 	)
@@ -59,293 +49,278 @@ var _ = Describe("ClusterServiceVersion", func() {
 	})
 
 	AfterEach(func() {
-		TearDown(testNamespace)
+		TeardownNamespace(ns.GetName())
 	})
 
-	When("a CustomResourceDefinition was installed alongside a ClusterServiceVersion", func() {
-		var (
-			ns          corev1.Namespace
-			crd         apiextensionsv1.CustomResourceDefinition
-			og          operatorsv1.OperatorGroup
-			apiname     string
-			apifullname string
-		)
-
+	Context("OwnNamespace OperatorGroup", func() {
 		BeforeEach(func() {
-			ns = corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: genName("test-namespace-"),
-				},
-			}
-
-			Eventually(func() error {
-				return ctx.Ctx().Client().Create(context.Background(), &ns)
-			}).Should(Succeed())
-
-			og = operatorsv1.OperatorGroup{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      genName(fmt.Sprintf("%s-operatorgroup-", ns.GetName())),
-					Namespace: ns.GetName(),
-				},
-				Spec: operatorsv1.OperatorGroupSpec{
-					TargetNamespaces: []string{ns.GetName()},
-				},
-			}
-			Eventually(func() error {
-				return ctx.Ctx().Client().Create(context.Background(), &og)
-			}).Should(Succeed())
-
-			apiname = genName("api")
-			apifullname = apiname + "s.example.com"
-			crd = apiextensionsv1.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: apifullname,
-					Annotations: map[string]string{
-						"operatorframework.io/installed-alongside-0": fmt.Sprintf("%s/associated-csv", ns.GetName()),
-					},
-				},
-				Spec: apiextensionsv1.CustomResourceDefinitionSpec{
-					Group: "example.com",
-					Scope: apiextensionsv1.ClusterScoped,
-					Names: apiextensionsv1.CustomResourceDefinitionNames{
-						Plural:   apiname + "s",
-						Singular: apiname,
-						Kind:     strings.Title(apiname),
-						ListKind: strings.Title(apiname) + "List",
-					},
-					Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
-						Name:    "v1",
-						Served:  true,
-						Storage: true,
-						Schema: &apiextensionsv1.CustomResourceValidation{
-							OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-								Type: "object",
-							},
-						},
-					}},
-				},
-			}
-			Eventually(func() error {
-				return ctx.Ctx().Client().Create(context.Background(), &crd)
-			}).Should(Succeed())
+			nsName := genName("csv-e2e-")
+			ns = SetupGeneratedTestNamespace(nsName, nsName)
 		})
 
-		AfterEach(func() {
-			Eventually(func() error {
-				return ctx.Ctx().Client().Delete(context.Background(), &crd)
-			}).Should(WithTransform(apierrors.IsNotFound, BeTrue()))
-
-			Eventually(func() error {
-				return ctx.Ctx().Client().Delete(context.Background(), &og)
-			}).Should(WithTransform(apierrors.IsNotFound, BeTrue()))
-
-			Eventually(func() error {
-				return ctx.Ctx().Client().Delete(context.Background(), &ns)
-			}).Should(WithTransform(apierrors.IsNotFound, BeTrue()))
-		})
-
-		// issue: https://github.com/operator-framework/operator-lifecycle-manager/issues/2646
-		It("[FLAKE] can satisfy an associated ClusterServiceVersion's ownership requirement", func() {
-			associated := operatorsv1alpha1.ClusterServiceVersion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "associated-csv",
-					Namespace: ns.GetName(),
-				},
-				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-					CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
-						Owned: []operatorsv1alpha1.CRDDescription{{
-							Name:    apifullname,
-							Version: "v1",
-							Kind:    "Test",
-						}},
-					},
-					InstallStrategy: newNginxInstallStrategy(genName("deployment-"), nil, nil),
-					InstallModes: []operatorsv1alpha1.InstallMode{
-						{
-							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-							Supported: true,
-						},
-					},
-				},
-			}
-			Expect(ctx.Ctx().Client().Create(context.Background(), &associated)).To(Succeed())
-
-			Eventually(func() ([]operatorsv1alpha1.RequirementStatus, error) {
-				if err := ctx.Ctx().Client().Get(context.Background(), client.ObjectKeyFromObject(&associated), &associated); err != nil {
-					return nil, err
-				}
-				var result []operatorsv1alpha1.RequirementStatus
-				for _, s := range associated.Status.RequirementStatus {
-					result = append(result, operatorsv1alpha1.RequirementStatus{
-						Group:   s.Group,
-						Version: s.Version,
-						Kind:    s.Kind,
-						Name:    s.Name,
-						Status:  s.Status,
-					})
-				}
-				return result, nil
-			}).Should(ContainElement(
-				operatorsv1alpha1.RequirementStatus{
-					Group:   apiextensionsv1.SchemeGroupVersion.Group,
-					Version: apiextensionsv1.SchemeGroupVersion.Version,
-					Kind:    "CustomResourceDefinition",
-					Name:    crd.GetName(),
-					Status:  operatorsv1alpha1.RequirementStatusReasonPresent,
-				},
-			))
-
-			Eventually(func() error {
-				return ctx.Ctx().Client().Delete(context.Background(), &associated)
-			}).Should(Succeed())
-		})
-
-		// Without this exception, upgrades can become blocked
-		// when the original CSV's CRD requirement becomes
-		// unsatisfied.
-		It("can satisfy an unassociated ClusterServiceVersion's ownership requirement if replaced by an associated ClusterServiceVersion", func() {
-			unassociated := operatorsv1alpha1.ClusterServiceVersion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "unassociated-csv",
-					Namespace: ns.GetName(),
-				},
-				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-					CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
-						Owned: []operatorsv1alpha1.CRDDescription{{
-							Name:    apifullname,
-							Version: "v1",
-							Kind:    "Test",
-						}},
-					},
-					InstallStrategy: newNginxInstallStrategy(genName("deployment-"), nil, nil),
-					InstallModes: []operatorsv1alpha1.InstallMode{
-						{
-							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-							Supported: true,
-						},
-					},
-				},
-			}
-			Expect(ctx.Ctx().Client().Create(context.Background(), &unassociated)).To(Succeed())
-
-			associated := operatorsv1alpha1.ClusterServiceVersion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "associated-csv",
-					Namespace: ns.GetName(),
-				},
-				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-					CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
-						Owned: []operatorsv1alpha1.CRDDescription{{
-							Name:    apifullname,
-							Version: "v1",
-							Kind:    "Test",
-						}},
-					},
-					InstallStrategy: newNginxInstallStrategy(genName("deployment-"), nil, nil),
-					InstallModes: []operatorsv1alpha1.InstallMode{
-						{
-							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-							Supported: true,
-						},
-					},
-					Replaces: unassociated.GetName(),
-				},
-			}
-			Expect(ctx.Ctx().Client().Create(context.Background(), &associated)).To(Succeed())
-
-			Eventually(func() error {
-				return ctx.Ctx().Client().Get(context.Background(), client.ObjectKeyFromObject(&unassociated), &unassociated)
-			}).Should(WithTransform(apierrors.IsNotFound, BeTrue()))
-
-			Eventually(func() error {
-				return ctx.Ctx().Client().Delete(context.Background(), &associated)
-			}).Should(Succeed())
-		})
-
-		// issue:https://github.com/operator-framework/operator-lifecycle-manager/issues/2639
-		It("[FLAKE] can satisfy an unassociated ClusterServiceVersion's non-ownership requirement", func() {
-			unassociated := operatorsv1alpha1.ClusterServiceVersion{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "unassociated-csv",
-					Namespace: ns.GetName(),
-				},
-				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-					CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
-						Required: []operatorsv1alpha1.CRDDescription{{
-							Name:    apifullname,
-							Version: "v1",
-							Kind:    "Test",
-						}},
-					},
-					InstallStrategy: newNginxInstallStrategy(genName("deployment-"), nil, nil),
-					InstallModes: []operatorsv1alpha1.InstallMode{
-						{
-							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-							Supported: true,
-						},
-					},
-				},
-			}
-			Expect(ctx.Ctx().Client().Create(context.Background(), &unassociated)).To(Succeed())
-
-			Eventually(func() ([]operatorsv1alpha1.RequirementStatus, error) {
-				if err := ctx.Ctx().Client().Get(context.Background(), client.ObjectKeyFromObject(&unassociated), &unassociated); err != nil {
-					return nil, err
-				}
-				var result []operatorsv1alpha1.RequirementStatus
-				for _, s := range unassociated.Status.RequirementStatus {
-					result = append(result, operatorsv1alpha1.RequirementStatus{
-						Group:   s.Group,
-						Version: s.Version,
-						Kind:    s.Kind,
-						Name:    s.Name,
-						Status:  s.Status,
-					})
-				}
-				return result, nil
-			}).Should(ContainElement(
-				operatorsv1alpha1.RequirementStatus{
-					Group:   apiextensionsv1.SchemeGroupVersion.Group,
-					Version: apiextensionsv1.SchemeGroupVersion.Version,
-					Kind:    "CustomResourceDefinition",
-					Name:    crd.GetName(),
-					Status:  operatorsv1alpha1.RequirementStatusReasonPresent,
-				},
-			))
-			Eventually(func() error {
-				return ctx.Ctx().Client().Delete(context.Background(), &unassociated)
-			}).Should(Succeed())
-		})
-
-		When("an unassociated ClusterServiceVersion in different namespace owns the same CRD", func() {
+		When("a CustomResourceDefinition was installed alongside a ClusterServiceVersion", func() {
 			var (
-				ns corev1.Namespace
+				crd         apiextensionsv1.CustomResourceDefinition
+				apiname     string
+				apifullname string
 			)
 
 			BeforeEach(func() {
-				ns = corev1.Namespace{
+				apiname = genName("api")
+				apifullname = apiname + "s.example.com"
+				crd = apiextensionsv1.CustomResourceDefinition{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: genName("test-namespace-2-"),
+						Name: apifullname,
+						Annotations: map[string]string{
+							"operatorframework.io/installed-alongside-0": fmt.Sprintf("%s/associated-csv", ns.GetName()),
+						},
+					},
+					Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+						Group: "example.com",
+						Scope: apiextensionsv1.ClusterScoped,
+						Names: apiextensionsv1.CustomResourceDefinitionNames{
+							Plural:   apiname + "s",
+							Singular: apiname,
+							Kind:     strings.Title(apiname),
+							ListKind: strings.Title(apiname) + "List",
+						},
+						Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+							Name:    "v1",
+							Served:  true,
+							Storage: true,
+							Schema: &apiextensionsv1.CustomResourceValidation{
+								OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+									Type: "object",
+								},
+							},
+						}},
 					},
 				}
-				Expect(ctx.Ctx().Client().Create(context.Background(), &ns)).To(Succeed())
-
-				og = operatorsv1.OperatorGroup{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      fmt.Sprintf("%s-operatorgroup", ns.GetName()),
-						Namespace: ns.GetName(),
-					},
-					Spec: operatorsv1.OperatorGroupSpec{
-						TargetNamespaces: []string{ns.GetName()},
-					},
-				}
-				Expect(ctx.Ctx().Client().Create(context.TODO(), &og)).To(Succeed())
+				Eventually(func() error {
+					return ctx.Ctx().Client().Create(context.Background(), &crd)
+				}).Should(Succeed())
 			})
 
 			AfterEach(func() {
 				Eventually(func() error {
-					return ctx.Ctx().Client().Delete(context.Background(), &ns)
+					return ctx.Ctx().KubeClient().ApiextensionsInterface().ApiextensionsV1().CustomResourceDefinitions().Delete(context.TODO(), crd.GetName(), metav1.DeleteOptions{})
+				}).Should(Succeed())
+			})
+
+			It("can satisfy an associated ClusterServiceVersion's ownership requirement", func() {
+				associated := operatorsv1alpha1.ClusterServiceVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "associated-csv",
+						Namespace: ns.GetName(),
+					},
+					Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+						CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
+							Owned: []operatorsv1alpha1.CRDDescription{{
+								Name:    apifullname,
+								Version: "v1",
+								Kind:    "Test",
+							}},
+						},
+						InstallStrategy: newNginxInstallStrategy(genName("deployment-"), nil, nil),
+						InstallModes: []operatorsv1alpha1.InstallMode{
+							{
+								Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+								Supported: true,
+							},
+						},
+					},
+				}
+				Expect(ctx.Ctx().Client().Create(context.Background(), &associated)).To(Succeed())
+
+				Eventually(func() ([]operatorsv1alpha1.RequirementStatus, error) {
+					if err := ctx.Ctx().Client().Get(context.Background(), client.ObjectKeyFromObject(&associated), &associated); err != nil {
+						return nil, err
+					}
+					var result []operatorsv1alpha1.RequirementStatus
+					for _, s := range associated.Status.RequirementStatus {
+						result = append(result, operatorsv1alpha1.RequirementStatus{
+							Group:   s.Group,
+							Version: s.Version,
+							Kind:    s.Kind,
+							Name:    s.Name,
+							Status:  s.Status,
+						})
+					}
+					return result, nil
+				}).Should(ContainElement(
+					operatorsv1alpha1.RequirementStatus{
+						Group:   apiextensionsv1.SchemeGroupVersion.Group,
+						Version: apiextensionsv1.SchemeGroupVersion.Version,
+						Kind:    "CustomResourceDefinition",
+						Name:    crd.GetName(),
+						Status:  operatorsv1alpha1.RequirementStatusReasonPresent,
+					},
+				))
+
+				Eventually(func() error {
+					return ctx.Ctx().Client().Delete(context.Background(), &associated)
+				}).Should(Succeed())
+			})
+
+			// Without this exception, upgrades can become blocked
+			// when the original CSV's CRD requirement becomes
+			// unsatisfied.
+			It("can satisfy an unassociated ClusterServiceVersion's ownership requirement if replaced by an associated ClusterServiceVersion", func() {
+				unassociated := operatorsv1alpha1.ClusterServiceVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "unassociated-csv",
+						Namespace: ns.GetName(),
+					},
+					Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+						CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
+							Owned: []operatorsv1alpha1.CRDDescription{{
+								Name:    apifullname,
+								Version: "v1",
+								Kind:    "Test",
+							}},
+						},
+						InstallStrategy: newNginxInstallStrategy(genName("deployment-"), nil, nil),
+						InstallModes: []operatorsv1alpha1.InstallMode{
+							{
+								Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+								Supported: true,
+							},
+						},
+					},
+				}
+				Expect(ctx.Ctx().Client().Create(context.Background(), &unassociated)).To(Succeed())
+
+				associated := operatorsv1alpha1.ClusterServiceVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "associated-csv",
+						Namespace: ns.GetName(),
+					},
+					Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+						CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
+							Owned: []operatorsv1alpha1.CRDDescription{{
+								Name:    apifullname,
+								Version: "v1",
+								Kind:    "Test",
+							}},
+						},
+						InstallStrategy: newNginxInstallStrategy(genName("deployment-"), nil, nil),
+						InstallModes: []operatorsv1alpha1.InstallMode{
+							{
+								Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+								Supported: true,
+							},
+						},
+						Replaces: unassociated.GetName(),
+					},
+				}
+				Expect(ctx.Ctx().Client().Create(context.Background(), &associated)).To(Succeed())
+
+				Eventually(func() error {
+					return ctx.Ctx().Client().Get(context.Background(), client.ObjectKeyFromObject(&unassociated), &unassociated)
 				}).Should(WithTransform(apierrors.IsNotFound, BeTrue()))
+
+				Eventually(func() error {
+					return ctx.Ctx().Client().Delete(context.Background(), &associated)
+				}).Should(Succeed())
+			})
+
+			It("can satisfy an unassociated ClusterServiceVersion's non-ownership requirement", func() {
+				unassociated := operatorsv1alpha1.ClusterServiceVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "unassociated-csv",
+						Namespace: ns.GetName(),
+					},
+					Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+						CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
+							Required: []operatorsv1alpha1.CRDDescription{{
+								Name:    apifullname,
+								Version: "v1",
+								Kind:    "Test",
+							}},
+						},
+						InstallStrategy: newNginxInstallStrategy(genName("deployment-"), nil, nil),
+						InstallModes: []operatorsv1alpha1.InstallMode{
+							{
+								Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+								Supported: true,
+							},
+						},
+					},
+				}
+				Expect(ctx.Ctx().Client().Create(context.Background(), &unassociated)).To(Succeed())
+
+				Eventually(func() ([]operatorsv1alpha1.RequirementStatus, error) {
+					if err := ctx.Ctx().Client().Get(context.Background(), client.ObjectKeyFromObject(&unassociated), &unassociated); err != nil {
+						return nil, err
+					}
+					var result []operatorsv1alpha1.RequirementStatus
+					for _, s := range unassociated.Status.RequirementStatus {
+						result = append(result, operatorsv1alpha1.RequirementStatus{
+							Group:   s.Group,
+							Version: s.Version,
+							Kind:    s.Kind,
+							Name:    s.Name,
+							Status:  s.Status,
+						})
+					}
+					return result, nil
+				}).Should(ContainElement(
+					operatorsv1alpha1.RequirementStatus{
+						Group:   apiextensionsv1.SchemeGroupVersion.Group,
+						Version: apiextensionsv1.SchemeGroupVersion.Version,
+						Kind:    "CustomResourceDefinition",
+						Name:    crd.GetName(),
+						Status:  operatorsv1alpha1.RequirementStatusReasonPresent,
+					},
+				))
+				Eventually(func() error {
+					return ctx.Ctx().Client().Delete(context.Background(), &unassociated)
+				}).Should(Succeed())
+			})
+		})
+
+		When("an unassociated ClusterServiceVersion in different namespace owns the same CRD", func() {
+
+			var (
+				crd         apiextensionsv1.CustomResourceDefinition
+				apiname     string
+				apifullname string
+			)
+
+			BeforeEach(func() {
+				apiname = genName("api")
+				apifullname = apiname + "s.example.com"
+				crd = apiextensionsv1.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: apifullname,
+						Annotations: map[string]string{
+							"operatorframework.io/installed-alongside-0": fmt.Sprintf("%s/associated-csv", ns.GetName()),
+						},
+					},
+					Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+						Group: "example.com",
+						Scope: apiextensionsv1.ClusterScoped,
+						Names: apiextensionsv1.CustomResourceDefinitionNames{
+							Plural:   apiname + "s",
+							Singular: apiname,
+							Kind:     strings.Title(apiname),
+							ListKind: strings.Title(apiname) + "List",
+						},
+						Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+							Name:    "v1",
+							Served:  true,
+							Storage: true,
+							Schema: &apiextensionsv1.CustomResourceValidation{
+								OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+									Type: "object",
+								},
+							},
+						}},
+					},
+				}
+				Eventually(func() error {
+					return ctx.Ctx().Client().Create(context.Background(), &crd)
+				}).Should(Succeed())
 			})
 
 			It("can satisfy the unassociated ClusterServiceVersion's ownership requirement", func() {
@@ -425,606 +400,879 @@ var _ = Describe("ClusterServiceVersion", func() {
 		})
 	})
 
-	When("a csv exists specifying two replicas with one max unavailable", func() {
-		var (
-			csv operatorsv1alpha1.ClusterServiceVersion
-		)
-
-		const (
-			TestReadinessGate = "operatorframework.io/test-readiness-gate"
-		)
-
+	Context("AllNamespaces OperatorGroup", func() {
 		BeforeEach(func() {
-			csv = operatorsv1alpha1.ClusterServiceVersion{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "test-csv",
-					Namespace:    testNamespace,
-				},
-				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-					InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
-						StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
-						StrategySpec: operatorsv1alpha1.StrategyDetailsDeployment{
-							DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
-								{
-									Name: "deployment",
-									Spec: appsv1.DeploymentSpec{
-										Strategy: appsv1.DeploymentStrategy{
-											Type: appsv1.RollingUpdateDeploymentStrategyType,
-											RollingUpdate: &appsv1.RollingUpdateDeployment{
-												MaxUnavailable: &[]intstr.IntOrString{intstr.FromInt(1)}[0],
+			ns = SetupGeneratedTestNamespace(genName("csv-e2e-"))
+		})
+
+		When("a csv exists specifying two replicas with one max unavailable", func() {
+			var (
+				csv operatorsv1alpha1.ClusterServiceVersion
+			)
+
+			const (
+				TestReadinessGate = "operatorframework.io/test-readiness-gate"
+			)
+
+			BeforeEach(func() {
+				csv = operatorsv1alpha1.ClusterServiceVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "test-csv",
+						Namespace:    ns.GetName(),
+					},
+					Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+						InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+							StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
+							StrategySpec: operatorsv1alpha1.StrategyDetailsDeployment{
+								DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
+									{
+										Name: "deployment",
+										Spec: appsv1.DeploymentSpec{
+											Strategy: appsv1.DeploymentStrategy{
+												Type: appsv1.RollingUpdateDeploymentStrategyType,
+												RollingUpdate: &appsv1.RollingUpdateDeployment{
+													MaxUnavailable: &[]intstr.IntOrString{intstr.FromInt(1)}[0],
+												},
 											},
-										},
-										Selector: &metav1.LabelSelector{
-											MatchLabels: map[string]string{"app": "foobar"},
-										},
-										Replicas: &[]int32{2}[0],
-										Template: corev1.PodTemplateSpec{
-											ObjectMeta: metav1.ObjectMeta{
-												Labels: map[string]string{"app": "foobar"},
+											Selector: &metav1.LabelSelector{
+												MatchLabels: map[string]string{"app": "foobar"},
 											},
-											Spec: corev1.PodSpec{
-												Containers: []corev1.Container{
-													{
-														Name:  "foobar",
-														Image: *dummyImage,
+											Replicas: &[]int32{2}[0],
+											Template: corev1.PodTemplateSpec{
+												ObjectMeta: metav1.ObjectMeta{
+													Labels: map[string]string{"app": "foobar"},
+												},
+												Spec: corev1.PodSpec{
+													Containers: []corev1.Container{
+														{
+															Name:  "foobar",
+															Image: *dummyImage,
+														},
+													},
+													ReadinessGates: []corev1.PodReadinessGate{
+														{ConditionType: TestReadinessGate},
 													},
 												},
-												ReadinessGates: []corev1.PodReadinessGate{
-													{ConditionType: TestReadinessGate},
-												},
 											},
 										},
 									},
 								},
 							},
 						},
+						InstallModes: []operatorsv1alpha1.InstallMode{{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						}},
 					},
-					InstallModes: []operatorsv1alpha1.InstallMode{{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
-					}},
-				},
-			}
-			Expect(ctx.Ctx().Client().Create(context.Background(), &csv)).To(Succeed())
-
-			Eventually(func() (*operatorsv1alpha1.ClusterServiceVersion, error) {
-				var ps corev1.PodList
-				if err := ctx.Ctx().Client().List(context.Background(), &ps, client.MatchingLabels{"app": "foobar"}); err != nil {
-					return nil, err
 				}
+				Expect(ctx.Ctx().Client().Create(context.Background(), &csv)).To(Succeed())
 
-				if len(ps.Items) != 2 {
-					return nil, fmt.Errorf("%d pods match deployment selector, want %d", len(ps.Items), 2)
-				}
-
-				for _, pod := range ps.Items {
-					index := -1
-					for i, c := range pod.Status.Conditions {
-						if c.Type == TestReadinessGate {
-							index = i
-							break
-						}
-					}
-					if index == -1 {
-						index = len(pod.Status.Conditions)
-						pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{Type: TestReadinessGate})
-					}
-					if pod.Status.Conditions[index].Status == corev1.ConditionTrue {
-						continue
-					}
-					pod.Status.Conditions[index].Status = corev1.ConditionTrue
-					if err := ctx.Ctx().Client().Status().Update(context.Background(), &pod); err != nil {
+				Eventually(func() (*operatorsv1alpha1.ClusterServiceVersion, error) {
+					var ps corev1.PodList
+					if err := ctx.Ctx().Client().List(context.Background(), &ps, client.MatchingLabels{"app": "foobar"}); err != nil {
 						return nil, err
 					}
-				}
 
-				if err := ctx.Ctx().Client().Get(context.Background(), client.ObjectKeyFromObject(&csv), &csv); err != nil {
-					return nil, err
-				}
-				return &csv, nil
-			}).Should(HavePhase(operatorsv1alpha1.CSVPhaseSucceeded))
+					if len(ps.Items) != 2 {
+						return nil, fmt.Errorf("%d pods match deployment selector, want %d", len(ps.Items), 2)
+					}
+
+					for _, pod := range ps.Items {
+						index := -1
+						for i, c := range pod.Status.Conditions {
+							if c.Type == TestReadinessGate {
+								index = i
+								break
+							}
+						}
+						if index == -1 {
+							index = len(pod.Status.Conditions)
+							pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{Type: TestReadinessGate})
+						}
+						if pod.Status.Conditions[index].Status == corev1.ConditionTrue {
+							continue
+						}
+						pod.Status.Conditions[index].Status = corev1.ConditionTrue
+						if err := ctx.Ctx().Client().Status().Update(context.Background(), &pod); err != nil {
+							return nil, err
+						}
+					}
+
+					if err := ctx.Ctx().Client().Get(context.Background(), client.ObjectKeyFromObject(&csv), &csv); err != nil {
+						return nil, err
+					}
+					return &csv, nil
+				}).Should(CSVHasPhase(operatorsv1alpha1.CSVPhaseSucceeded))
+			})
+
+			It("remains in phase Succeeded when only one pod is available", func() {
+				Eventually(func() int32 {
+					dep, err := c.GetDeployment(ns.GetName(), "deployment")
+					if err != nil || dep == nil {
+						return 0
+					}
+					return dep.Status.ReadyReplicas
+				}).Should(Equal(int32(2)))
+
+				var ps corev1.PodList
+				Expect(ctx.Ctx().Client().List(context.Background(), &ps, client.MatchingLabels{"app": "foobar"})).To(Succeed())
+				Expect(ps.Items).To(Not(BeEmpty()))
+
+				Expect(ctx.Ctx().Client().Delete(context.Background(), &ps.Items[0])).To(Succeed())
+
+				Consistently(func() (*operatorsv1alpha1.ClusterServiceVersion, error) {
+					return &csv, ctx.Ctx().Client().Get(context.Background(), client.ObjectKeyFromObject(&csv), &csv)
+				}).Should(CSVHasPhase(operatorsv1alpha1.CSVPhaseSucceeded))
+			})
 		})
+		When("a copied csv exists", func() {
+			var (
+				target   corev1.Namespace
+				original operatorsv1alpha1.ClusterServiceVersion
+				copyCSV  operatorsv1alpha1.ClusterServiceVersion
+			)
 
-		It("remains in phase Succeeded when only one pod is available", func() {
-			Eventually(func() int32 {
-				dep, err := c.GetDeployment(testNamespace, "deployment")
-				if err != nil || dep == nil {
-					return 0
+			BeforeEach(func() {
+				target = corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "watched-",
+					},
 				}
-				return dep.Status.ReadyReplicas
-			}).Should(Equal(int32(2)))
+				Expect(ctx.Ctx().Client().Create(context.Background(), &target)).To(Succeed())
 
-			var ps corev1.PodList
-			Expect(ctx.Ctx().Client().List(context.Background(), &ps, client.MatchingLabels{"app": "foobar"})).To(Succeed())
-			Expect(ps.Items).To(Not(BeEmpty()))
-
-			Expect(ctx.Ctx().Client().Delete(context.Background(), &ps.Items[0])).To(Succeed())
-
-			Consistently(func() (*operatorsv1alpha1.ClusterServiceVersion, error) {
-				return &csv, ctx.Ctx().Client().Get(context.Background(), client.ObjectKeyFromObject(&csv), &csv)
-			}).Should(HavePhase(operatorsv1alpha1.CSVPhaseSucceeded))
-		})
-	})
-
-	When("a copied csv exists", func() {
-		var (
-			target   corev1.Namespace
-			original operatorsv1alpha1.ClusterServiceVersion
-			copy     operatorsv1alpha1.ClusterServiceVersion
-		)
-
-		BeforeEach(func() {
-			target = corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "watched-",
-				},
-			}
-			Expect(ctx.Ctx().Client().Create(context.Background(), &target)).To(Succeed())
-
-			original = operatorsv1alpha1.ClusterServiceVersion{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
-					APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "csv-",
-					Namespace:    testNamespace,
-				},
-				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-					InstallStrategy: newNginxInstallStrategy(genName("csv-"), nil, nil),
-					InstallModes: []operatorsv1alpha1.InstallMode{
-						{
-							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-							Supported: true,
+				original = operatorsv1alpha1.ClusterServiceVersion{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+						APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "csv-",
+						Namespace:    ns.GetName(),
+					},
+					Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+						InstallStrategy: newNginxInstallStrategy(genName("csv-"), nil, nil),
+						InstallModes: []operatorsv1alpha1.InstallMode{
+							{
+								Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+								Supported: true,
+							},
 						},
 					},
-				},
-			}
-			Expect(ctx.Ctx().Client().Create(context.Background(), &original)).To(Succeed())
-
-			Eventually(func() error {
-				key := client.ObjectKeyFromObject(&original)
-				key.Namespace = target.GetName()
-				return ctx.Ctx().Client().Get(context.Background(), key, &copy)
-			}).Should(Succeed())
-		})
-
-		AfterEach(func() {
-			if target.GetName() != "" {
-				Expect(ctx.Ctx().Client().Delete(context.Background(), &target)).To(Succeed())
-			}
-		})
-
-		It("is synchronized with the original csv", func() {
-			Eventually(func() error {
-				key := client.ObjectKeyFromObject(&copy)
-
-				key.Namespace = target.Name
-				if err := ctx.Ctx().Client().Get(context.Background(), key, &copy); err != nil {
-					return err
 				}
+				Expect(ctx.Ctx().Client().Create(context.Background(), &original)).To(Succeed())
 
-				copy.Status.LastUpdateTime = &metav1.Time{Time: time.Unix(1, 0)}
-				return ctx.Ctx().Client().Status().Update(context.Background(), &copy)
-			}).Should(Succeed())
+				Eventually(func() error {
+					key := client.ObjectKeyFromObject(&original)
+					key.Namespace = target.GetName()
+					return ctx.Ctx().Client().Get(context.Background(), key, &copyCSV)
+				}).Should(Succeed())
+			})
 
-			Eventually(func() (bool, error) {
-				key := client.ObjectKeyFromObject(&original)
-
-				if err := ctx.Ctx().Client().Get(context.Background(), key, &original); err != nil {
-					return false, err
+			AfterEach(func() {
+				if target.GetName() != "" {
+					Expect(ctx.Ctx().Client().Delete(context.Background(), &target)).To(Succeed())
 				}
+			})
 
-				key.Namespace = target.Name
-				if err := ctx.Ctx().Client().Get(context.Background(), key, &copy); err != nil {
-					return false, err
-				}
+			It("is synchronized with the original csv", func() {
+				Eventually(func() error {
+					key := client.ObjectKeyFromObject(&copyCSV)
 
-				return original.Status.LastUpdateTime.Equal(copy.Status.LastUpdateTime), nil
-			}).Should(BeTrue(), "Change to status of copy should have been reverted")
+					key.Namespace = target.Name
+					if err := ctx.Ctx().Client().Get(context.Background(), key, &copyCSV); err != nil {
+						return err
+					}
+
+					copyCSV.Status.LastUpdateTime = &metav1.Time{Time: time.Unix(1, 0)}
+					return ctx.Ctx().Client().Status().Update(context.Background(), &copyCSV)
+				}).Should(Succeed())
+
+				Eventually(func() (bool, error) {
+					key := client.ObjectKeyFromObject(&original)
+
+					if err := ctx.Ctx().Client().Get(context.Background(), key, &original); err != nil {
+						return false, err
+					}
+
+					key.Namespace = target.Name
+					if err := ctx.Ctx().Client().Get(context.Background(), key, &copyCSV); err != nil {
+						return false, err
+					}
+
+					return original.Status.LastUpdateTime.Equal(copyCSV.Status.LastUpdateTime), nil
+				}).Should(BeTrue(), "Change to status of copy should have been reverted")
+			})
 		})
-	})
+		When("a csv requires a serviceaccount solely owned by a non-csv", func() {
+			var (
+				cm  corev1.ConfigMap
+				sa  corev1.ServiceAccount
+				csv operatorsv1alpha1.ClusterServiceVersion
+			)
 
-	When("a csv requires a serviceaccount solely owned by a non-csv", func() {
-		var (
-			cm  corev1.ConfigMap
-			sa  corev1.ServiceAccount
-			csv operatorsv1alpha1.ClusterServiceVersion
-		)
+			BeforeEach(func() {
+				cm = corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "cm-",
+						Namespace:    ns.GetName(),
+					},
+				}
+				Expect(ctx.Ctx().Client().Create(context.Background(), &cm)).To(Succeed())
 
-		BeforeEach(func() {
-			cm = corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "cm-",
-					Namespace:    testNamespace,
-				},
-			}
-			Expect(ctx.Ctx().Client().Create(context.Background(), &cm)).To(Succeed())
-
-			sa = corev1.ServiceAccount{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "sa-",
-					Namespace:    testNamespace,
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							Name:       cm.GetName(),
-							APIVersion: corev1.SchemeGroupVersion.String(),
-							Kind:       "ConfigMap",
-							UID:        cm.GetUID(),
+				sa = corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "sa-",
+						Namespace:    ns.GetName(),
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Name:       cm.GetName(),
+								APIVersion: corev1.SchemeGroupVersion.String(),
+								Kind:       "ConfigMap",
+								UID:        cm.GetUID(),
+							},
 						},
 					},
-				},
-			}
-			Expect(ctx.Ctx().Client().Create(context.Background(), &sa)).To(Succeed())
+				}
+				Expect(ctx.Ctx().Client().Create(context.Background(), &sa)).To(Succeed())
 
-			csv = operatorsv1alpha1.ClusterServiceVersion{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
-					APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "csv-",
-					Namespace:    testNamespace,
-				},
-				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-					InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
-						StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
-						StrategySpec: operatorsv1alpha1.StrategyDetailsDeployment{
-							DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
-								{
-									Name: "foo",
-									Spec: appsv1.DeploymentSpec{
-										Selector: &metav1.LabelSelector{
-											MatchLabels: map[string]string{"app": "foo"},
-										},
-										Template: corev1.PodTemplateSpec{
-											ObjectMeta: metav1.ObjectMeta{
-												Labels: map[string]string{"app": "foo"},
+				csv = operatorsv1alpha1.ClusterServiceVersion{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+						APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "csv-",
+						Namespace:    ns.GetName(),
+					},
+					Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+						InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+							StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
+							StrategySpec: operatorsv1alpha1.StrategyDetailsDeployment{
+								DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
+									{
+										Name: "foo",
+										Spec: appsv1.DeploymentSpec{
+											Selector: &metav1.LabelSelector{
+												MatchLabels: map[string]string{"app": "foo"},
 											},
-											Spec: corev1.PodSpec{Containers: []corev1.Container{
-												{
-													Name:  genName("foo"),
-													Image: *dummyImage,
+											Template: corev1.PodTemplateSpec{
+												ObjectMeta: metav1.ObjectMeta{
+													Labels: map[string]string{"app": "foo"},
 												},
-											}},
+												Spec: corev1.PodSpec{Containers: []corev1.Container{
+													{
+														Name:  genName("foo"),
+														Image: *dummyImage,
+													},
+												}},
+											},
 										},
 									},
 								},
-							},
-							Permissions: []operatorsv1alpha1.StrategyDeploymentPermissions{
-								{
-									ServiceAccountName: sa.GetName(),
-									Rules:              []rbacv1.PolicyRule{},
+								Permissions: []operatorsv1alpha1.StrategyDeploymentPermissions{
+									{
+										ServiceAccountName: sa.GetName(),
+										Rules:              []rbacv1.PolicyRule{},
+									},
 								},
 							},
 						},
+						InstallModes: []operatorsv1alpha1.InstallMode{
+							{
+								Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+								Supported: true,
+							},
+						},
 					},
+				}
+				Expect(ctx.Ctx().Client().Create(context.Background(), &csv)).To(Succeed())
+			})
+
+			AfterEach(func() {
+				if cm.GetName() != "" {
+					Expect(ctx.Ctx().Client().Delete(context.Background(), &cm)).To(Succeed())
+				}
+			})
+
+			It("considers the serviceaccount requirement satisfied", func() {
+				Eventually(func() (operatorsv1alpha1.StatusReason, error) {
+					if err := ctx.Ctx().Client().Get(context.Background(), client.ObjectKeyFromObject(&csv), &csv); err != nil {
+						return "", err
+					}
+					for _, requirement := range csv.Status.RequirementStatus {
+						if requirement.Name != sa.GetName() {
+							continue
+						}
+						return requirement.Status, nil
+					}
+					return "", fmt.Errorf("missing expected requirement %q", sa.GetName())
+				}).Should(Equal(operatorsv1alpha1.RequirementStatusReasonPresent))
+			})
+		})
+
+		It("create with unmet requirements min kube version", func() {
+
+			depName := genName("dep-")
+			csv := operatorsv1alpha1.ClusterServiceVersion{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+					APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: genName("csv"),
+				},
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					MinKubeVersion: "999.999.999",
 					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
 						{
 							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
 							Supported: true,
 						},
 					},
+					InstallStrategy: newNginxInstallStrategy(depName, nil, nil),
 				},
 			}
-			Expect(ctx.Ctx().Client().Create(context.Background(), &csv)).To(Succeed())
+
+			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCSV()
+
+			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvPendingChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Shouldn't create deployment
+			Consistently(func() bool {
+				_, err := c.GetDeployment(ns.GetName(), depName)
+				return apierrors.IsNotFound(err)
+			}).Should(BeTrue())
 		})
+		// TODO: same test but missing serviceaccount instead
+		It("create with unmet requirements CRD", func() {
 
-		AfterEach(func() {
-			if cm.GetName() != "" {
-				Expect(ctx.Ctx().Client().Delete(context.Background(), &cm)).To(Succeed())
-			}
-		})
-
-		It("considers the serviceaccount requirement satisfied", func() {
-			Eventually(func() (operatorsv1alpha1.StatusReason, error) {
-				if err := ctx.Ctx().Client().Get(context.Background(), client.ObjectKeyFromObject(&csv), &csv); err != nil {
-					return "", err
-				}
-				for _, requirement := range csv.Status.RequirementStatus {
-					if requirement.Name != sa.GetName() {
-						continue
-					}
-					return requirement.Status, nil
-				}
-				return "", fmt.Errorf("missing expected requirement %q", sa.GetName())
-			}).Should(Equal(operatorsv1alpha1.RequirementStatusReasonPresent))
-		})
-	})
-
-	It("create with unmet requirements min kube version", func() {
-
-		depName := genName("dep-")
-		csv := operatorsv1alpha1.ClusterServiceVersion{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
-				APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("csv"),
-			},
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				MinKubeVersion: "999.999.999",
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
-					},
+			depName := genName("dep-")
+			csv := operatorsv1alpha1.ClusterServiceVersion{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+					APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
 				},
-				InstallStrategy: newNginxInstallStrategy(depName, nil, nil),
-			},
-		}
-
-		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCSV()
-
-		_, err = fetchCSV(crc, csv.Name, testNamespace, csvPendingChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Shouldn't create deployment
-		Consistently(func() bool {
-			_, err := c.GetDeployment(testNamespace, depName)
-			return apierrors.IsNotFound(err)
-		}).Should(BeTrue())
-	})
-	// TODO: same test but missing serviceaccount instead
-	It("create with unmet requirements CRD", func() {
-
-		depName := genName("dep-")
-		csv := operatorsv1alpha1.ClusterServiceVersion{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
-				APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("csv"),
-			},
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				MinKubeVersion: "0.0.0",
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
-					},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: genName("csv"),
 				},
-				InstallStrategy: newNginxInstallStrategy(depName, nil, nil),
-				CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
-					Owned: []operatorsv1alpha1.CRDDescription{
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					MinKubeVersion: "0.0.0",
+					InstallModes: []operatorsv1alpha1.InstallMode{
 						{
-							DisplayName: "Not In Cluster",
-							Description: "A CRD that is not currently in the cluster",
-							Name:        "not.in.cluster.com",
-							Version:     "v1alpha1",
-							Kind:        "NotInCluster",
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
 						},
 					},
-				},
-			},
-		}
 
-		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCSV()
-
-		_, err = fetchCSV(crc, csv.Name, testNamespace, csvPendingChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Shouldn't create deployment
-		Consistently(func() bool {
-			_, err := c.GetDeployment(testNamespace, depName)
-			return apierrors.IsNotFound(err)
-		}).Should(BeTrue())
-	})
-
-	It("create with unmet permissions CRD", func() {
-
-		saName := genName("dep-")
-		permissions := []operatorsv1alpha1.StrategyDeploymentPermissions{
-			{
-				ServiceAccountName: saName,
-				Rules: []rbacv1.PolicyRule{
-					{
-						Verbs:     []string{"create"},
-						APIGroups: []string{""},
-						Resources: []string{"deployment"},
-					},
-				},
-			},
-		}
-
-		clusterPermissions := []operatorsv1alpha1.StrategyDeploymentPermissions{
-			{
-				ServiceAccountName: saName,
-				Rules: []rbacv1.PolicyRule{
-					{
-						Verbs:     []string{"get"},
-						APIGroups: []string{""},
-						Resources: []string{"deployment"},
-					},
-				},
-			},
-		}
-
-		crdPlural := genName("ins")
-		crdName := crdPlural + ".cluster.com"
-		depName := genName("dep-")
-		csv := operatorsv1alpha1.ClusterServiceVersion{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
-				APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("csv"),
-			},
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
-					},
-				},
-				InstallStrategy: newNginxInstallStrategy(depName, permissions, clusterPermissions),
-				CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
-					Owned: []operatorsv1alpha1.CRDDescription{
-						{
-							Name:        crdName,
-							Version:     "v1alpha1",
-							Kind:        crdPlural,
-							DisplayName: crdName,
-							Description: crdName,
-						},
-					},
-				},
-			},
-		}
-
-		// Create dependency first (CRD)
-		cleanupCRD, err := createCRD(c, apiextensions.CustomResourceDefinition{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: crdName,
-			},
-			Spec: apiextensions.CustomResourceDefinitionSpec{
-				Group: "cluster.com",
-				Versions: []apiextensions.CustomResourceDefinitionVersion{
-					{
-						Name:    "v1alpha1",
-						Served:  true,
-						Storage: true,
-						Schema: &apiextensions.CustomResourceValidation{
-							OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
-								Type:        "object",
-								Description: "my crd schema",
+					InstallStrategy: newNginxInstallStrategy(depName, nil, nil),
+					CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
+						Owned: []operatorsv1alpha1.CRDDescription{
+							{
+								DisplayName: "Not In Cluster",
+								Description: "A CRD that is not currently in the cluster",
+								Name:        "not.in.cluster.com",
+								Version:     "v1alpha1",
+								Kind:        "NotInCluster",
 							},
 						},
 					},
 				},
-				Names: apiextensions.CustomResourceDefinitionNames{
-					Plural:   crdPlural,
-					Singular: crdPlural,
-					Kind:     crdPlural,
-					ListKind: "list" + crdPlural,
-				},
-				Scope: apiextensions.NamespaceScoped,
-			},
+			}
+
+			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCSV()
+
+			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvPendingChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Shouldn't create deployment
+			Consistently(func() bool {
+				_, err := c.GetDeployment(ns.GetName(), depName)
+				return apierrors.IsNotFound(err)
+			}).Should(BeTrue())
 		})
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCRD()
 
-		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, true, false)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCSV()
-
-		_, err = fetchCSV(crc, csv.Name, testNamespace, csvPendingChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Shouldn't create deployment
-		Consistently(func() bool {
-			_, err := c.GetDeployment(testNamespace, depName)
-			return apierrors.IsNotFound(err)
-		}).Should(BeTrue())
-	})
-	It("create with unmet requirements API service", func() {
-
-		depName := genName("dep-")
-		csv := operatorsv1alpha1.ClusterServiceVersion{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
-				APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("csv"),
-			},
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				MinKubeVersion: "0.0.0",
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
-					},
-				},
-				InstallStrategy: newNginxInstallStrategy(depName, nil, nil),
-				APIServiceDefinitions: operatorsv1alpha1.APIServiceDefinitions{
-					Required: []operatorsv1alpha1.APIServiceDescription{
+		It("create with unmet permissions CRD", func() {
+			saName := genName("dep-")
+			permissions := []operatorsv1alpha1.StrategyDeploymentPermissions{
+				{
+					ServiceAccountName: saName,
+					Rules: []rbacv1.PolicyRule{
 						{
-							DisplayName: "Not In Cluster",
-							Description: "An apiservice that is not currently in the cluster",
-							Group:       "not.in.cluster.com",
-							Version:     "v1alpha1",
-							Kind:        "NotInCluster",
+							Verbs:     []string{"create"},
+							APIGroups: []string{""},
+							Resources: []string{"deployment"},
 						},
 					},
 				},
-			},
-		}
+			}
 
-		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCSV()
+			clusterPermissions := []operatorsv1alpha1.StrategyDeploymentPermissions{
+				{
+					ServiceAccountName: saName,
+					Rules: []rbacv1.PolicyRule{
+						{
+							Verbs:     []string{"get"},
+							APIGroups: []string{""},
+							Resources: []string{"deployment"},
+						},
+					},
+				},
+			}
 
-		_, err = fetchCSV(crc, csv.Name, testNamespace, csvPendingChecker)
-		Expect(err).ShouldNot(HaveOccurred())
+			crdPlural := genName("ins")
+			crdName := crdPlural + ".cluster.com"
+			depName := genName("dep-")
+			csv := operatorsv1alpha1.ClusterServiceVersion{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+					APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: genName("csv"),
+				},
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
+					},
+					InstallStrategy: newNginxInstallStrategy(depName, permissions, clusterPermissions),
+					CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
+						Owned: []operatorsv1alpha1.CRDDescription{
+							{
+								Name:        crdName,
+								Version:     "v1alpha1",
+								Kind:        crdPlural,
+								DisplayName: crdName,
+								Description: crdName,
+							},
+						},
+					},
+				},
+			}
 
-		// Shouldn't create deployment
-		Consistently(func() bool {
-			_, err := c.GetDeployment(testNamespace, depName)
-			return apierrors.IsNotFound(err)
-		}).Should(BeTrue())
-	})
-	It("create with unmet permissions API service", func() {
+			// Create dependency first (CRD)
+			cleanupCRD, err := createCRD(c, apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: crdName,
+				},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "cluster.com",
+					Versions: []apiextensions.CustomResourceDefinitionVersion{
+						{
+							Name:    "v1alpha1",
+							Served:  true,
+							Storage: true,
+							Schema: &apiextensions.CustomResourceValidation{
+								OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+									Type:        "object",
+									Description: "my crd schema",
+								},
+							},
+						},
+					},
+					Names: apiextensions.CustomResourceDefinitionNames{
+						Plural:   crdPlural,
+						Singular: crdPlural,
+						Kind:     crdPlural,
+						ListKind: "list" + crdPlural,
+					},
+					Scope: apiextensions.NamespaceScoped,
+				},
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCRD()
 
-		saName := genName("dep-")
-		permissions := []operatorsv1alpha1.StrategyDeploymentPermissions{
-			{
-				ServiceAccountName: saName,
+			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), true, false)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCSV()
+
+			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvPendingChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Shouldn't create deployment
+			Consistently(func() bool {
+				_, err := c.GetDeployment(ns.GetName(), depName)
+				return apierrors.IsNotFound(err)
+			}).Should(BeTrue())
+		})
+		It("create with unmet requirements API service", func() {
+
+			depName := genName("dep-")
+			csv := operatorsv1alpha1.ClusterServiceVersion{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+					APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: genName("csv"),
+				},
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					MinKubeVersion: "0.0.0",
+					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
+					},
+					InstallStrategy: newNginxInstallStrategy(depName, nil, nil),
+					APIServiceDefinitions: operatorsv1alpha1.APIServiceDefinitions{
+						Required: []operatorsv1alpha1.APIServiceDescription{
+							{
+								DisplayName: "Not In Cluster",
+								Description: "An apiservice that is not currently in the cluster",
+								Group:       "not.in.cluster.com",
+								Version:     "v1alpha1",
+								Kind:        "NotInCluster",
+							},
+						},
+					},
+				},
+			}
+
+			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCSV()
+
+			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvPendingChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Shouldn't create deployment
+			Consistently(func() bool {
+				_, err := c.GetDeployment(ns.GetName(), depName)
+				return apierrors.IsNotFound(err)
+			}).Should(BeTrue())
+		})
+		It("create with unmet permissions API service", func() {
+
+			saName := genName("dep-")
+			permissions := []operatorsv1alpha1.StrategyDeploymentPermissions{
+				{
+					ServiceAccountName: saName,
+					Rules: []rbacv1.PolicyRule{
+						{
+							Verbs:     []string{"create"},
+							APIGroups: []string{""},
+							Resources: []string{"deployment"},
+						},
+					},
+				},
+			}
+
+			clusterPermissions := []operatorsv1alpha1.StrategyDeploymentPermissions{
+				{
+					ServiceAccountName: saName,
+					Rules: []rbacv1.PolicyRule{
+						{
+							Verbs:     []string{"get"},
+							APIGroups: []string{""},
+							Resources: []string{"deployment"},
+						},
+					},
+				},
+			}
+
+			depName := genName("dep-")
+			csv := operatorsv1alpha1.ClusterServiceVersion{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+					APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: genName("csv"),
+				},
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					MinKubeVersion: "0.0.0",
+					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
+					},
+					InstallStrategy: newNginxInstallStrategy(depName, permissions, clusterPermissions),
+					// Cheating a little; this is an APIservice that will exist for the e2e tests
+					APIServiceDefinitions: operatorsv1alpha1.APIServiceDefinitions{
+						Required: []operatorsv1alpha1.APIServiceDescription{
+							{
+								Group:       "packages.operators.coreos.com",
+								Version:     "v1",
+								Kind:        "PackageManifest",
+								DisplayName: "Package Manifest",
+								Description: "An apiservice that exists",
+							},
+						},
+					},
+				},
+			}
+
+			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCSV()
+
+			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvPendingChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Shouldn't create deployment
+			Consistently(func() bool {
+				_, err := c.GetDeployment(ns.GetName(), depName)
+				return apierrors.IsNotFound(err)
+			}).Should(BeTrue())
+		})
+		It("create with unmet requirements native API", func() {
+
+			depName := genName("dep-")
+			csv := operatorsv1alpha1.ClusterServiceVersion{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+					APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: genName("csv"),
+				},
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					MinKubeVersion: "0.0.0",
+					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
+					},
+					InstallStrategy: newNginxInstallStrategy(depName, nil, nil),
+					NativeAPIs:      []metav1.GroupVersionKind{{Group: "kubenative.io", Version: "v1", Kind: "Native"}},
+				},
+			}
+
+			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCSV()
+
+			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvPendingChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Shouldn't create deployment
+			Consistently(func() bool {
+				_, err := c.GetDeployment(ns.GetName(), depName)
+				return apierrors.IsNotFound(err)
+			}).Should(BeTrue())
+		})
+		// TODO: same test but create serviceaccount instead
+		It("create requirements met CRD", func() {
+
+			saName := genName("sa-")
+			permissions := []operatorsv1alpha1.StrategyDeploymentPermissions{
+				{
+					ServiceAccountName: saName,
+					Rules: []rbacv1.PolicyRule{
+						{
+							Verbs:     []string{"create"},
+							APIGroups: []string{""},
+							Resources: []string{"deployment"},
+						},
+					},
+				},
+			}
+
+			clusterPermissions := []operatorsv1alpha1.StrategyDeploymentPermissions{
+				{
+					ServiceAccountName: saName,
+					Rules: []rbacv1.PolicyRule{
+						{
+							Verbs:     []string{"get"},
+							APIGroups: []string{""},
+							Resources: []string{"deployment"},
+						},
+						{
+							Verbs:           []string{"put", "post", "get"},
+							NonResourceURLs: []string{"/osb", "/osb/*"},
+						},
+					},
+				},
+			}
+
+			crdPlural := genName("ins")
+			crdName := crdPlural + ".cluster.com"
+			depName := genName("dep-")
+			csv := operatorsv1alpha1.ClusterServiceVersion{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+					APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: genName("csv"),
+				},
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					MinKubeVersion: "0.0.0",
+					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
+					},
+					InstallStrategy: newNginxInstallStrategy(depName, permissions, clusterPermissions),
+					CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
+						Owned: []operatorsv1alpha1.CRDDescription{
+							{
+								Name:        crdName,
+								Version:     "v1alpha1",
+								Kind:        crdPlural,
+								DisplayName: crdName,
+								Description: crdName,
+							},
+						},
+					},
+				},
+			}
+
+			// Create CSV first, knowing it will fail
+			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), true, false)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCSV()
+
+			fetchedCSV, err := fetchCSV(crc, csv.Name, ns.GetName(), csvPendingChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			sa := corev1.ServiceAccount{}
+			sa.SetName(saName)
+			sa.SetNamespace(ns.GetName())
+			sa.SetOwnerReferences([]metav1.OwnerReference{{
+				Name:       fetchedCSV.GetName(),
+				APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
+				Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+				UID:        fetchedCSV.GetUID(),
+			}})
+			_, err = c.CreateServiceAccount(&sa)
+			Expect(err).ShouldNot(HaveOccurred(), "could not create ServiceAccount %#v", sa)
+
+			crd := apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: crdName,
+				},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "cluster.com",
+					Versions: []apiextensions.CustomResourceDefinitionVersion{
+						{
+							Name:    "v1alpha1",
+							Served:  true,
+							Storage: true,
+							Schema: &apiextensions.CustomResourceValidation{
+								OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+									Type:        "object",
+									Description: "my crd schema",
+								},
+							},
+						},
+					},
+					Names: apiextensions.CustomResourceDefinitionNames{
+						Plural:   crdPlural,
+						Singular: crdPlural,
+						Kind:     crdPlural,
+						ListKind: "list" + crdPlural,
+					},
+					Scope: apiextensions.NamespaceScoped,
+				},
+			}
+			crd.SetOwnerReferences([]metav1.OwnerReference{{
+				Name:       fetchedCSV.GetName(),
+				APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
+				Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+				UID:        fetchedCSV.GetUID(),
+			}})
+			cleanupCRD, err := createCRD(c, crd)
+			defer cleanupCRD()
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Create Role/Cluster Roles and RoleBindings
+			role := rbacv1.Role{
 				Rules: []rbacv1.PolicyRule{
 					{
 						Verbs:     []string{"create"},
@@ -1032,12 +1280,33 @@ var _ = Describe("ClusterServiceVersion", func() {
 						Resources: []string{"deployment"},
 					},
 				},
-			},
-		}
+			}
+			role.SetName(genName("dep-"))
+			role.SetNamespace(ns.GetName())
+			_, err = c.CreateRole(&role)
+			Expect(err).ShouldNot(HaveOccurred(), "could not create Role")
 
-		clusterPermissions := []operatorsv1alpha1.StrategyDeploymentPermissions{
-			{
-				ServiceAccountName: saName,
+			roleBinding := rbacv1.RoleBinding{
+				Subjects: []rbacv1.Subject{
+					{
+						Kind:      "ServiceAccount",
+						APIGroup:  "",
+						Name:      sa.GetName(),
+						Namespace: sa.GetNamespace(),
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "Role",
+					Name:     role.GetName(),
+				},
+			}
+			roleBinding.SetName(genName("dep-"))
+			roleBinding.SetNamespace(ns.GetName())
+			_, err = c.CreateRoleBinding(&roleBinding)
+			Expect(err).ShouldNot(HaveOccurred(), "could not create RoleBinding")
+
+			clusterRole := rbacv1.ClusterRole{
 				Rules: []rbacv1.PolicyRule{
 					{
 						Verbs:     []string{"get"},
@@ -1045,403 +1314,182 @@ var _ = Describe("ClusterServiceVersion", func() {
 						Resources: []string{"deployment"},
 					},
 				},
-			},
-		}
+			}
+			clusterRole.SetName(genName("dep-"))
+			_, err = c.CreateClusterRole(&clusterRole)
+			Expect(err).ShouldNot(HaveOccurred(), "could not create ClusterRole")
 
-		depName := genName("dep-")
-		csv := operatorsv1alpha1.ClusterServiceVersion{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
-				APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("csv"),
-			},
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				MinKubeVersion: "0.0.0",
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
-					},
-				},
-				InstallStrategy: newNginxInstallStrategy(depName, permissions, clusterPermissions),
-				// Cheating a little; this is an APIservice that will exist for the e2e tests
-				APIServiceDefinitions: operatorsv1alpha1.APIServiceDefinitions{
-					Required: []operatorsv1alpha1.APIServiceDescription{
-						{
-							Group:       "packages.operators.coreos.com",
-							Version:     "v1",
-							Kind:        "PackageManifest",
-							DisplayName: "Package Manifest",
-							Description: "An apiservice that exists",
-						},
-					},
-				},
-			},
-		}
-
-		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCSV()
-
-		_, err = fetchCSV(crc, csv.Name, testNamespace, csvPendingChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Shouldn't create deployment
-		Consistently(func() bool {
-			_, err := c.GetDeployment(testNamespace, depName)
-			return apierrors.IsNotFound(err)
-		}).Should(BeTrue())
-	})
-	It("create with unmet requirements native API", func() {
-
-		depName := genName("dep-")
-		csv := operatorsv1alpha1.ClusterServiceVersion{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
-				APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("csv"),
-			},
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				MinKubeVersion: "0.0.0",
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
-					},
-				},
-				InstallStrategy: newNginxInstallStrategy(depName, nil, nil),
-				NativeAPIs:      []metav1.GroupVersionKind{{Group: "kubenative.io", Version: "v1", Kind: "Native"}},
-			},
-		}
-
-		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCSV()
-
-		_, err = fetchCSV(crc, csv.Name, testNamespace, csvPendingChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Shouldn't create deployment
-		Consistently(func() bool {
-			_, err := c.GetDeployment(testNamespace, depName)
-			return apierrors.IsNotFound(err)
-		}).Should(BeTrue())
-	})
-	// TODO: same test but create serviceaccount instead
-	It("create requirements met CRD", func() {
-
-		saName := genName("sa-")
-		permissions := []operatorsv1alpha1.StrategyDeploymentPermissions{
-			{
-				ServiceAccountName: saName,
+			nonResourceClusterRole := rbacv1.ClusterRole{
 				Rules: []rbacv1.PolicyRule{
-					{
-						Verbs:     []string{"create"},
-						APIGroups: []string{""},
-						Resources: []string{"deployment"},
-					},
-				},
-			},
-		}
-
-		clusterPermissions := []operatorsv1alpha1.StrategyDeploymentPermissions{
-			{
-				ServiceAccountName: saName,
-				Rules: []rbacv1.PolicyRule{
-					{
-						Verbs:     []string{"get"},
-						APIGroups: []string{""},
-						Resources: []string{"deployment"},
-					},
 					{
 						Verbs:           []string{"put", "post", "get"},
 						NonResourceURLs: []string{"/osb", "/osb/*"},
 					},
 				},
-			},
-		}
+			}
+			nonResourceClusterRole.SetName(genName("dep-"))
+			_, err = c.CreateClusterRole(&nonResourceClusterRole)
+			Expect(err).ShouldNot(HaveOccurred(), "could not create ClusterRole")
 
-		crdPlural := genName("ins")
-		crdName := crdPlural + ".cluster.com"
-		depName := genName("dep-")
-		csv := operatorsv1alpha1.ClusterServiceVersion{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
-				APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("csv"),
-			},
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				MinKubeVersion: "0.0.0",
-				InstallModes: []operatorsv1alpha1.InstallMode{
+			clusterRoleBinding := rbacv1.ClusterRoleBinding{
+				Subjects: []rbacv1.Subject{
 					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
+						Kind:      "ServiceAccount",
+						APIGroup:  "",
+						Name:      sa.GetName(),
+						Namespace: sa.GetNamespace(),
 					},
 				},
-				InstallStrategy: newNginxInstallStrategy(depName, permissions, clusterPermissions),
-				CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
-					Owned: []operatorsv1alpha1.CRDDescription{
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "ClusterRole",
+					Name:     clusterRole.GetName(),
+				},
+			}
+			clusterRoleBinding.SetName(genName("dep-"))
+			_, err = c.CreateClusterRoleBinding(&clusterRoleBinding)
+			Expect(err).ShouldNot(HaveOccurred(), "could not create ClusterRoleBinding")
+
+			nonResourceClusterRoleBinding := rbacv1.ClusterRoleBinding{
+				Subjects: []rbacv1.Subject{
+					{
+						Kind:      "ServiceAccount",
+						APIGroup:  "",
+						Name:      sa.GetName(),
+						Namespace: sa.GetNamespace(),
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "ClusterRole",
+					Name:     nonResourceClusterRole.GetName(),
+				},
+			}
+			nonResourceClusterRoleBinding.SetName(genName("dep-"))
+			_, err = c.CreateClusterRoleBinding(&nonResourceClusterRoleBinding)
+			Expect(err).ShouldNot(HaveOccurred(), "could not create ClusterRoleBinding")
+
+			ctx.Ctx().Logf("checking for deployment")
+			// Poll for deployment to be ready
+			Eventually(func() (bool, error) {
+				dep, err := c.GetDeployment(ns.GetName(), depName)
+				if apierrors.IsNotFound(err) {
+					ctx.Ctx().Logf("deployment %s not found\n", depName)
+					return false, nil
+				} else if err != nil {
+					ctx.Ctx().Logf("unexpected error fetching deployment %s\n", depName)
+					return false, err
+				}
+				if dep.Status.UpdatedReplicas == *(dep.Spec.Replicas) &&
+					dep.Status.Replicas == *(dep.Spec.Replicas) &&
+					dep.Status.AvailableReplicas == *(dep.Spec.Replicas) {
+					ctx.Ctx().Logf("deployment ready")
+					return true, nil
+				}
+				ctx.Ctx().Logf("deployment not ready")
+				return false, nil
+			}).Should(BeTrue())
+
+			fetchedCSV, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Delete CRD
+			cleanupCRD()
+
+			// Wait for CSV failure
+			fetchedCSV, err = fetchCSV(crc, csv.Name, ns.GetName(), csvPendingChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Recreate the CRD
+			cleanupCRD, err = createCRD(c, crd)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCRD()
+
+			// Wait for CSV success again
+			fetchedCSV, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("create requirements met API service", func() {
+
+			sa := corev1.ServiceAccount{}
+			sa.SetName(genName("sa-"))
+			sa.SetNamespace(ns.GetName())
+			_, err := c.CreateServiceAccount(&sa)
+			Expect(err).ShouldNot(HaveOccurred(), "could not create ServiceAccount")
+
+			permissions := []operatorsv1alpha1.StrategyDeploymentPermissions{
+				{
+					ServiceAccountName: sa.GetName(),
+					Rules: []rbacv1.PolicyRule{
 						{
-							Name:        crdName,
-							Version:     "v1alpha1",
-							Kind:        crdPlural,
-							DisplayName: crdName,
-							Description: crdName,
+							Verbs:     []string{"create"},
+							APIGroups: []string{""},
+							Resources: []string{"deployment"},
 						},
 					},
 				},
-			},
-		}
+			}
 
-		// Create CSV first, knowing it will fail
-		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, true, false)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCSV()
+			clusterPermissions := []operatorsv1alpha1.StrategyDeploymentPermissions{
+				{
+					ServiceAccountName: sa.GetName(),
+					Rules: []rbacv1.PolicyRule{
+						{
+							Verbs:     []string{"get"},
+							APIGroups: []string{""},
+							Resources: []string{"deployment"},
+						},
+					},
+				},
+			}
 
-		fetchedCSV, err := fetchCSV(crc, csv.Name, testNamespace, csvPendingChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		sa := corev1.ServiceAccount{}
-		sa.SetName(saName)
-		sa.SetNamespace(testNamespace)
-		sa.SetOwnerReferences([]metav1.OwnerReference{{
-			Name:       fetchedCSV.GetName(),
-			APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
-			Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
-			UID:        fetchedCSV.GetUID(),
-		}})
-		_, err = c.CreateServiceAccount(&sa)
-		Expect(err).ShouldNot(HaveOccurred(), "could not create ServiceAccount %#v", sa)
-
-		crd := apiextensions.CustomResourceDefinition{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: crdName,
-			},
-			Spec: apiextensions.CustomResourceDefinitionSpec{
-				Group: "cluster.com",
-				Versions: []apiextensions.CustomResourceDefinitionVersion{
-					{
-						Name:    "v1alpha1",
-						Served:  true,
-						Storage: true,
-						Schema: &apiextensions.CustomResourceValidation{
-							OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
-								Type:        "object",
-								Description: "my crd schema",
+			depName := genName("dep-")
+			csv := operatorsv1alpha1.ClusterServiceVersion{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+					APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: genName("csv"),
+				},
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					MinKubeVersion: "0.0.0",
+					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
+					},
+					InstallStrategy: newNginxInstallStrategy(depName, permissions, clusterPermissions),
+					// Cheating a little; this is an APIservice that will exist for the e2e tests
+					APIServiceDefinitions: operatorsv1alpha1.APIServiceDefinitions{
+						Required: []operatorsv1alpha1.APIServiceDescription{
+							{
+								Group:       "packages.operators.coreos.com",
+								Version:     "v1",
+								Kind:        "PackageManifest",
+								DisplayName: "Package Manifest",
+								Description: "An apiservice that exists",
 							},
 						},
 					},
 				},
-				Names: apiextensions.CustomResourceDefinitionNames{
-					Plural:   crdPlural,
-					Singular: crdPlural,
-					Kind:     crdPlural,
-					ListKind: "list" + crdPlural,
-				},
-				Scope: apiextensions.NamespaceScoped,
-			},
-		}
-		crd.SetOwnerReferences([]metav1.OwnerReference{{
-			Name:       fetchedCSV.GetName(),
-			APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
-			Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
-			UID:        fetchedCSV.GetUID(),
-		}})
-		cleanupCRD, err := createCRD(c, crd)
-		defer cleanupCRD()
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Create Role/Cluster Roles and RoleBindings
-		role := rbacv1.Role{
-			Rules: []rbacv1.PolicyRule{
-				{
-					Verbs:     []string{"create"},
-					APIGroups: []string{""},
-					Resources: []string{"deployment"},
-				},
-			},
-		}
-		role.SetName(genName("dep-"))
-		role.SetNamespace(testNamespace)
-		_, err = c.CreateRole(&role)
-		Expect(err).ShouldNot(HaveOccurred(), "could not create Role")
-
-		roleBinding := rbacv1.RoleBinding{
-			Subjects: []rbacv1.Subject{
-				{
-					Kind:      "ServiceAccount",
-					APIGroup:  "",
-					Name:      sa.GetName(),
-					Namespace: sa.GetNamespace(),
-				},
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: "rbac.authorization.k8s.io",
-				Kind:     "Role",
-				Name:     role.GetName(),
-			},
-		}
-		roleBinding.SetName(genName("dep-"))
-		roleBinding.SetNamespace(testNamespace)
-		_, err = c.CreateRoleBinding(&roleBinding)
-		Expect(err).ShouldNot(HaveOccurred(), "could not create RoleBinding")
-
-		clusterRole := rbacv1.ClusterRole{
-			Rules: []rbacv1.PolicyRule{
-				{
-					Verbs:     []string{"get"},
-					APIGroups: []string{""},
-					Resources: []string{"deployment"},
-				},
-			},
-		}
-		clusterRole.SetName(genName("dep-"))
-		_, err = c.CreateClusterRole(&clusterRole)
-		Expect(err).ShouldNot(HaveOccurred(), "could not create ClusterRole")
-
-		nonResourceClusterRole := rbacv1.ClusterRole{
-			Rules: []rbacv1.PolicyRule{
-				{
-					Verbs:           []string{"put", "post", "get"},
-					NonResourceURLs: []string{"/osb", "/osb/*"},
-				},
-			},
-		}
-		nonResourceClusterRole.SetName(genName("dep-"))
-		_, err = c.CreateClusterRole(&nonResourceClusterRole)
-		Expect(err).ShouldNot(HaveOccurred(), "could not create ClusterRole")
-
-		clusterRoleBinding := rbacv1.ClusterRoleBinding{
-			Subjects: []rbacv1.Subject{
-				{
-					Kind:      "ServiceAccount",
-					APIGroup:  "",
-					Name:      sa.GetName(),
-					Namespace: sa.GetNamespace(),
-				},
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: "rbac.authorization.k8s.io",
-				Kind:     "ClusterRole",
-				Name:     clusterRole.GetName(),
-			},
-		}
-		clusterRoleBinding.SetName(genName("dep-"))
-		_, err = c.CreateClusterRoleBinding(&clusterRoleBinding)
-		Expect(err).ShouldNot(HaveOccurred(), "could not create ClusterRoleBinding")
-
-		nonResourceClusterRoleBinding := rbacv1.ClusterRoleBinding{
-			Subjects: []rbacv1.Subject{
-				{
-					Kind:      "ServiceAccount",
-					APIGroup:  "",
-					Name:      sa.GetName(),
-					Namespace: sa.GetNamespace(),
-				},
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: "rbac.authorization.k8s.io",
-				Kind:     "ClusterRole",
-				Name:     nonResourceClusterRole.GetName(),
-			},
-		}
-		nonResourceClusterRoleBinding.SetName(genName("dep-"))
-		_, err = c.CreateClusterRoleBinding(&nonResourceClusterRoleBinding)
-		Expect(err).ShouldNot(HaveOccurred(), "could not create ClusterRoleBinding")
-
-		ctx.Ctx().Logf("checking for deployment")
-		// Poll for deployment to be ready
-		Eventually(func() (bool, error) {
-			dep, err := c.GetDeployment(testNamespace, depName)
-			if apierrors.IsNotFound(err) {
-				ctx.Ctx().Logf("deployment %s not found\n", depName)
-				return false, nil
-			} else if err != nil {
-				ctx.Ctx().Logf("unexpected error fetching deployment %s\n", depName)
-				return false, err
 			}
-			if dep.Status.UpdatedReplicas == *(dep.Spec.Replicas) &&
-				dep.Status.Replicas == *(dep.Spec.Replicas) &&
-				dep.Status.AvailableReplicas == *(dep.Spec.Replicas) {
-				ctx.Ctx().Logf("deployment ready")
-				return true, nil
-			}
-			ctx.Ctx().Logf("deployment not ready")
-			return false, nil
-		}).Should(BeTrue())
 
-		fetchedCSV, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Delete CRD
-		cleanupCRD()
-
-		// Wait for CSV failure
-		fetchedCSV, err = fetchCSV(crc, csv.Name, testNamespace, csvPendingChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Recreate the CRD
-		cleanupCRD, err = createCRD(c, crd)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCRD()
-
-		// Wait for CSV success again
-		fetchedCSV, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-	})
-	It("create requirements met API service", func() {
-
-		sa := corev1.ServiceAccount{}
-		sa.SetName(genName("sa-"))
-		sa.SetNamespace(testNamespace)
-		_, err := c.CreateServiceAccount(&sa)
-		Expect(err).ShouldNot(HaveOccurred(), "could not create ServiceAccount")
-
-		permissions := []operatorsv1alpha1.StrategyDeploymentPermissions{
-			{
-				ServiceAccountName: sa.GetName(),
+			// Create Role/Cluster Roles and RoleBindings
+			role := rbacv1.Role{
 				Rules: []rbacv1.PolicyRule{
 					{
 						Verbs:     []string{"create"},
@@ -1449,12 +1497,33 @@ var _ = Describe("ClusterServiceVersion", func() {
 						Resources: []string{"deployment"},
 					},
 				},
-			},
-		}
+			}
+			role.SetName(genName("dep-"))
+			role.SetNamespace(ns.GetName())
+			_, err = c.CreateRole(&role)
+			Expect(err).ShouldNot(HaveOccurred(), "could not create Role")
 
-		clusterPermissions := []operatorsv1alpha1.StrategyDeploymentPermissions{
-			{
-				ServiceAccountName: sa.GetName(),
+			roleBinding := rbacv1.RoleBinding{
+				Subjects: []rbacv1.Subject{
+					{
+						Kind:      "ServiceAccount",
+						APIGroup:  "",
+						Name:      sa.GetName(),
+						Namespace: sa.GetNamespace(),
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "Role",
+					Name:     role.GetName(),
+				},
+			}
+			roleBinding.SetName(genName("dep-"))
+			roleBinding.SetNamespace(ns.GetName())
+			_, err = c.CreateRoleBinding(&roleBinding)
+			Expect(err).ShouldNot(HaveOccurred(), "could not create RoleBinding")
+
+			clusterRole := rbacv1.ClusterRole{
 				Rules: []rbacv1.PolicyRule{
 					{
 						Verbs:     []string{"get"},
@@ -1462,3002 +1531,2656 @@ var _ = Describe("ClusterServiceVersion", func() {
 						Resources: []string{"deployment"},
 					},
 				},
-			},
-		}
+			}
+			clusterRole.SetName(genName("dep-"))
+			_, err = c.CreateClusterRole(&clusterRole)
+			Expect(err).ShouldNot(HaveOccurred(), "could not create ClusterRole")
 
-		depName := genName("dep-")
-		csv := operatorsv1alpha1.ClusterServiceVersion{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
-				APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("csv"),
-			},
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				MinKubeVersion: "0.0.0",
-				InstallModes: []operatorsv1alpha1.InstallMode{
+			clusterRoleBinding := rbacv1.ClusterRoleBinding{
+				Subjects: []rbacv1.Subject{
 					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
+						Kind:      "ServiceAccount",
+						APIGroup:  "",
+						Name:      sa.GetName(),
+						Namespace: sa.GetNamespace(),
 					},
 				},
-				InstallStrategy: newNginxInstallStrategy(depName, permissions, clusterPermissions),
-				// Cheating a little; this is an APIservice that will exist for the e2e tests
-				APIServiceDefinitions: operatorsv1alpha1.APIServiceDefinitions{
-					Required: []operatorsv1alpha1.APIServiceDescription{
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "ClusterRole",
+					Name:     clusterRole.GetName(),
+				},
+			}
+			clusterRoleBinding.SetName(genName("dep-"))
+			_, err = c.CreateClusterRoleBinding(&clusterRoleBinding)
+			Expect(err).ShouldNot(HaveOccurred(), "could not create ClusterRoleBinding")
+
+			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCSV()
+
+			fetchedCSV, err := fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Fetch cluster service version again to check for unnecessary control loops
+			sameCSV, err := fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
+		})
+		It("create with owned API service", func() {
+
+			depName := genName("hat-server")
+			mockGroup := fmt.Sprintf("hats.%s.redhat.com", genName(""))
+			version := "v1alpha1"
+			mockGroupVersion := strings.Join([]string{mockGroup, version}, "/")
+			mockKinds := []string{"fez", "fedora"}
+			depSpec := newMockExtServerDeployment(depName, []mockGroupVersionKind{{depName, mockGroupVersion, mockKinds, 5443}})
+			apiServiceName := strings.Join([]string{version, mockGroup}, ".")
+
+			// Create CSV for the package-server
+			strategy := operatorsv1alpha1.StrategyDetailsDeployment{
+				DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
+					{
+						Name: depName,
+						Spec: depSpec,
+					},
+				},
+			}
+
+			owned := make([]operatorsv1alpha1.APIServiceDescription, len(mockKinds))
+			for i, kind := range mockKinds {
+				owned[i] = operatorsv1alpha1.APIServiceDescription{
+					Name:           apiServiceName,
+					Group:          mockGroup,
+					Version:        version,
+					Kind:           kind,
+					DeploymentName: depName,
+					ContainerPort:  int32(5443),
+					DisplayName:    kind,
+					Description:    fmt.Sprintf("A %s", kind),
+				}
+			}
+
+			csv := operatorsv1alpha1.ClusterServiceVersion{
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					MinKubeVersion: "0.0.0",
+					InstallModes: []operatorsv1alpha1.InstallMode{
 						{
-							Group:       "packages.operators.coreos.com",
-							Version:     "v1",
-							Kind:        "PackageManifest",
-							DisplayName: "Package Manifest",
-							Description: "An apiservice that exists",
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
 						},
 					},
+					InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+						StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
+						StrategySpec: strategy,
+					},
+					APIServiceDefinitions: operatorsv1alpha1.APIServiceDefinitions{
+						Owned: owned,
+					},
 				},
-			},
-		}
-
-		// Create Role/Cluster Roles and RoleBindings
-		role := rbacv1.Role{
-			Rules: []rbacv1.PolicyRule{
-				{
-					Verbs:     []string{"create"},
-					APIGroups: []string{""},
-					Resources: []string{"deployment"},
-				},
-			},
-		}
-		role.SetName(genName("dep-"))
-		role.SetNamespace(testNamespace)
-		_, err = c.CreateRole(&role)
-		Expect(err).ShouldNot(HaveOccurred(), "could not create Role")
-
-		roleBinding := rbacv1.RoleBinding{
-			Subjects: []rbacv1.Subject{
-				{
-					Kind:      "ServiceAccount",
-					APIGroup:  "",
-					Name:      sa.GetName(),
-					Namespace: sa.GetNamespace(),
-				},
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: "rbac.authorization.k8s.io",
-				Kind:     "Role",
-				Name:     role.GetName(),
-			},
-		}
-		roleBinding.SetName(genName("dep-"))
-		roleBinding.SetNamespace(testNamespace)
-		_, err = c.CreateRoleBinding(&roleBinding)
-		Expect(err).ShouldNot(HaveOccurred(), "could not create RoleBinding")
-
-		clusterRole := rbacv1.ClusterRole{
-			Rules: []rbacv1.PolicyRule{
-				{
-					Verbs:     []string{"get"},
-					APIGroups: []string{""},
-					Resources: []string{"deployment"},
-				},
-			},
-		}
-		clusterRole.SetName(genName("dep-"))
-		_, err = c.CreateClusterRole(&clusterRole)
-		Expect(err).ShouldNot(HaveOccurred(), "could not create ClusterRole")
-
-		clusterRoleBinding := rbacv1.ClusterRoleBinding{
-			Subjects: []rbacv1.Subject{
-				{
-					Kind:      "ServiceAccount",
-					APIGroup:  "",
-					Name:      sa.GetName(),
-					Namespace: sa.GetNamespace(),
-				},
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: "rbac.authorization.k8s.io",
-				Kind:     "ClusterRole",
-				Name:     clusterRole.GetName(),
-			},
-		}
-		clusterRoleBinding.SetName(genName("dep-"))
-		_, err = c.CreateClusterRoleBinding(&clusterRoleBinding)
-		Expect(err).ShouldNot(HaveOccurred(), "could not create ClusterRoleBinding")
-
-		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCSV()
-
-		fetchedCSV, err := fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Fetch cluster service version again to check for unnecessary control loops
-		sameCSV, err := fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
-	})
-	It("create with owned API service", func() {
-
-		depName := genName("hat-server")
-		mockGroup := fmt.Sprintf("hats.%s.redhat.com", genName(""))
-		version := "v1alpha1"
-		mockGroupVersion := strings.Join([]string{mockGroup, version}, "/")
-		mockKinds := []string{"fez", "fedora"}
-		depSpec := newMockExtServerDeployment(depName, []mockGroupVersionKind{{depName, mockGroupVersion, mockKinds, 5443}})
-		apiServiceName := strings.Join([]string{version, mockGroup}, ".")
-
-		// Create CSV for the package-server
-		strategy := operatorsv1alpha1.StrategyDetailsDeployment{
-			DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
-				{
-					Name: depName,
-					Spec: depSpec,
-				},
-			},
-		}
-
-		owned := make([]operatorsv1alpha1.APIServiceDescription, len(mockKinds))
-		for i, kind := range mockKinds {
-			owned[i] = operatorsv1alpha1.APIServiceDescription{
-				Name:           apiServiceName,
-				Group:          mockGroup,
-				Version:        version,
-				Kind:           kind,
-				DeploymentName: depName,
-				ContainerPort:  int32(5443),
-				DisplayName:    kind,
-				Description:    fmt.Sprintf("A %s", kind),
 			}
-		}
+			csv.SetName(depName)
 
-		csv := operatorsv1alpha1.ClusterServiceVersion{
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				MinKubeVersion: "0.0.0",
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
-					},
-				},
-				InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
-					StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
-					StrategySpec: strategy,
-				},
-				APIServiceDefinitions: operatorsv1alpha1.APIServiceDefinitions{
-					Owned: owned,
-				},
-			},
-		}
-		csv.SetName(depName)
+			// Create the APIService CSV
+			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer func() {
+				watcher, err := c.ApiregistrationV1Interface().ApiregistrationV1().APIServices().Watch(context.TODO(), metav1.ListOptions{FieldSelector: "metadata.name=" + apiServiceName})
+				Expect(err).ShouldNot(HaveOccurred())
 
-		// Create the APIService CSV
-		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer func() {
+				deleted := make(chan struct{})
+				go func() {
+					defer GinkgoRecover()
+					events := watcher.ResultChan()
+					for {
+						select {
+						case evt := <-events:
+							if evt.Type == watch.Deleted {
+								deleted <- struct{}{}
+								return
+							}
+						case <-time.After(pollDuration):
+							Fail("API service not cleaned up after CSV deleted")
+						}
+					}
+				}()
+
+				cleanupCSV()
+				<-deleted
+			}()
+
+			fetchedCSV, err := fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Should create Deployment
+			dep, err := c.GetDeployment(ns.GetName(), depName)
+			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Deployment")
+
+			// Should create APIService
+			apiService, err := c.GetAPIService(apiServiceName)
+			Expect(err).ShouldNot(HaveOccurred(), "error getting expected APIService")
+
+			// Should create Service
+			serviceName := fmt.Sprintf("%s-service", depName)
+			_, err = c.GetService(ns.GetName(), serviceName)
+			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Service")
+
+			// Should create certificate Secret
+			secretName := fmt.Sprintf("%s-cert", serviceName)
+			_, err = c.GetSecret(ns.GetName(), secretName)
+			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret")
+
+			// Should create a Role for the Secret
+			_, err = c.GetRole(ns.GetName(), secretName)
+			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret Role")
+
+			// Should create a RoleBinding for the Secret
+			_, err = c.GetRoleBinding(ns.GetName(), secretName)
+			Expect(err).ShouldNot(HaveOccurred(), "error getting exptected Secret RoleBinding")
+
+			// Should create a system:auth-delegator Cluster RoleBinding
+			_, err = c.GetClusterRoleBinding(fmt.Sprintf("%s-system:auth-delegator", serviceName))
+			Expect(err).ShouldNot(HaveOccurred(), "error getting expected system:auth-delegator ClusterRoleBinding")
+
+			// Should create an extension-apiserver-authentication-reader RoleBinding in kube-system
+			_, err = c.GetRoleBinding("kube-system", fmt.Sprintf("%s-auth-reader", serviceName))
+			Expect(err).ShouldNot(HaveOccurred(), "error getting expected extension-apiserver-authentication-reader RoleBinding")
+
+			// Store the ca sha annotation
+			oldCAAnnotation, ok := dep.Spec.Template.GetAnnotations()[install.OLMCAHashAnnotationKey]
+			Expect(ok).Should(BeTrue(), "expected olm sha annotation not present on existing pod template")
+
+			// Induce a cert rotation
+			Eventually(Apply(fetchedCSV, func(csv *operatorsv1alpha1.ClusterServiceVersion) error {
+				now := metav1.Now()
+				csv.Status.CertsLastUpdated = &now
+				csv.Status.CertsRotateAt = &now
+				return nil
+			})).Should(Succeed())
+
+			_, err = fetchCSV(crc, csv.Name, ns.GetName(), func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
+				// Should create deployment
+				dep, err = c.GetDeployment(ns.GetName(), depName)
+				if err != nil {
+					return false
+				}
+
+				// Should have a new ca hash annotation
+				newCAAnnotation, ok := dep.Spec.Template.GetAnnotations()[install.OLMCAHashAnnotationKey]
+				if !ok {
+					ctx.Ctx().Logf("expected olm sha annotation not present in new pod template")
+					return false
+				}
+
+				if newCAAnnotation != oldCAAnnotation {
+					// Check for success
+					return csvSucceededChecker(csv)
+				}
+
+				return false
+			})
+			Expect(err).ShouldNot(HaveOccurred(), "failed to rotate cert")
+
+			// Get the APIService UID
+			oldAPIServiceUID := apiService.GetUID()
+
+			// Delete the APIService
+			err = c.DeleteAPIService(apiServiceName, &metav1.DeleteOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Wait for CSV success
+			fetchedCSV, err = fetchCSV(crc, csv.GetName(), ns.GetName(), func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
+				// Should create an APIService
+				apiService, err := c.GetAPIService(apiServiceName)
+				if err != nil {
+					return false
+				}
+
+				if csvSucceededChecker(csv) {
+					return apiService.GetUID() != oldAPIServiceUID
+				}
+				return false
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("update with owned API service", func() {
+
+			depName := genName("hat-server")
+			mockGroup := fmt.Sprintf("hats.%s.redhat.com", genName(""))
+			version := "v1alpha1"
+			mockGroupVersion := strings.Join([]string{mockGroup, version}, "/")
+			mockKinds := []string{"fedora"}
+			depSpec := newMockExtServerDeployment(depName, []mockGroupVersionKind{{depName, mockGroupVersion, mockKinds, 5443}})
+			apiServiceName := strings.Join([]string{version, mockGroup}, ".")
+
+			// Create CSVs for the hat-server
+			strategy := operatorsv1alpha1.StrategyDetailsDeployment{
+				DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
+					{
+						Name: depName,
+						Spec: depSpec,
+					},
+				},
+			}
+
+			owned := make([]operatorsv1alpha1.APIServiceDescription, len(mockKinds))
+			for i, kind := range mockKinds {
+				owned[i] = operatorsv1alpha1.APIServiceDescription{
+					Name:           apiServiceName,
+					Group:          mockGroup,
+					Version:        version,
+					Kind:           kind,
+					DeploymentName: depName,
+					ContainerPort:  int32(5443),
+					DisplayName:    kind,
+					Description:    fmt.Sprintf("A %s", kind),
+				}
+			}
+
+			csv := operatorsv1alpha1.ClusterServiceVersion{
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					MinKubeVersion: "0.0.0",
+					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
+					},
+					InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+						StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
+						StrategySpec: strategy,
+					},
+					APIServiceDefinitions: operatorsv1alpha1.APIServiceDefinitions{
+						Owned: owned,
+					},
+				},
+			}
+			csv.SetName("csv-hat-1")
+
+			// Create the APIService CSV
+			_, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Should create Deployment
+			_, err = c.GetDeployment(ns.GetName(), depName)
+			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Deployment")
+
+			// Should create APIService
+			_, err = c.GetAPIService(apiServiceName)
+			Expect(err).ShouldNot(HaveOccurred(), "error getting expected APIService")
+
+			// Should create Service
+			serviceName := fmt.Sprintf("%s-service", depName)
+			_, err = c.GetService(ns.GetName(), serviceName)
+			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Service")
+
+			// Should create certificate Secret
+			secretName := fmt.Sprintf("%s-cert", serviceName)
+			_, err = c.GetSecret(ns.GetName(), secretName)
+			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret")
+
+			// Should create a Role for the Secret
+			_, err = c.GetRole(ns.GetName(), secretName)
+			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret Role")
+
+			// Should create a RoleBinding for the Secret
+			_, err = c.GetRoleBinding(ns.GetName(), secretName)
+			Expect(err).ShouldNot(HaveOccurred(), "error getting exptected Secret RoleBinding")
+
+			// Should create a system:auth-delegator Cluster RoleBinding
+			_, err = c.GetClusterRoleBinding(fmt.Sprintf("%s-system:auth-delegator", serviceName))
+			Expect(err).ShouldNot(HaveOccurred(), "error getting expected system:auth-delegator ClusterRoleBinding")
+
+			// Should create an extension-apiserver-authentication-reader RoleBinding in kube-system
+			_, err = c.GetRoleBinding("kube-system", fmt.Sprintf("%s-auth-reader", serviceName))
+			Expect(err).ShouldNot(HaveOccurred(), "error getting expected extension-apiserver-authentication-reader RoleBinding")
+
+			// Create a new CSV that owns the same API Service and replace the old CSV
+			csv2 := operatorsv1alpha1.ClusterServiceVersion{
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					Replaces:       csv.Name,
+					MinKubeVersion: "0.0.0",
+					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
+					},
+					InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+						StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
+						StrategySpec: strategy,
+					},
+					APIServiceDefinitions: operatorsv1alpha1.APIServiceDefinitions{
+						Owned: owned,
+					},
+				},
+			}
+			csv2.SetName("csv-hat-2")
+
+			// Create CSV2 to replace CSV
+			cleanupCSV2, err := createCSV(c, crc, csv2, ns.GetName(), false, true)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCSV2()
+
+			_, err = fetchCSV(crc, csv2.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Should create Deployment
+			_, err = c.GetDeployment(ns.GetName(), depName)
+			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Deployment")
+
+			// Should create APIService
+			_, err = c.GetAPIService(apiServiceName)
+			Expect(err).ShouldNot(HaveOccurred(), "error getting expected APIService")
+
+			// Should create Service
+			Eventually(func() error {
+				_, err := c.GetService(ns.GetName(), serviceName)
+				return err
+			}, timeout, interval).ShouldNot(HaveOccurred())
+
+			// Should create certificate Secret
+			secretName = fmt.Sprintf("%s-cert", serviceName)
+			Eventually(func() error {
+				_, err = c.GetSecret(ns.GetName(), secretName)
+				return err
+			}, timeout, interval).ShouldNot(HaveOccurred())
+
+			// Should create a Role for the Secret
+			_, err = c.GetRole(ns.GetName(), secretName)
+			Eventually(func() error {
+				_, err = c.GetRole(ns.GetName(), secretName)
+				return err
+			}, timeout, interval).ShouldNot(HaveOccurred())
+
+			// Should create a RoleBinding for the Secret
+			Eventually(func() error {
+				_, err = c.GetRoleBinding(ns.GetName(), secretName)
+				return err
+			}, timeout, interval).ShouldNot(HaveOccurred())
+
+			// Should create a system:auth-delegator Cluster RoleBinding
+			Eventually(func() error {
+				_, err = c.GetClusterRoleBinding(fmt.Sprintf("%s-system:auth-delegator", serviceName))
+				return err
+			}, timeout, interval).ShouldNot(HaveOccurred())
+
+			// Should create an extension-apiserver-authentication-reader RoleBinding in kube-system
+			Eventually(func() error {
+				_, err = c.GetRoleBinding("kube-system", fmt.Sprintf("%s-auth-reader", serviceName))
+				return err
+			}, timeout, interval).ShouldNot(HaveOccurred())
+			Expect(err).ShouldNot(HaveOccurred(), "error getting expected extension-apiserver-authentication-reader RoleBinding")
+
+			// Should eventually GC the CSV
+			Eventually(func() bool {
+				return csvExists(ns.GetName(), crc, csv.Name)
+			}).Should(BeFalse())
+
+			// Rename the initial CSV
+			csv.SetName("csv-hat-3")
+
+			// Recreate the old CSV
+			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, true)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCSV()
+
+			fetched, err := fetchCSV(crc, csv.Name, ns.GetName(), buildCSVReasonChecker(operatorsv1alpha1.CSVReasonOwnerConflict))
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(fetched.Status.Phase).Should(Equal(operatorsv1alpha1.CSVPhaseFailed))
+		})
+		It("create same CSV with owned API service multi namespace", func() {
+
+			// Create new namespace in a new operator group
+			secondNamespaceName := genName(ns.GetName() + "-")
+			matchingLabel := map[string]string{"inGroup": secondNamespaceName}
+
+			_, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   secondNamespaceName,
+					Labels: matchingLabel,
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+			defer func() {
+				err = c.KubernetesInterface().CoreV1().Namespaces().Delete(context.TODO(), secondNamespaceName, metav1.DeleteOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
+			}()
+
+			// Create a new operator group for the new namespace
+			operatorGroup := operatorsv1.OperatorGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      genName("e2e-operator-group-"),
+					Namespace: secondNamespaceName,
+				},
+				Spec: operatorsv1.OperatorGroupSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: matchingLabel,
+					},
+				},
+			}
+			_, err = crc.OperatorsV1().OperatorGroups(secondNamespaceName).Create(context.TODO(), &operatorGroup, metav1.CreateOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+			defer func() {
+				err = crc.OperatorsV1().OperatorGroups(secondNamespaceName).Delete(context.TODO(), operatorGroup.Name, metav1.DeleteOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
+			}()
+
+			ctx.Ctx().Logf("Waiting on new operator group to have correct status")
+			Eventually(func() ([]string, error) {
+				og, err := crc.OperatorsV1().OperatorGroups(secondNamespaceName).Get(context.TODO(), operatorGroup.Name, metav1.GetOptions{})
+				if err != nil {
+					return nil, err
+				}
+				return og.Status.Namespaces, nil
+			}).Should(ConsistOf([]string{secondNamespaceName}))
+
+			depName := genName("hat-server")
+			mockGroup := fmt.Sprintf("hats.%s.redhat.com", genName(""))
+			version := "v1alpha1"
+			mockGroupVersion := strings.Join([]string{mockGroup, version}, "/")
+			mockKinds := []string{"fedora"}
+			depSpec := newMockExtServerDeployment(depName, []mockGroupVersionKind{{depName, mockGroupVersion, mockKinds, 5443}})
+			apiServiceName := strings.Join([]string{version, mockGroup}, ".")
+
+			// Create CSVs for the hat-server
+			strategy := operatorsv1alpha1.StrategyDetailsDeployment{
+				DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
+					{
+						Name: depName,
+						Spec: depSpec,
+					},
+				},
+			}
+
+			owned := make([]operatorsv1alpha1.APIServiceDescription, len(mockKinds))
+			for i, kind := range mockKinds {
+				owned[i] = operatorsv1alpha1.APIServiceDescription{
+					Name:           apiServiceName,
+					Group:          mockGroup,
+					Version:        version,
+					Kind:           kind,
+					DeploymentName: depName,
+					ContainerPort:  int32(5443),
+					DisplayName:    kind,
+					Description:    fmt.Sprintf("A %s", kind),
+				}
+			}
+
+			csv := operatorsv1alpha1.ClusterServiceVersion{
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					MinKubeVersion: "0.0.0",
+					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
+					},
+					InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+						StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
+						StrategySpec: strategy,
+					},
+					APIServiceDefinitions: operatorsv1alpha1.APIServiceDefinitions{
+						Owned: owned,
+					},
+				},
+			}
+			csv.SetName("csv-hat-1")
+
+			// Create the initial CSV
+			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCSV()
+
+			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Should create Deployment
+			_, err = c.GetDeployment(ns.GetName(), depName)
+			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Deployment")
+
+			// Should create APIService
+			_, err = c.GetAPIService(apiServiceName)
+			Expect(err).ShouldNot(HaveOccurred(), "error getting expected APIService")
+
+			// Should create Service
+			serviceName := fmt.Sprintf("%s-service", depName)
+			_, err = c.GetService(ns.GetName(), serviceName)
+			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Service")
+
+			// Should create certificate Secret
+			secretName := fmt.Sprintf("%s-cert", serviceName)
+			_, err = c.GetSecret(ns.GetName(), secretName)
+			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret")
+
+			// Should create a Role for the Secret
+			_, err = c.GetRole(ns.GetName(), secretName)
+			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret Role")
+
+			// Should create a RoleBinding for the Secret
+			_, err = c.GetRoleBinding(ns.GetName(), secretName)
+			Expect(err).ShouldNot(HaveOccurred(), "error getting exptected Secret RoleBinding")
+
+			// Should create a system:auth-delegator Cluster RoleBinding
+			_, err = c.GetClusterRoleBinding(fmt.Sprintf("%s-system:auth-delegator", serviceName))
+			Expect(err).ShouldNot(HaveOccurred(), "error getting expected system:auth-delegator ClusterRoleBinding")
+
+			// Should create an extension-apiserver-authentication-reader RoleBinding in kube-system
+			_, err = c.GetRoleBinding("kube-system", fmt.Sprintf("%s-auth-reader", serviceName))
+			Expect(err).ShouldNot(HaveOccurred(), "error getting expected extension-apiserver-authentication-reader RoleBinding")
+
+			// Create a new CSV that owns the same API Service but in a different namespace
+			csv2 := operatorsv1alpha1.ClusterServiceVersion{
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					MinKubeVersion: "0.0.0",
+					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
+					},
+					InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+						StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
+						StrategySpec: strategy,
+					},
+					APIServiceDefinitions: operatorsv1alpha1.APIServiceDefinitions{
+						Owned: owned,
+					},
+				},
+			}
+			csv2.SetName("csv-hat-2")
+
+			// Create CSV2 to replace CSV
+			_, err = createCSV(c, crc, csv2, secondNamespaceName, false, true)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			_, err = fetchCSV(crc, csv2.Name, secondNamespaceName, csvFailedChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("orphaned API service clean up", func() {
+
+			mockGroup := fmt.Sprintf("hats.%s.redhat.com", genName(""))
+			version := "v1alpha1"
+			apiServiceName := strings.Join([]string{version, mockGroup}, ".")
+
+			apiService := &apiregistrationv1.APIService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: apiServiceName,
+				},
+				Spec: apiregistrationv1.APIServiceSpec{
+					Group:                mockGroup,
+					Version:              version,
+					GroupPriorityMinimum: 100,
+					VersionPriority:      100,
+				},
+			}
+
 			watcher, err := c.ApiregistrationV1Interface().ApiregistrationV1().APIServices().Watch(context.TODO(), metav1.ListOptions{FieldSelector: "metadata.name=" + apiServiceName})
 			Expect(err).ShouldNot(HaveOccurred())
 
 			deleted := make(chan struct{})
+			quit := make(chan struct{})
+			defer close(quit)
 			go func() {
 				defer GinkgoRecover()
 				events := watcher.ResultChan()
 				for {
 					select {
+					case <-quit:
+						return
 					case evt := <-events:
 						if evt.Type == watch.Deleted {
 							deleted <- struct{}{}
-							return
 						}
 					case <-time.After(pollDuration):
-						Fail("API service not cleaned up after CSV deleted")
+						Fail("orphaned apiservice not cleaned up as expected")
 					}
 				}
 			}()
 
-			cleanupCSV()
+			_, err = c.CreateAPIService(apiService)
+			Expect(err).ShouldNot(HaveOccurred(), "error creating expected APIService")
+			orphanedAPISvc, err := c.GetAPIService(apiServiceName)
+			Expect(err).ShouldNot(HaveOccurred(), "error getting expected APIService")
+
+			newLabels := map[string]string{"olm.owner": "hat-serverfd4r5", "olm.owner.kind": "ClusterServiceVersion", "olm.owner.namespace": "nonexistent-namespace"}
+			orphanedAPISvc.SetLabels(newLabels)
+			_, err = c.UpdateAPIService(orphanedAPISvc)
+			Expect(err).ShouldNot(HaveOccurred(), "error updating APIService")
 			<-deleted
-		}()
 
-		fetchedCSV, err := fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
+			_, err = c.CreateAPIService(apiService)
+			Expect(err).ShouldNot(HaveOccurred(), "error creating expected APIService")
+			orphanedAPISvc, err = c.GetAPIService(apiServiceName)
+			Expect(err).ShouldNot(HaveOccurred(), "error getting expected APIService")
 
-		// Should create Deployment
-		dep, err := c.GetDeployment(testNamespace, depName)
-		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Deployment")
-
-		// Should create APIService
-		apiService, err := c.GetAPIService(apiServiceName)
-		Expect(err).ShouldNot(HaveOccurred(), "error getting expected APIService")
-
-		// Should create Service
-		serviceName := fmt.Sprintf("%s-service", depName)
-		_, err = c.GetService(testNamespace, serviceName)
-		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Service")
-
-		// Should create certificate Secret
-		secretName := fmt.Sprintf("%s-cert", serviceName)
-		_, err = c.GetSecret(testNamespace, secretName)
-		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret")
-
-		// Should create a Role for the Secret
-		_, err = c.GetRole(testNamespace, secretName)
-		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret Role")
-
-		// Should create a RoleBinding for the Secret
-		_, err = c.GetRoleBinding(testNamespace, secretName)
-		Expect(err).ShouldNot(HaveOccurred(), "error getting exptected Secret RoleBinding")
-
-		// Should create a system:auth-delegator Cluster RoleBinding
-		_, err = c.GetClusterRoleBinding(fmt.Sprintf("%s-system:auth-delegator", serviceName))
-		Expect(err).ShouldNot(HaveOccurred(), "error getting expected system:auth-delegator ClusterRoleBinding")
-
-		// Should create an extension-apiserver-authentication-reader RoleBinding in kube-system
-		_, err = c.GetRoleBinding("kube-system", fmt.Sprintf("%s-auth-reader", serviceName))
-		Expect(err).ShouldNot(HaveOccurred(), "error getting expected extension-apiserver-authentication-reader RoleBinding")
-
-		// Store the ca sha annotation
-		oldCAAnnotation, ok := dep.Spec.Template.GetAnnotations()[install.OLMCAHashAnnotationKey]
-		Expect(ok).Should(BeTrue(), "expected olm sha annotation not present on existing pod template")
-
-		// Induce a cert rotation
-		Eventually(Apply(fetchedCSV, func(csv *operatorsv1alpha1.ClusterServiceVersion) error {
-			now := metav1.Now()
-			csv.Status.CertsLastUpdated = &now
-			csv.Status.CertsRotateAt = &now
-			return nil
-		})).Should(Succeed())
-
-		_, err = fetchCSV(crc, csv.Name, testNamespace, func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
-			// Should create deployment
-			dep, err = c.GetDeployment(testNamespace, depName)
-			if err != nil {
-				return false
-			}
-
-			// Should have a new ca hash annotation
-			newCAAnnotation, ok := dep.Spec.Template.GetAnnotations()[install.OLMCAHashAnnotationKey]
-			if !ok {
-				ctx.Ctx().Logf("expected olm sha annotation not present in new pod template")
-				return false
-			}
-
-			if newCAAnnotation != oldCAAnnotation {
-				// Check for success
-				return csvSucceededChecker(csv)
-			}
-
-			return false
+			newLabels = map[string]string{"olm.owner": "hat-serverfd4r5", "olm.owner.kind": "ClusterServiceVersion", "olm.owner.namespace": ns.GetName()}
+			orphanedAPISvc.SetLabels(newLabels)
+			_, err = c.UpdateAPIService(orphanedAPISvc)
+			Expect(err).ShouldNot(HaveOccurred(), "error updating APIService")
+			<-deleted
 		})
-		Expect(err).ShouldNot(HaveOccurred(), "failed to rotate cert")
-
-		// Get the APIService UID
-		oldAPIServiceUID := apiService.GetUID()
-
-		// Delete the APIService
-		err = c.DeleteAPIService(apiServiceName, &metav1.DeleteOptions{})
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Wait for CSV success
-		fetchedCSV, err = fetchCSV(crc, csv.GetName(), testNamespace, func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
-			// Should create an APIService
-			apiService, err := c.GetAPIService(apiServiceName)
-			if err != nil {
-				return false
+		It("CSV annotations overwrite pod template annotations defined in a StrategyDetailsDeployment", func() {
+			// Create a StrategyDetailsDeployment that defines the `foo1` and `foo2` annotations on a pod template
+			nginxName := genName("nginx-")
+			strategy := operatorsv1alpha1.StrategyDetailsDeployment{
+				DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
+					{
+						Name: genName("dep-"),
+						Spec: newNginxDeployment(nginxName),
+					},
+				},
+			}
+			strategy.DeploymentSpecs[0].Spec.Template.Annotations = map[string]string{
+				"foo1": "notBar1",
+				"foo2": "bar2",
 			}
 
-			if csvSucceededChecker(csv) {
-				return apiService.GetUID() != oldAPIServiceUID
+			// Create a CSV that defines the `foo1` and `foo3` annotations
+			csv := operatorsv1alpha1.ClusterServiceVersion{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+					APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: genName("csv"),
+					Annotations: map[string]string{
+						"foo1": "bar1",
+						"foo3": "bar3",
+					},
+				},
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					MinKubeVersion: "0.0.0",
+					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
+					},
+					InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+						StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
+						StrategySpec: strategy,
+					},
+				},
 			}
-			return false
-		})
-		Expect(err).ShouldNot(HaveOccurred())
-	})
-	It("update with owned API service", func() {
 
-		depName := genName("hat-server")
-		mockGroup := fmt.Sprintf("hats.%s.redhat.com", genName(""))
-		version := "v1alpha1"
-		mockGroupVersion := strings.Join([]string{mockGroup, version}, "/")
-		mockKinds := []string{"fedora"}
-		depSpec := newMockExtServerDeployment(depName, []mockGroupVersionKind{{depName, mockGroupVersion, mockKinds, 5443}})
-		apiServiceName := strings.Join([]string{version, mockGroup}, ".")
-
-		// Create CSVs for the hat-server
-		strategy := operatorsv1alpha1.StrategyDetailsDeployment{
-			DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
-				{
-					Name: depName,
-					Spec: depSpec,
-				},
-			},
-		}
-
-		owned := make([]operatorsv1alpha1.APIServiceDescription, len(mockKinds))
-		for i, kind := range mockKinds {
-			owned[i] = operatorsv1alpha1.APIServiceDescription{
-				Name:           apiServiceName,
-				Group:          mockGroup,
-				Version:        version,
-				Kind:           kind,
-				DeploymentName: depName,
-				ContainerPort:  int32(5443),
-				DisplayName:    kind,
-				Description:    fmt.Sprintf("A %s", kind),
-			}
-		}
-
-		csv := operatorsv1alpha1.ClusterServiceVersion{
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				MinKubeVersion: "0.0.0",
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
-					},
-				},
-				InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
-					StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
-					StrategySpec: strategy,
-				},
-				APIServiceDefinitions: operatorsv1alpha1.APIServiceDefinitions{
-					Owned: owned,
-				},
-			},
-		}
-		csv.SetName("csv-hat-1")
-
-		// Create the APIService CSV
-		_, err := createCSV(c, crc, csv, testNamespace, false, false)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Should create Deployment
-		_, err = c.GetDeployment(testNamespace, depName)
-		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Deployment")
-
-		// Should create APIService
-		_, err = c.GetAPIService(apiServiceName)
-		Expect(err).ShouldNot(HaveOccurred(), "error getting expected APIService")
-
-		// Should create Service
-		serviceName := fmt.Sprintf("%s-service", depName)
-		_, err = c.GetService(testNamespace, serviceName)
-		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Service")
-
-		// Should create certificate Secret
-		secretName := fmt.Sprintf("%s-cert", serviceName)
-		_, err = c.GetSecret(testNamespace, secretName)
-		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret")
-
-		// Should create a Role for the Secret
-		_, err = c.GetRole(testNamespace, secretName)
-		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret Role")
-
-		// Should create a RoleBinding for the Secret
-		_, err = c.GetRoleBinding(testNamespace, secretName)
-		Expect(err).ShouldNot(HaveOccurred(), "error getting exptected Secret RoleBinding")
-
-		// Should create a system:auth-delegator Cluster RoleBinding
-		_, err = c.GetClusterRoleBinding(fmt.Sprintf("%s-system:auth-delegator", serviceName))
-		Expect(err).ShouldNot(HaveOccurred(), "error getting expected system:auth-delegator ClusterRoleBinding")
-
-		// Should create an extension-apiserver-authentication-reader RoleBinding in kube-system
-		_, err = c.GetRoleBinding("kube-system", fmt.Sprintf("%s-auth-reader", serviceName))
-		Expect(err).ShouldNot(HaveOccurred(), "error getting expected extension-apiserver-authentication-reader RoleBinding")
-
-		// Create a new CSV that owns the same API Service and replace the old CSV
-		csv2 := operatorsv1alpha1.ClusterServiceVersion{
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				Replaces:       csv.Name,
-				MinKubeVersion: "0.0.0",
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
-					},
-				},
-				InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
-					StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
-					StrategySpec: strategy,
-				},
-				APIServiceDefinitions: operatorsv1alpha1.APIServiceDefinitions{
-					Owned: owned,
-				},
-			},
-		}
-		csv2.SetName("csv-hat-2")
-
-		// Create CSV2 to replace CSV
-		cleanupCSV2, err := createCSV(c, crc, csv2, testNamespace, false, true)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCSV2()
-
-		_, err = fetchCSV(crc, csv2.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Should create Deployment
-		_, err = c.GetDeployment(testNamespace, depName)
-		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Deployment")
-
-		// Should create APIService
-		_, err = c.GetAPIService(apiServiceName)
-		Expect(err).ShouldNot(HaveOccurred(), "error getting expected APIService")
-
-		// Should create Service
-		Eventually(func() error {
-			_, err := c.GetService(testNamespace, serviceName)
-			return err
-		}, timeout, interval).ShouldNot(HaveOccurred())
-
-		// Should create certificate Secret
-		secretName = fmt.Sprintf("%s-cert", serviceName)
-		Eventually(func() error {
-			_, err = c.GetSecret(testNamespace, secretName)
-			return err
-		}, timeout, interval).ShouldNot(HaveOccurred())
-
-		// Should create a Role for the Secret
-		_, err = c.GetRole(testNamespace, secretName)
-		Eventually(func() error {
-			_, err = c.GetRole(testNamespace, secretName)
-			return err
-		}, timeout, interval).ShouldNot(HaveOccurred())
-
-		// Should create a RoleBinding for the Secret
-		Eventually(func() error {
-			_, err = c.GetRoleBinding(testNamespace, secretName)
-			return err
-		}, timeout, interval).ShouldNot(HaveOccurred())
-
-		// Should create a system:auth-delegator Cluster RoleBinding
-		Eventually(func() error {
-			_, err = c.GetClusterRoleBinding(fmt.Sprintf("%s-system:auth-delegator", serviceName))
-			return err
-		}, timeout, interval).ShouldNot(HaveOccurred())
-
-		// Should create an extension-apiserver-authentication-reader RoleBinding in kube-system
-		Eventually(func() error {
-			_, err = c.GetRoleBinding("kube-system", fmt.Sprintf("%s-auth-reader", serviceName))
-			return err
-		}, timeout, interval).ShouldNot(HaveOccurred())
-		Expect(err).ShouldNot(HaveOccurred(), "error getting expected extension-apiserver-authentication-reader RoleBinding")
-
-		// Should eventually GC the CSV
-		Eventually(func() bool {
-			return csvExists(crc, csv.Name)
-		}).Should(BeFalse())
-
-		// Rename the initial CSV
-		csv.SetName("csv-hat-3")
-
-		// Recreate the old CSV
-		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, true)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCSV()
-
-		fetched, err := fetchCSV(crc, csv.Name, testNamespace, buildCSVReasonChecker(operatorsv1alpha1.CSVReasonOwnerConflict))
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(fetched.Status.Phase).Should(Equal(operatorsv1alpha1.CSVPhaseFailed))
-	})
-	It("create same CSV with owned API service multi namespace", func() {
-
-		// Create new namespace in a new operator group
-		secondNamespaceName := genName(testNamespace + "-")
-		matchingLabel := map[string]string{"inGroup": secondNamespaceName}
-
-		_, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   secondNamespaceName,
-				Labels: matchingLabel,
-			},
-		}, metav1.CreateOptions{})
-		Expect(err).ShouldNot(HaveOccurred())
-		defer func() {
-			err = c.KubernetesInterface().CoreV1().Namespaces().Delete(context.TODO(), secondNamespaceName, metav1.DeleteOptions{})
+			// Create the CSV and make sure to clean it up
+			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
-		}()
+			defer cleanupCSV()
 
-		// Create a new operator group for the new namespace
-		operatorGroup := operatorsv1.OperatorGroup{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      genName("e2e-operator-group-"),
-				Namespace: secondNamespaceName,
-			},
-			Spec: operatorsv1.OperatorGroupSpec{
-				Selector: &metav1.LabelSelector{
-					MatchLabels: matchingLabel,
-				},
-			},
-		}
-		_, err = crc.OperatorsV1().OperatorGroups(secondNamespaceName).Create(context.TODO(), &operatorGroup, metav1.CreateOptions{})
-		Expect(err).ShouldNot(HaveOccurred())
-		defer func() {
-			err = crc.OperatorsV1().OperatorGroups(secondNamespaceName).Delete(context.TODO(), operatorGroup.Name, metav1.DeleteOptions{})
+			// Wait for current CSV to succeed
+			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
-		}()
 
-		ctx.Ctx().Logf("Waiting on new operator group to have correct status")
-		Eventually(func() ([]string, error) {
-			og, err := crc.OperatorsV1().OperatorGroups(secondNamespaceName).Get(context.TODO(), operatorGroup.Name, metav1.GetOptions{})
-			if err != nil {
-				return nil, err
+			// Should have created deployment
+			dep, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[0].Name)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(dep).ShouldNot(BeNil())
+
+			// Make sure that the pods annotations are correct
+			annotations := dep.Spec.Template.Annotations
+			Expect(annotations["foo1"]).Should(Equal("bar1"))
+			Expect(annotations["foo2"]).Should(Equal("bar2"))
+			Expect(annotations["foo3"]).Should(Equal("bar3"))
+		})
+		It("Set labels for the Deployment created via the ClusterServiceVersion", func() {
+			// Create a StrategyDetailsDeployment that defines labels for Deployment inside
+			nginxName := genName("nginx-")
+			strategy := operatorsv1alpha1.StrategyDetailsDeployment{
+				DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
+					{
+						Name: genName("dep-"),
+						Spec: newNginxDeployment(nginxName),
+						Label: k8slabels.Set{
+							"application":      "nginx",
+							"application.type": "proxy",
+						},
+					},
+				},
 			}
-			return og.Status.Namespaces, nil
-		}).Should(ConsistOf([]string{secondNamespaceName}))
 
-		depName := genName("hat-server")
-		mockGroup := fmt.Sprintf("hats.%s.redhat.com", genName(""))
-		version := "v1alpha1"
-		mockGroupVersion := strings.Join([]string{mockGroup, version}, "/")
-		mockKinds := []string{"fedora"}
-		depSpec := newMockExtServerDeployment(depName, []mockGroupVersionKind{{depName, mockGroupVersion, mockKinds, 5443}})
-		apiServiceName := strings.Join([]string{version, mockGroup}, ".")
-
-		// Create CSVs for the hat-server
-		strategy := operatorsv1alpha1.StrategyDetailsDeployment{
-			DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
-				{
-					Name: depName,
-					Spec: depSpec,
+			csv := operatorsv1alpha1.ClusterServiceVersion{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+					APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
 				},
-			},
-		}
-
-		owned := make([]operatorsv1alpha1.APIServiceDescription, len(mockKinds))
-		for i, kind := range mockKinds {
-			owned[i] = operatorsv1alpha1.APIServiceDescription{
-				Name:           apiServiceName,
-				Group:          mockGroup,
-				Version:        version,
-				Kind:           kind,
-				DeploymentName: depName,
-				ContainerPort:  int32(5443),
-				DisplayName:    kind,
-				Description:    fmt.Sprintf("A %s", kind),
+				ObjectMeta: metav1.ObjectMeta{
+					Name: genName("csv"),
+				},
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					MinKubeVersion: "0.0.0",
+					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
+					},
+					InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+						StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
+						StrategySpec: strategy,
+					},
+				},
 			}
-		}
 
-		csv := operatorsv1alpha1.ClusterServiceVersion{
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				MinKubeVersion: "0.0.0",
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
+			// Create the CSV and make sure to clean it up
+			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCSV()
+
+			// Wait for current CSV to succeed
+			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Should have created deployment
+			dep, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[0].Name)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(dep).ShouldNot(BeNil())
+
+			// Make sure that the deployment labels are correct
+			labels := dep.GetLabels()
+			Expect(labels["olm.owner"]).Should(Equal(csv.GetName()))
+			Expect(labels["olm.owner.namespace"]).Should(Equal(ns.GetName()))
+			Expect(labels["application"]).Should(Equal("nginx"))
+			Expect(labels["application.type"]).Should(Equal("proxy"))
+		})
+		It("update same deployment name", func() {
+
+			// Create dependency first (CRD)
+			crdPlural := genName("ins")
+			crdName := crdPlural + ".cluster.com"
+			cleanupCRD, err := createCRD(c, apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: crdName,
+				},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "cluster.com",
+					Versions: []apiextensions.CustomResourceDefinitionVersion{
+						{
+							Name:    "v1alpha1",
+							Served:  true,
+							Storage: true,
+							Schema: &apiextensions.CustomResourceValidation{
+								OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+									Type:        "object",
+									Description: "my crd schema",
+								},
+							},
+						},
 					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
+					Names: apiextensions.CustomResourceDefinitionNames{
+						Plural:   crdPlural,
+						Singular: crdPlural,
+						Kind:     crdPlural,
+						ListKind: "list" + crdPlural,
 					},
+					Scope: apiextensions.NamespaceScoped,
+				},
+			})
+
+			// Create "current" CSV
+			nginxName := genName("nginx-")
+			strategy := operatorsv1alpha1.StrategyDetailsDeployment{
+				DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
 					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
+						Name: genName("dep-"),
+						Spec: newNginxDeployment(nginxName),
 					},
 				},
-				InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
-					StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
-					StrategySpec: strategy,
-				},
-				APIServiceDefinitions: operatorsv1alpha1.APIServiceDefinitions{
-					Owned: owned,
-				},
-			},
-		}
-		csv.SetName("csv-hat-1")
-
-		// Create the initial CSV
-		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCSV()
-
-		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Should create Deployment
-		_, err = c.GetDeployment(testNamespace, depName)
-		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Deployment")
-
-		// Should create APIService
-		_, err = c.GetAPIService(apiServiceName)
-		Expect(err).ShouldNot(HaveOccurred(), "error getting expected APIService")
-
-		// Should create Service
-		serviceName := fmt.Sprintf("%s-service", depName)
-		_, err = c.GetService(testNamespace, serviceName)
-		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Service")
-
-		// Should create certificate Secret
-		secretName := fmt.Sprintf("%s-cert", serviceName)
-		_, err = c.GetSecret(testNamespace, secretName)
-		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret")
-
-		// Should create a Role for the Secret
-		_, err = c.GetRole(testNamespace, secretName)
-		Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret Role")
-
-		// Should create a RoleBinding for the Secret
-		_, err = c.GetRoleBinding(testNamespace, secretName)
-		Expect(err).ShouldNot(HaveOccurred(), "error getting exptected Secret RoleBinding")
-
-		// Should create a system:auth-delegator Cluster RoleBinding
-		_, err = c.GetClusterRoleBinding(fmt.Sprintf("%s-system:auth-delegator", serviceName))
-		Expect(err).ShouldNot(HaveOccurred(), "error getting expected system:auth-delegator ClusterRoleBinding")
-
-		// Should create an extension-apiserver-authentication-reader RoleBinding in kube-system
-		_, err = c.GetRoleBinding("kube-system", fmt.Sprintf("%s-auth-reader", serviceName))
-		Expect(err).ShouldNot(HaveOccurred(), "error getting expected extension-apiserver-authentication-reader RoleBinding")
-
-		// Create a new CSV that owns the same API Service but in a different namespace
-		csv2 := operatorsv1alpha1.ClusterServiceVersion{
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				MinKubeVersion: "0.0.0",
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
-					},
-				},
-				InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
-					StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
-					StrategySpec: strategy,
-				},
-				APIServiceDefinitions: operatorsv1alpha1.APIServiceDefinitions{
-					Owned: owned,
-				},
-			},
-		}
-		csv2.SetName("csv-hat-2")
-
-		// Create CSV2 to replace CSV
-		_, err = createCSV(c, crc, csv2, secondNamespaceName, false, true)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		_, err = fetchCSV(crc, csv2.Name, secondNamespaceName, csvFailedChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-	})
-	It("orphaned API service clean up", func() {
-
-		mockGroup := fmt.Sprintf("hats.%s.redhat.com", genName(""))
-		version := "v1alpha1"
-		apiServiceName := strings.Join([]string{version, mockGroup}, ".")
-
-		apiService := &apiregistrationv1.APIService{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: apiServiceName,
-			},
-			Spec: apiregistrationv1.APIServiceSpec{
-				Group:                mockGroup,
-				Version:              version,
-				GroupPriorityMinimum: 100,
-				VersionPriority:      100,
-			},
-		}
-
-		watcher, err := c.ApiregistrationV1Interface().ApiregistrationV1().APIServices().Watch(context.TODO(), metav1.ListOptions{FieldSelector: "metadata.name=" + apiServiceName})
-		Expect(err).ShouldNot(HaveOccurred())
-
-		deleted := make(chan struct{})
-		quit := make(chan struct{})
-		defer close(quit)
-		go func() {
-			defer GinkgoRecover()
-			events := watcher.ResultChan()
-			for {
-				select {
-				case <-quit:
-					return
-				case evt := <-events:
-					if evt.Type == watch.Deleted {
-						deleted <- struct{}{}
-					}
-				case <-time.After(pollDuration):
-					Fail("orphaned apiservice not cleaned up as expected")
-				}
 			}
-		}()
 
-		_, err = c.CreateAPIService(apiService)
-		Expect(err).ShouldNot(HaveOccurred(), "error creating expected APIService")
-		orphanedAPISvc, err := c.GetAPIService(apiServiceName)
-		Expect(err).ShouldNot(HaveOccurred(), "error getting expected APIService")
+			Expect(err).ShouldNot(HaveOccurred())
 
-		newLabels := map[string]string{"olm.owner": "hat-serverfd4r5", "olm.owner.kind": "ClusterServiceVersion", "olm.owner.namespace": "nonexistent-namespace"}
-		orphanedAPISvc.SetLabels(newLabels)
-		_, err = c.UpdateAPIService(orphanedAPISvc)
-		Expect(err).ShouldNot(HaveOccurred(), "error updating APIService")
-		<-deleted
-
-		_, err = c.CreateAPIService(apiService)
-		Expect(err).ShouldNot(HaveOccurred(), "error creating expected APIService")
-		orphanedAPISvc, err = c.GetAPIService(apiServiceName)
-		Expect(err).ShouldNot(HaveOccurred(), "error getting expected APIService")
-
-		newLabels = map[string]string{"olm.owner": "hat-serverfd4r5", "olm.owner.kind": "ClusterServiceVersion", "olm.owner.namespace": testNamespace}
-		orphanedAPISvc.SetLabels(newLabels)
-		_, err = c.UpdateAPIService(orphanedAPISvc)
-		Expect(err).ShouldNot(HaveOccurred(), "error updating APIService")
-		<-deleted
-	})
-	It("CSV annotations overwrite pod template annotations defined in a StrategyDetailsDeployment", func() {
-		// Create a StrategyDetailsDeployment that defines the `foo1` and `foo2` annotations on a pod template
-		nginxName := genName("nginx-")
-		strategy := operatorsv1alpha1.StrategyDetailsDeployment{
-			DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
-				{
-					Name: genName("dep-"),
-					Spec: newNginxDeployment(nginxName),
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCRD()
+			csv := operatorsv1alpha1.ClusterServiceVersion{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+					APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
 				},
-			},
-		}
-		strategy.DeploymentSpecs[0].Spec.Template.Annotations = map[string]string{
-			"foo1": "notBar1",
-			"foo2": "bar2",
-		}
-
-		// Create a CSV that defines the `foo1` and `foo3` annotations
-		csv := operatorsv1alpha1.ClusterServiceVersion{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
-				APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("csv"),
-				Annotations: map[string]string{
-					"foo1": "bar1",
-					"foo3": "bar3",
+				ObjectMeta: metav1.ObjectMeta{
+					Name: genName("csv"),
 				},
-			},
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				MinKubeVersion: "0.0.0",
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					MinKubeVersion: "0.0.0",
+					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
 					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
+					InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+						StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
+						StrategySpec: strategy,
 					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
-					},
-				},
-				InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
-					StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
-					StrategySpec: strategy,
-				},
-			},
-		}
-
-		// Create the CSV and make sure to clean it up
-		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCSV()
-
-		// Wait for current CSV to succeed
-		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Should have created deployment
-		dep, err := c.GetDeployment(testNamespace, strategy.DeploymentSpecs[0].Name)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(dep).ShouldNot(BeNil())
-
-		// Make sure that the pods annotations are correct
-		annotations := dep.Spec.Template.Annotations
-		Expect(annotations["foo1"]).Should(Equal("bar1"))
-		Expect(annotations["foo2"]).Should(Equal("bar2"))
-		Expect(annotations["foo3"]).Should(Equal("bar3"))
-	})
-	It("Set labels for the Deployment created via the ClusterServiceVersion", func() {
-		// Create a StrategyDetailsDeployment that defines labels for Deployment inside
-		nginxName := genName("nginx-")
-		strategy := operatorsv1alpha1.StrategyDetailsDeployment{
-			DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
-				{
-					Name: genName("dep-"),
-					Spec: newNginxDeployment(nginxName),
-					Label: k8slabels.Set{
-						"application":      "nginx",
-						"application.type": "proxy",
-					},
-				},
-			},
-		}
-
-		csv := operatorsv1alpha1.ClusterServiceVersion{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
-				APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("csv"),
-			},
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				MinKubeVersion: "0.0.0",
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
-					},
-				},
-				InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
-					StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
-					StrategySpec: strategy,
-				},
-			},
-		}
-
-		// Create the CSV and make sure to clean it up
-		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCSV()
-
-		// Wait for current CSV to succeed
-		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Should have created deployment
-		dep, err := c.GetDeployment(testNamespace, strategy.DeploymentSpecs[0].Name)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(dep).ShouldNot(BeNil())
-
-		// Make sure that the deployment labels are correct
-		labels := dep.GetLabels()
-		Expect(labels["olm.owner"]).Should(Equal(csv.GetName()))
-		Expect(labels["olm.owner.namespace"]).Should(Equal(testNamespace))
-		Expect(labels["application"]).Should(Equal("nginx"))
-		Expect(labels["application.type"]).Should(Equal("proxy"))
-	})
-	It("update same deployment name", func() {
-
-		// Create dependency first (CRD)
-		crdPlural := genName("ins")
-		crdName := crdPlural + ".cluster.com"
-		cleanupCRD, err := createCRD(c, apiextensions.CustomResourceDefinition{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: crdName,
-			},
-			Spec: apiextensions.CustomResourceDefinitionSpec{
-				Group: "cluster.com",
-				Versions: []apiextensions.CustomResourceDefinitionVersion{
-					{
-						Name:    "v1alpha1",
-						Served:  true,
-						Storage: true,
-						Schema: &apiextensions.CustomResourceValidation{
-							OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
-								Type:        "object",
-								Description: "my crd schema",
+					CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
+						Owned: []operatorsv1alpha1.CRDDescription{
+							{
+								Name:        crdName,
+								Version:     "v1alpha1",
+								Kind:        crdPlural,
+								DisplayName: crdName,
+								Description: "In the cluster",
 							},
 						},
 					},
 				},
-				Names: apiextensions.CustomResourceDefinitionNames{
-					Plural:   crdPlural,
-					Singular: crdPlural,
-					Kind:     crdPlural,
-					ListKind: "list" + crdPlural,
-				},
-				Scope: apiextensions.NamespaceScoped,
-			},
-		})
-
-		// Create "current" CSV
-		nginxName := genName("nginx-")
-		strategy := operatorsv1alpha1.StrategyDetailsDeployment{
-			DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
-				{
-					Name: genName("dep-"),
-					Spec: newNginxDeployment(nginxName),
-				},
-			},
-		}
-
-		Expect(err).ShouldNot(HaveOccurred())
-
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCRD()
-		csv := operatorsv1alpha1.ClusterServiceVersion{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
-				APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("csv"),
-			},
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				MinKubeVersion: "0.0.0",
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
-					},
-				},
-				InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
-					StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
-					StrategySpec: strategy,
-				},
-				CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
-					Owned: []operatorsv1alpha1.CRDDescription{
-						{
-							Name:        crdName,
-							Version:     "v1alpha1",
-							Kind:        crdPlural,
-							DisplayName: crdName,
-							Description: "In the cluster",
-						},
-					},
-				},
-			},
-		}
-
-		// Don't need to cleanup this CSV, it will be deleted by the upgrade process
-		_, err = createCSV(c, crc, csv, testNamespace, false, false)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Wait for current CSV to succeed
-		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Should have created deployment
-		dep, err := c.GetDeployment(testNamespace, strategy.DeploymentSpecs[0].Name)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(dep).ShouldNot(BeNil())
-
-		// Create "updated" CSV
-		strategyNew := operatorsv1alpha1.StrategyDetailsDeployment{
-			DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
-				{
-					// Same name
-					Name: strategy.DeploymentSpecs[0].Name,
-					// Different spec
-					Spec: newNginxDeployment(nginxName),
-				},
-			},
-		}
-
-		Expect(err).ShouldNot(HaveOccurred())
-
-		csvNew := operatorsv1alpha1.ClusterServiceVersion{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
-				APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("csv"),
-			},
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				Replaces: csv.Name,
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
-					},
-				},
-				InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
-					StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
-					StrategySpec: strategyNew,
-				},
-				CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
-					Owned: []operatorsv1alpha1.CRDDescription{
-						{
-							Name:        crdName,
-							Version:     "v1alpha1",
-							Kind:        crdPlural,
-							DisplayName: crdName,
-							Description: "In the cluster",
-						},
-					},
-				},
-			},
-		}
-
-		cleanupNewCSV, err := createCSV(c, crc, csvNew, testNamespace, true, false)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupNewCSV()
-
-		// Wait for updated CSV to succeed
-		fetchedCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Should have updated existing deployment
-		depUpdated, err := c.GetDeployment(testNamespace, strategyNew.DeploymentSpecs[0].Name)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(depUpdated).ShouldNot(BeNil())
-		Expect(strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Name).Should(Equal(depUpdated.Spec.Template.Spec.Containers[0].Name))
-
-		// Should eventually GC the CSV
-		Eventually(func() bool {
-			return csvExists(crc, csv.Name)
-		}).Should(BeFalse())
-
-		// Fetch cluster service version again to check for unnecessary control loops
-		sameCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
-	})
-	It("update different deployment name", func() {
-
-		// Create dependency first (CRD)
-		crdPlural := genName("ins2")
-		crdName := crdPlural + ".cluster.com"
-		cleanupCRD, err := createCRD(c, apiextensions.CustomResourceDefinition{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: crdName,
-			},
-			Spec: apiextensions.CustomResourceDefinitionSpec{
-				Group: "cluster.com",
-				Versions: []apiextensions.CustomResourceDefinitionVersion{
-					{
-						Name:    "v1alpha1",
-						Served:  true,
-						Storage: true,
-						Schema: &apiextensions.CustomResourceValidation{
-							OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
-								Type:        "object",
-								Description: "my crd schema",
-							},
-						},
-					},
-				},
-				Names: apiextensions.CustomResourceDefinitionNames{
-					Plural:   crdPlural,
-					Singular: crdPlural,
-					Kind:     crdPlural,
-					ListKind: "list" + crdPlural,
-				},
-				Scope: apiextensions.NamespaceScoped,
-			},
-		})
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCRD()
-
-		// create "current" CSV
-		strategy := operatorsv1alpha1.StrategyDetailsDeployment{
-			DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
-				{
-					Name: genName("dep-"),
-					Spec: newNginxDeployment(genName("nginx-")),
-				},
-			},
-		}
-
-		Expect(err).ShouldNot(HaveOccurred())
-
-		csv := operatorsv1alpha1.ClusterServiceVersion{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
-				APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("csv"),
-			},
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				MinKubeVersion: "0.0.0",
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
-					},
-				},
-				InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
-					StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
-					StrategySpec: strategy,
-				},
-				CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
-					Owned: []operatorsv1alpha1.CRDDescription{
-						{
-							Name:        crdName,
-							Version:     "v1alpha1",
-							Kind:        crdPlural,
-							DisplayName: crdName,
-							Description: "In the cluster2",
-						},
-					},
-				},
-			},
-		}
-
-		// don't need to clean up this CSV, it will be deleted by the upgrade process
-		_, err = createCSV(c, crc, csv, testNamespace, false, false)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Wait for current CSV to succeed
-		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Should have created deployment
-		dep, err := c.GetDeployment(testNamespace, strategy.DeploymentSpecs[0].Name)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(dep).ShouldNot(BeNil())
-
-		// Create "updated" CSV
-		strategyNew := operatorsv1alpha1.StrategyDetailsDeployment{
-			DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
-				{
-					Name: genName("dep2"),
-					Spec: newNginxDeployment(genName("nginx-")),
-				},
-			},
-		}
-
-		Expect(err).ShouldNot(HaveOccurred())
-
-		csvNew := operatorsv1alpha1.ClusterServiceVersion{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
-				APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("csv2"),
-			},
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				Replaces: csv.Name,
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
-					},
-				},
-				InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
-					StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
-					StrategySpec: strategyNew,
-				},
-				CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
-					Owned: []operatorsv1alpha1.CRDDescription{
-						{
-							Name:        crdName,
-							Version:     "v1alpha1",
-							Kind:        crdPlural,
-							DisplayName: crdName,
-							Description: "In the cluster2",
-						},
-					},
-				},
-			},
-		}
-
-		cleanupNewCSV, err := createCSV(c, crc, csvNew, testNamespace, true, false)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupNewCSV()
-
-		// Wait for updated CSV to succeed
-		fetchedCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Fetch cluster service version again to check for unnecessary control loops
-		sameCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
-
-		// Should have created new deployment and deleted old
-		depNew, err := c.GetDeployment(testNamespace, strategyNew.DeploymentSpecs[0].Name)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(depNew).ShouldNot(BeNil())
-		err = waitForDeploymentToDelete(c, strategy.DeploymentSpecs[0].Name)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Should eventually GC the CSV
-		Eventually(func() bool {
-			return csvExists(crc, csv.Name)
-		}).Should(BeFalse())
-	})
-	It("update multiple intermediates", func() {
-
-		// Create dependency first (CRD)
-		crdPlural := genName("ins3")
-		crdName := crdPlural + ".cluster.com"
-		cleanupCRD, err := createCRD(c, apiextensions.CustomResourceDefinition{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: crdName,
-			},
-			Spec: apiextensions.CustomResourceDefinitionSpec{
-				Group: "cluster.com",
-				Versions: []apiextensions.CustomResourceDefinitionVersion{
-					{
-						Name:    "v1alpha1",
-						Served:  true,
-						Storage: true,
-						Schema: &apiextensions.CustomResourceValidation{
-							OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
-								Type:        "object",
-								Description: "my crd schema",
-							},
-						},
-					},
-				},
-				Names: apiextensions.CustomResourceDefinitionNames{
-					Plural:   crdPlural,
-					Singular: crdPlural,
-					Kind:     crdPlural,
-					ListKind: "list" + crdPlural,
-				},
-				Scope: apiextensions.NamespaceScoped,
-			},
-		})
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCRD()
-
-		// create "current" CSV
-		strategy := operatorsv1alpha1.StrategyDetailsDeployment{
-			DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
-				{
-					Name: genName("dep-"),
-					Spec: newNginxDeployment(genName("nginx-")),
-				},
-			},
-		}
-
-		Expect(err).ShouldNot(HaveOccurred())
-
-		csv := operatorsv1alpha1.ClusterServiceVersion{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
-				APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("csv"),
-			},
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				MinKubeVersion: "0.0.0",
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
-					},
-				},
-				InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
-					StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
-					StrategySpec: strategy,
-				},
-				CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
-					Owned: []operatorsv1alpha1.CRDDescription{
-						{
-							Name:        crdName,
-							Version:     "v1alpha1",
-							Kind:        crdPlural,
-							DisplayName: crdName,
-							Description: "In the cluster3",
-						},
-					},
-				},
-			},
-		}
-
-		// don't need to clean up this CSV, it will be deleted by the upgrade process
-		_, err = createCSV(c, crc, csv, testNamespace, false, false)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Wait for current CSV to succeed
-		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Should have created deployment
-		dep, err := c.GetDeployment(testNamespace, strategy.DeploymentSpecs[0].Name)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(dep).ShouldNot(BeNil())
-
-		// Create "updated" CSV
-		strategyNew := operatorsv1alpha1.StrategyDetailsDeployment{
-			DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
-				{
-					Name: genName("dep2"),
-					Spec: newNginxDeployment(genName("nginx-")),
-				},
-			},
-		}
-
-		Expect(err).ShouldNot(HaveOccurred())
-
-		csvNew := operatorsv1alpha1.ClusterServiceVersion{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
-				APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("csv2"),
-			},
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				Replaces: csv.Name,
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
-					},
-				},
-				InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
-					StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
-					StrategySpec: strategyNew,
-				},
-				CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
-					Owned: []operatorsv1alpha1.CRDDescription{
-						{
-							Name:        crdName,
-							Version:     "v1alpha1",
-							Kind:        crdPlural,
-							DisplayName: crdName,
-							Description: "In the cluster3",
-						},
-					},
-				},
-			},
-		}
-
-		cleanupNewCSV, err := createCSV(c, crc, csvNew, testNamespace, true, false)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupNewCSV()
-
-		// Wait for updated CSV to succeed
-		fetchedCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Fetch cluster service version again to check for unnecessary control loops
-		sameCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
-
-		// Should have created new deployment and deleted old
-		depNew, err := c.GetDeployment(testNamespace, strategyNew.DeploymentSpecs[0].Name)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(depNew).ShouldNot(BeNil())
-		err = waitForDeploymentToDelete(c, strategy.DeploymentSpecs[0].Name)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Should eventually GC the CSV
-		Eventually(func() bool {
-			return csvExists(crc, csv.Name)
-		}).Should(BeFalse())
-	})
-	It("update in place", func() {
-
-		// Create dependency first (CRD)
-		crdPlural := genName("ins")
-		crdName := crdPlural + ".cluster.com"
-		cleanupCRD, err := createCRD(c, apiextensions.CustomResourceDefinition{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: crdName,
-			},
-			Spec: apiextensions.CustomResourceDefinitionSpec{
-				Group: "cluster.com",
-				Versions: []apiextensions.CustomResourceDefinitionVersion{
-					{
-						Name:    "v1alpha1",
-						Served:  true,
-						Storage: true,
-						Schema: &apiextensions.CustomResourceValidation{
-							OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
-								Type:        "object",
-								Description: "my crd schema",
-							},
-						},
-					},
-				},
-				Names: apiextensions.CustomResourceDefinitionNames{
-					Plural:   crdPlural,
-					Singular: crdPlural,
-					Kind:     crdPlural,
-					ListKind: "list" + crdPlural,
-				},
-				Scope: apiextensions.NamespaceScoped,
-			},
-		})
-
-		// Create "current" CSV
-		nginxName := genName("nginx-")
-		strategy := operatorsv1alpha1.StrategyDetailsDeployment{
-			DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
-				{
-					Name: genName("dep-"),
-					Spec: newNginxDeployment(nginxName),
-				},
-			},
-		}
-
-		Expect(err).ShouldNot(HaveOccurred())
-
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCRD()
-		csv := operatorsv1alpha1.ClusterServiceVersion{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
-				APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("csv"),
-			},
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				MinKubeVersion: "0.0.0",
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
-					},
-				},
-				InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
-					StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
-					StrategySpec: strategy,
-				},
-				CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
-					Owned: []operatorsv1alpha1.CRDDescription{
-						{
-							Name:        crdName,
-							Version:     "v1alpha1",
-							Kind:        crdPlural,
-							DisplayName: crdName,
-							Description: "In the cluster",
-						},
-					},
-				},
-			},
-		}
-
-		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, true)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCSV()
-
-		// Wait for current CSV to succeed
-		fetchedCSV, err := fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Should have created deployment
-		dep, err := c.GetDeployment(testNamespace, strategy.DeploymentSpecs[0].Name)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(dep).ShouldNot(BeNil())
-
-		// Create "updated" CSV
-		strategyNew := strategy
-		strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers = []corev1.Container{
-			{
-				Name:  genName("nginx-"),
-				Image: *dummyImage,
-				Ports: []corev1.ContainerPort{
-					{
-						ContainerPort: 80,
-					},
-				},
-				ImagePullPolicy: corev1.PullIfNotPresent,
-			},
-		}
-
-		// Also set something outside the spec template - this should be ignored
-		var five int32 = 5
-		strategyNew.DeploymentSpecs[0].Spec.Replicas = &five
-
-		Expect(err).ShouldNot(HaveOccurred())
-
-		fetchedCSV.Spec.InstallStrategy.StrategySpec = strategyNew
-
-		// Update CSV directly
-		_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Update(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// wait for deployment spec to be updated
-		Eventually(func() (string, error) {
-			fetched, err := c.GetDeployment(testNamespace, strategyNew.DeploymentSpecs[0].Name)
-			if err != nil {
-				return "", err
 			}
-			ctx.Ctx().Logf("waiting for deployment to update...")
-			return fetched.Spec.Template.Spec.Containers[0].Name, nil
-		}).Should(Equal(strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Name))
 
-		// Wait for updated CSV to succeed
-		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
+			// Don't need to cleanup this CSV, it will be deleted by the upgrade process
+			_, err = createCSV(c, crc, csv, ns.GetName(), false, false)
+			Expect(err).ShouldNot(HaveOccurred())
 
-		depUpdated, err := c.GetDeployment(testNamespace, strategyNew.DeploymentSpecs[0].Name)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(depUpdated).ShouldNot(BeNil())
+			// Wait for current CSV to succeed
+			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
 
-		// Deployment should have changed even though the CSV is otherwise the same
-		Expect(strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Name).Should(Equal(depUpdated.Spec.Template.Spec.Containers[0].Name))
-		Expect(strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Image).Should(Equal(depUpdated.Spec.Template.Spec.Containers[0].Image))
+			// Should have created deployment
+			dep, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[0].Name)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(dep).ShouldNot(BeNil())
 
-		// Field updated even though template spec didn't change, because it was part of a template spec change as well
-		Expect(*strategyNew.DeploymentSpecs[0].Spec.Replicas).Should(Equal(*depUpdated.Spec.Replicas))
-	})
-	It("update multiple version CRD", func() {
-
-		// Create initial CRD which has 2 versions: v1alpha1 & v1alpha2
-		crdPlural := genName("ins4")
-		crdName := crdPlural + ".cluster.com"
-		cleanupCRD, err := createCRD(c, apiextensions.CustomResourceDefinition{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: crdName,
-			},
-			Spec: apiextensions.CustomResourceDefinitionSpec{
-				Group: "cluster.com",
-				Versions: []apiextensions.CustomResourceDefinitionVersion{
+			// Create "updated" CSV
+			strategyNew := operatorsv1alpha1.StrategyDetailsDeployment{
+				DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
 					{
-						Name:    "v1alpha1",
-						Served:  true,
-						Storage: true,
-						Schema: &apiextensions.CustomResourceValidation{
-							OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
-								Type:        "object",
-								Description: "my crd schema",
-							},
-						},
-					},
-					{
-						Name:    "v1alpha2",
-						Served:  true,
-						Storage: false,
-						Schema: &apiextensions.CustomResourceValidation{
-							OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
-								Type:        "object",
-								Description: "my crd schema",
-							},
-						},
+						// Same name
+						Name: strategy.DeploymentSpecs[0].Name,
+						// Different spec
+						Spec: newNginxDeployment(nginxName),
 					},
 				},
-				Names: apiextensions.CustomResourceDefinitionNames{
-					Plural:   crdPlural,
-					Singular: crdPlural,
-					Kind:     crdPlural,
-					ListKind: "list" + crdPlural,
-				},
-				Scope: apiextensions.NamespaceScoped,
-			},
-		})
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCRD()
+			}
 
-		// create initial deployment strategy
-		strategy := operatorsv1alpha1.StrategyDetailsDeployment{
-			DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
-				{
-					Name: genName("dep1-"),
-					Spec: newNginxDeployment(genName("nginx-")),
-				},
-			},
-		}
+			Expect(err).ShouldNot(HaveOccurred())
 
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// First CSV with owning CRD v1alpha1
-		csv := operatorsv1alpha1.ClusterServiceVersion{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
-				APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("csv"),
-			},
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				MinKubeVersion: "0.0.0",
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
-					},
+			csvNew := operatorsv1alpha1.ClusterServiceVersion{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+					APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
 				},
-				InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
-					StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
-					StrategySpec: strategy,
+				ObjectMeta: metav1.ObjectMeta{
+					Name: genName("csv"),
 				},
-				CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
-					Owned: []operatorsv1alpha1.CRDDescription{
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					Replaces: csv.Name,
+					InstallModes: []operatorsv1alpha1.InstallMode{
 						{
-							Name:        crdName,
-							Version:     "v1alpha1",
-							Kind:        crdPlural,
-							DisplayName: crdName,
-							Description: "In the cluster4",
-						},
-					},
-				},
-			},
-		}
-
-		// CSV will be deleted by the upgrade process later
-		_, err = createCSV(c, crc, csv, testNamespace, false, false)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Wait for current CSV to succeed
-		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Should have created deployment
-		dep, err := c.GetDeployment(testNamespace, strategy.DeploymentSpecs[0].Name)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(dep).ShouldNot(BeNil())
-
-		// Create updated deployment strategy
-		strategyNew := operatorsv1alpha1.StrategyDetailsDeployment{
-			DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
-				{
-					Name: genName("dep2-"),
-					Spec: newNginxDeployment(genName("nginx-")),
-				},
-			},
-		}
-
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Second CSV with owning CRD v1alpha1 and v1alpha2
-		csvNew := operatorsv1alpha1.ClusterServiceVersion{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
-				APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("csv2"),
-			},
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				Replaces: csv.Name,
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
-					},
-				},
-				InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
-					StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
-					StrategySpec: strategyNew,
-				},
-				CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
-					Owned: []operatorsv1alpha1.CRDDescription{
-						{
-							Name:        crdName,
-							Version:     "v1alpha1",
-							Kind:        crdPlural,
-							DisplayName: crdName,
-							Description: "In the cluster4",
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
 						},
 						{
-							Name:        crdName,
-							Version:     "v1alpha2",
-							Kind:        crdPlural,
-							DisplayName: crdName,
-							Description: "In the cluster4",
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
 						},
-					},
-				},
-			},
-		}
-
-		// Create newly updated CSV
-		_, err = createCSV(c, crc, csvNew, testNamespace, false, false)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Wait for updated CSV to succeed
-		fetchedCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Fetch cluster service version again to check for unnecessary control loops
-		sameCSV, err := fetchCSV(crc, csvNew.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
-
-		// Should have created new deployment and deleted old one
-		depNew, err := c.GetDeployment(testNamespace, strategyNew.DeploymentSpecs[0].Name)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(depNew).ShouldNot(BeNil())
-		err = waitForDeploymentToDelete(c, strategy.DeploymentSpecs[0].Name)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Create updated deployment strategy
-		strategyNew2 := operatorsv1alpha1.StrategyDetailsDeployment{
-			DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
-				{
-					Name: genName("dep3-"),
-					Spec: newNginxDeployment(genName("nginx-")),
-				},
-			},
-		}
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Third CSV with owning CRD v1alpha2
-		csvNew2 := operatorsv1alpha1.ClusterServiceVersion{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
-				APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("csv3"),
-			},
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				Replaces: csvNew.Name,
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
-					},
-				},
-				InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
-					StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
-					StrategySpec: strategyNew2,
-				},
-				CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
-					Owned: []operatorsv1alpha1.CRDDescription{
 						{
-							Name:        crdName,
-							Version:     "v1alpha2",
-							Kind:        crdPlural,
-							DisplayName: crdName,
-							Description: "In the cluster4",
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
 						},
 					},
-				},
-			},
-		}
-
-		// Create newly updated CSV
-		cleanupNewCSV, err := createCSV(c, crc, csvNew2, testNamespace, true, false)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupNewCSV()
-
-		// Wait for updated CSV to succeed
-		fetchedCSV, err = fetchCSV(crc, csvNew2.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Fetch cluster service version again to check for unnecessary control loops
-		sameCSV, err = fetchCSV(crc, csvNew2.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
-
-		// Should have created new deployment and deleted old one
-		depNew, err = c.GetDeployment(testNamespace, strategyNew2.DeploymentSpecs[0].Name)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(depNew).ShouldNot(BeNil())
-		err = waitForDeploymentToDelete(c, strategyNew.DeploymentSpecs[0].Name)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Should clean up the CSV
-		Eventually(func() bool {
-			return csvExists(crc, csvNew.Name)
-		}).Should(BeFalse())
-	})
-	It("update modify deployment name", func() {
-
-		// Create dependency first (CRD)
-		crdPlural := genName("ins2")
-		crdName := crdPlural + ".cluster.com"
-		cleanupCRD, err := createCRD(c, apiextensions.CustomResourceDefinition{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: crdName,
-			},
-			Spec: apiextensions.CustomResourceDefinitionSpec{
-				Group: "cluster.com",
-				Versions: []apiextensions.CustomResourceDefinitionVersion{
-					{
-						Name:    "v1alpha1",
-						Served:  true,
-						Storage: true,
-						Schema: &apiextensions.CustomResourceValidation{
-							OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
-								Type:        "object",
-								Description: "my crd schema",
+					InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+						StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
+						StrategySpec: strategyNew,
+					},
+					CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
+						Owned: []operatorsv1alpha1.CRDDescription{
+							{
+								Name:        crdName,
+								Version:     "v1alpha1",
+								Kind:        crdPlural,
+								DisplayName: crdName,
+								Description: "In the cluster",
 							},
 						},
 					},
 				},
-				Names: apiextensions.CustomResourceDefinitionNames{
-					Plural:   crdPlural,
-					Singular: crdPlural,
-					Kind:     crdPlural,
-					ListKind: "list" + crdPlural,
-				},
-				Scope: apiextensions.NamespaceScoped,
-			},
-		})
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCRD()
+			}
 
-		// create "current" CSV
-		strategy := operatorsv1alpha1.StrategyDetailsDeployment{
-			DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
-				{
-					Name: genName("dep-"),
-					Spec: newNginxDeployment(genName("nginx-")),
-				},
-				{
-					Name: "dep2-test",
-					Spec: newNginxDeployment("nginx2"),
-				},
-			},
-		}
+			cleanupNewCSV, err := createCSV(c, crc, csvNew, ns.GetName(), true, false)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupNewCSV()
 
-		Expect(err).ShouldNot(HaveOccurred())
-
-		csv := operatorsv1alpha1.ClusterServiceVersion{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
-				APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("csv"),
-			},
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
-					},
-				},
-				InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
-					StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
-					StrategySpec: strategy,
-				},
-				CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
-					Owned: []operatorsv1alpha1.CRDDescription{
-						{
-							Name:        crdName,
-							Version:     "v1alpha1",
-							Kind:        crdPlural,
-							DisplayName: crdName,
-							Description: "In the cluster2",
-						},
-					},
-				},
-			},
-		}
-
-		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, true, false)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCSV()
-
-		// Wait for current CSV to succeed
-		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Should have created deployments
-		dep, err := c.GetDeployment(testNamespace, strategy.DeploymentSpecs[0].Name)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(dep).ShouldNot(BeNil())
-		dep2, err := c.GetDeployment(testNamespace, strategy.DeploymentSpecs[1].Name)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(dep2).ShouldNot(BeNil())
-
-		// Create "updated" CSV
-		strategyNew := operatorsv1alpha1.StrategyDetailsDeployment{
-			DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
-				{
-					Name: genName("dep3-"),
-					Spec: newNginxDeployment(genName("nginx3-")),
-				},
-				{
-					Name: "dep2-test",
-					Spec: newNginxDeployment("nginx2"),
-				},
-			},
-		}
-
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Fetch the current csv
-		fetchedCSV, err := fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Update csv with same strategy with different deployment's name
-		fetchedCSV.Spec.InstallStrategy.StrategySpec = strategyNew
-
-		// Update the current csv with the new csv
-		_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Update(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Wait for new deployment to exist
-		err = waitForDeployment(c, strategyNew.DeploymentSpecs[0].Name)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Wait for updated CSV to succeed
-		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Should have created new deployment and deleted old
-		depNew, err := c.GetDeployment(testNamespace, strategyNew.DeploymentSpecs[0].Name)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(depNew).ShouldNot(BeNil())
-
-		// Make sure the unchanged deployment still exists
-		depNew2, err := c.GetDeployment(testNamespace, strategyNew.DeploymentSpecs[1].Name)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(depNew2).ShouldNot(BeNil())
-
-		err = waitForDeploymentToDelete(c, strategy.DeploymentSpecs[0].Name)
-		Expect(err).ShouldNot(HaveOccurred())
-	})
-	It("update deployment spec in an existing CSV for a hotfix", func() {
-
-		c := newKubeClient()
-		crc := newCRClient()
-
-		// Create dependency first (CRD)
-		crdPlural := genName("ins")
-		crdName := crdPlural + ".cluster.com"
-		cleanupCRD, err := createCRD(c, apiextensions.CustomResourceDefinition{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: crdName,
-			},
-			Spec: apiextensions.CustomResourceDefinitionSpec{
-				Group: "cluster.com",
-				Versions: []apiextensions.CustomResourceDefinitionVersion{
-					{
-						Name:    "v1alpha1",
-						Served:  true,
-						Storage: true,
-						Schema: &apiextensions.CustomResourceValidation{
-							OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
-								Type:        "object",
-								Description: "my crd schema",
-							},
-						},
-					},
-				},
-				Names: apiextensions.CustomResourceDefinitionNames{
-					Plural:   crdPlural,
-					Singular: crdPlural,
-					Kind:     crdPlural,
-					ListKind: "list" + crdPlural,
-				},
-				Scope: apiextensions.NamespaceScoped,
-			},
-		})
-		defer cleanupCRD()
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Create "current" CSV
-		nginxName := genName("nginx-")
-		strategy := operatorsv1alpha1.StrategyDetailsDeployment{
-			DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
-				{
-					Name: genName("dep-"),
-					Spec: newNginxDeployment(nginxName),
-				},
-			},
-		}
-
-		csv := operatorsv1alpha1.ClusterServiceVersion{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
-				APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("csv"),
-			},
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				MinKubeVersion: "0.0.0",
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
-					},
-				},
-				InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
-					StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
-					StrategySpec: strategy,
-				},
-				CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
-					Owned: []operatorsv1alpha1.CRDDescription{
-						{
-							Name:        crdName,
-							Version:     "v1alpha1",
-							Kind:        crdPlural,
-							DisplayName: crdName,
-							Description: "In the cluster",
-						},
-					},
-				},
-			},
-		}
-
-		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, true, false)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCSV()
-
-		// Wait for current CSV to succeed
-		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Should have created deployment
-		dep, err := c.GetDeployment(testNamespace, strategy.DeploymentSpecs[0].Name)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(dep).ShouldNot(BeNil())
-
-		// Create "updated" CSV
-		strategyNew := operatorsv1alpha1.StrategyDetailsDeployment{
-			DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
-				{
-					// Same name
-					Name: strategy.DeploymentSpecs[0].Name,
-					// Different spec
-					Spec: newNginxDeployment(nginxName),
-				},
-			},
-		}
-
-		// Fetch the current csv
-		fetchedCSV, err := fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Update csv with modified deployment spec
-		fetchedCSV.Spec.InstallStrategy.StrategySpec = strategyNew
-
-		Eventually(func() error {
-			// Update the current csv
-			_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Update(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
-			return err
-		}).Should(Succeed())
-
-		// Wait for updated CSV to succeed
-		_, err = fetchCSV(crc, csv.Name, testNamespace, func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
+			// Wait for updated CSV to succeed
+			fetchedCSV, err := fetchCSV(crc, csvNew.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have updated existing deployment
-			depUpdated, err := c.GetDeployment(testNamespace, strategyNew.DeploymentSpecs[0].Name)
+			depUpdated, err := c.GetDeployment(ns.GetName(), strategyNew.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(depUpdated).ShouldNot(BeNil())
-			// container name has been updated and differs from initial CSV spec and updated CSV spec
-			Expect(depUpdated.Spec.Template.Spec.Containers[0].Name).ShouldNot(Equal(strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Name))
+			Expect(strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Name).Should(Equal(depUpdated.Spec.Template.Spec.Containers[0].Name))
 
-			// Check for success
-			return csvSucceededChecker(csv)
+			// Should eventually GC the CSV
+			Eventually(func() bool {
+				return csvExists(ns.GetName(), crc, csv.Name)
+			}).Should(BeFalse())
+
+			// Fetch cluster service version again to check for unnecessary control loops
+			sameCSV, err := fetchCSV(crc, csvNew.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
 		})
-		Expect(err).ShouldNot(HaveOccurred())
+		It("update different deployment name", func() {
 
-	})
-	It("emits CSV requirement events", func() {
-
-		csv := &operatorsv1alpha1.ClusterServiceVersion{
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				MinKubeVersion: "0.0.0",
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
-					},
+			// Create dependency first (CRD)
+			crdPlural := genName("ins2")
+			crdName := crdPlural + ".cluster.com"
+			cleanupCRD, err := createCRD(c, apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: crdName,
 				},
-				InstallStrategy: newNginxInstallStrategy(genName("dep-"), nil, nil),
-				APIServiceDefinitions: operatorsv1alpha1.APIServiceDefinitions{
-					// Require an API that we know won't exist under our domain
-					Required: []operatorsv1alpha1.APIServiceDescription{
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "cluster.com",
+					Versions: []apiextensions.CustomResourceDefinitionVersion{
 						{
-							Group:   "bad.packages.operators.coreos.com",
-							Version: "v1",
-							Kind:    "PackageManifest",
+							Name:    "v1alpha1",
+							Served:  true,
+							Storage: true,
+							Schema: &apiextensions.CustomResourceValidation{
+								OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+									Type:        "object",
+									Description: "my crd schema",
+								},
+							},
 						},
 					},
+					Names: apiextensions.CustomResourceDefinitionNames{
+						Plural:   crdPlural,
+						Singular: crdPlural,
+						Kind:     crdPlural,
+						ListKind: "list" + crdPlural,
+					},
+					Scope: apiextensions.NamespaceScoped,
 				},
-			},
-		}
-		csv.SetNamespace(testNamespace)
-		csv.SetName(genName("csv-"))
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCRD()
 
-		clientCtx := context.Background()
-		listOpts := metav1.ListOptions{
-			FieldSelector: "involvedObject.kind=ClusterServiceVersion",
-		}
-		events, err := c.KubernetesInterface().CoreV1().Events(csv.GetNamespace()).List(clientCtx, listOpts)
-		Expect(err).ToNot(HaveOccurred())
-
-		// Watch latest events from test namespace for CSV
-		listOpts.ResourceVersion = events.ResourceVersion
-		w, err := c.KubernetesInterface().CoreV1().Events(testNamespace).Watch(context.Background(), listOpts)
-		Expect(err).ToNot(HaveOccurred())
-		defer w.Stop()
-
-		cleanupCSV, err := createCSV(c, crc, *csv, csv.GetNamespace(), false, false)
-		Expect(err).ToNot(HaveOccurred())
-		defer cleanupCSV()
-
-		By("emitting when requirements are not met")
-		nextReason := func() string {
-			if e := <-w.ResultChan(); e.Object != nil {
-				return e.Object.(*corev1.Event).Reason
-			}
-			return ""
-		}
-		Eventually(nextReason).Should(Equal("RequirementsNotMet"))
-
-		// Patch the CSV to require an API that we know exists
-		Eventually(ctx.Ctx().SSAClient().Apply(clientCtx, csv, func(c *operatorsv1alpha1.ClusterServiceVersion) error {
-			c.Spec.APIServiceDefinitions.Required[0].Group = "packages.operators.coreos.com"
-			return nil
-		})).Should(Succeed())
-
-		By("emitting when requirements are met")
-		Eventually(nextReason).Should(Equal("AllRequirementsMet"))
-	})
-
-	// TODO: test behavior when replaces field doesn't point to existing CSV
-	It("status invalid CSV", func() {
-
-		// Create CRD
-		crdPlural := genName("ins")
-		crdName := crdPlural + ".cluster.com"
-		cleanupCRD, err := createCRD(c, apiextensions.CustomResourceDefinition{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: crdName,
-			},
-			Spec: apiextensions.CustomResourceDefinitionSpec{
-				Group: "cluster.com",
-				Versions: []apiextensions.CustomResourceDefinitionVersion{
+			// create "current" CSV
+			strategy := operatorsv1alpha1.StrategyDetailsDeployment{
+				DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
 					{
-						Name:    "v1alpha1",
-						Served:  true,
-						Storage: true,
-						Schema: &apiextensions.CustomResourceValidation{
-							OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
-								Type:        "object",
-								Description: "my crd schema",
+						Name: genName("dep-"),
+						Spec: newNginxDeployment(genName("nginx-")),
+					},
+				},
+			}
+
+			Expect(err).ShouldNot(HaveOccurred())
+
+			csv := operatorsv1alpha1.ClusterServiceVersion{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+					APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: genName("csv"),
+				},
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					MinKubeVersion: "0.0.0",
+					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
+					},
+					InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+						StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
+						StrategySpec: strategy,
+					},
+					CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
+						Owned: []operatorsv1alpha1.CRDDescription{
+							{
+								Name:        crdName,
+								Version:     "v1alpha1",
+								Kind:        crdPlural,
+								DisplayName: crdName,
+								Description: "In the cluster2",
 							},
 						},
 					},
 				},
-				Names: apiextensions.CustomResourceDefinitionNames{
-					Plural:   crdPlural,
-					Singular: crdPlural,
-					Kind:     crdPlural,
-					ListKind: "list" + crdPlural,
-				},
-				Scope: apiextensions.NamespaceScoped,
-			},
-		})
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCRD()
+			}
 
-		// create CSV
-		strategy := operatorsv1alpha1.StrategyDetailsDeployment{
-			DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
-				{
-					Name: genName("dep-"),
-					Spec: newNginxDeployment(genName("nginx-")),
-				},
-			},
-		}
+			// don't need to clean up this CSV, it will be deleted by the upgrade process
+			_, err = createCSV(c, crc, csv, ns.GetName(), false, false)
+			Expect(err).ShouldNot(HaveOccurred())
 
-		Expect(err).ShouldNot(HaveOccurred())
+			// Wait for current CSV to succeed
+			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
 
-		csv := operatorsv1alpha1.ClusterServiceVersion{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
-				APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("csv"),
-			},
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				InstallModes: []operatorsv1alpha1.InstallMode{
+			// Should have created deployment
+			dep, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[0].Name)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(dep).ShouldNot(BeNil())
+
+			// Create "updated" CSV
+			strategyNew := operatorsv1alpha1.StrategyDetailsDeployment{
+				DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
 					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
+						Name: genName("dep2"),
+						Spec: newNginxDeployment(genName("nginx-")),
 					},
 				},
-				InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
-					StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
-					StrategySpec: strategy,
+			}
+
+			Expect(err).ShouldNot(HaveOccurred())
+
+			csvNew := operatorsv1alpha1.ClusterServiceVersion{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+					APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
 				},
-				CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
-					Owned: []operatorsv1alpha1.CRDDescription{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: genName("csv2"),
+				},
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					Replaces: csv.Name,
+					InstallModes: []operatorsv1alpha1.InstallMode{
 						{
-							Name:        crdName,
-							Version:     "apiextensions.k8s.io/v1alpha1", // purposely invalid, should be just v1alpha1 to match CRD
-							Kind:        crdPlural,
-							DisplayName: crdName,
-							Description: "In the cluster2",
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
+					},
+					InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+						StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
+						StrategySpec: strategyNew,
+					},
+					CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
+						Owned: []operatorsv1alpha1.CRDDescription{
+							{
+								Name:        crdName,
+								Version:     "v1alpha1",
+								Kind:        crdPlural,
+								DisplayName: crdName,
+								Description: "In the cluster2",
+							},
 						},
 					},
 				},
-			},
-		}
+			}
 
-		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, true, false)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCSV()
+			cleanupNewCSV, err := createCSV(c, crc, csvNew, ns.GetName(), true, false)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupNewCSV()
 
-		notServedStatus := operatorsv1alpha1.RequirementStatus{
-			Group:   "apiextensions.k8s.io",
-			Version: "v1",
-			Kind:    "CustomResourceDefinition",
-			Name:    crdName,
-			Status:  operatorsv1alpha1.RequirementStatusReasonNotPresent,
-			Message: "CRD version not served",
-		}
-		csvCheckPhaseAndRequirementStatus := func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
-			if csv.Status.Phase == operatorsv1alpha1.CSVPhasePending {
-				for _, status := range csv.Status.RequirementStatus {
-					if status.Message == notServedStatus.Message {
-						return true
-					}
+			// Wait for updated CSV to succeed
+			fetchedCSV, err := fetchCSV(crc, csvNew.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Fetch cluster service version again to check for unnecessary control loops
+			sameCSV, err := fetchCSV(crc, csvNew.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
+
+			// Should have created new deployment and deleted old
+			depNew, err := c.GetDeployment(ns.GetName(), strategyNew.DeploymentSpecs[0].Name)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(depNew).ShouldNot(BeNil())
+			err = waitForDeploymentToDelete(ns.GetName(), c, strategy.DeploymentSpecs[0].Name)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Should eventually GC the CSV
+			Eventually(func() bool {
+				return csvExists(ns.GetName(), crc, csv.Name)
+			}).Should(BeFalse())
+		})
+		It("update multiple intermediates", func() {
+
+			// Create dependency first (CRD)
+			crdPlural := genName("ins3")
+			crdName := crdPlural + ".cluster.com"
+			cleanupCRD, err := createCRD(c, apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: crdName,
+				},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "cluster.com",
+					Versions: []apiextensions.CustomResourceDefinitionVersion{
+						{
+							Name:    "v1alpha1",
+							Served:  true,
+							Storage: true,
+							Schema: &apiextensions.CustomResourceValidation{
+								OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+									Type:        "object",
+									Description: "my crd schema",
+								},
+							},
+						},
+					},
+					Names: apiextensions.CustomResourceDefinitionNames{
+						Plural:   crdPlural,
+						Singular: crdPlural,
+						Kind:     crdPlural,
+						ListKind: "list" + crdPlural,
+					},
+					Scope: apiextensions.NamespaceScoped,
+				},
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCRD()
+
+			// create "current" CSV
+			strategy := operatorsv1alpha1.StrategyDetailsDeployment{
+				DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
+					{
+						Name: genName("dep-"),
+						Spec: newNginxDeployment(genName("nginx-")),
+					},
+				},
+			}
+
+			Expect(err).ShouldNot(HaveOccurred())
+
+			csv := operatorsv1alpha1.ClusterServiceVersion{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+					APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: genName("csv"),
+				},
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					MinKubeVersion: "0.0.0",
+					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
+					},
+					InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+						StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
+						StrategySpec: strategy,
+					},
+					CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
+						Owned: []operatorsv1alpha1.CRDDescription{
+							{
+								Name:        crdName,
+								Version:     "v1alpha1",
+								Kind:        crdPlural,
+								DisplayName: crdName,
+								Description: "In the cluster3",
+							},
+						},
+					},
+				},
+			}
+
+			// don't need to clean up this CSV, it will be deleted by the upgrade process
+			_, err = createCSV(c, crc, csv, ns.GetName(), false, false)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Wait for current CSV to succeed
+			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Should have created deployment
+			dep, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[0].Name)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(dep).ShouldNot(BeNil())
+
+			// Create "updated" CSV
+			strategyNew := operatorsv1alpha1.StrategyDetailsDeployment{
+				DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
+					{
+						Name: genName("dep2"),
+						Spec: newNginxDeployment(genName("nginx-")),
+					},
+				},
+			}
+
+			Expect(err).ShouldNot(HaveOccurred())
+
+			csvNew := operatorsv1alpha1.ClusterServiceVersion{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+					APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: genName("csv2"),
+				},
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					Replaces: csv.Name,
+					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
+					},
+					InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+						StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
+						StrategySpec: strategyNew,
+					},
+					CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
+						Owned: []operatorsv1alpha1.CRDDescription{
+							{
+								Name:        crdName,
+								Version:     "v1alpha1",
+								Kind:        crdPlural,
+								DisplayName: crdName,
+								Description: "In the cluster3",
+							},
+						},
+					},
+				},
+			}
+
+			cleanupNewCSV, err := createCSV(c, crc, csvNew, ns.GetName(), true, false)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupNewCSV()
+
+			// Wait for updated CSV to succeed
+			fetchedCSV, err := fetchCSV(crc, csvNew.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Fetch cluster service version again to check for unnecessary control loops
+			sameCSV, err := fetchCSV(crc, csvNew.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
+
+			// Should have created new deployment and deleted old
+			depNew, err := c.GetDeployment(ns.GetName(), strategyNew.DeploymentSpecs[0].Name)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(depNew).ShouldNot(BeNil())
+			err = waitForDeploymentToDelete(ns.GetName(), c, strategy.DeploymentSpecs[0].Name)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Should eventually GC the CSV
+			Eventually(func() bool {
+				return csvExists(ns.GetName(), crc, csv.Name)
+			}).Should(BeFalse())
+		})
+		It("update in place", func() {
+
+			// Create dependency first (CRD)
+			crdPlural := genName("ins")
+			crdName := crdPlural + ".cluster.com"
+			cleanupCRD, err := createCRD(c, apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: crdName,
+				},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "cluster.com",
+					Versions: []apiextensions.CustomResourceDefinitionVersion{
+						{
+							Name:    "v1alpha1",
+							Served:  true,
+							Storage: true,
+							Schema: &apiextensions.CustomResourceValidation{
+								OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+									Type:        "object",
+									Description: "my crd schema",
+								},
+							},
+						},
+					},
+					Names: apiextensions.CustomResourceDefinitionNames{
+						Plural:   crdPlural,
+						Singular: crdPlural,
+						Kind:     crdPlural,
+						ListKind: "list" + crdPlural,
+					},
+					Scope: apiextensions.NamespaceScoped,
+				},
+			})
+
+			// Create "current" CSV
+			nginxName := genName("nginx-")
+			strategy := operatorsv1alpha1.StrategyDetailsDeployment{
+				DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
+					{
+						Name: genName("dep-"),
+						Spec: newNginxDeployment(nginxName),
+					},
+				},
+			}
+
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCRD()
+			csv := operatorsv1alpha1.ClusterServiceVersion{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+					APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: genName("csv"),
+				},
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					MinKubeVersion: "0.0.0",
+					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
+					},
+					InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+						StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
+						StrategySpec: strategy,
+					},
+					CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
+						Owned: []operatorsv1alpha1.CRDDescription{
+							{
+								Name:        crdName,
+								Version:     "v1alpha1",
+								Kind:        crdPlural,
+								DisplayName: crdName,
+								Description: "In the cluster",
+							},
+						},
+					},
+				},
+			}
+
+			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, true)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCSV()
+
+			// Wait for current CSV to succeed
+			fetchedCSV, err := fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Should have created deployment
+			dep, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[0].Name)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(dep).ShouldNot(BeNil())
+
+			// Create "updated" CSV
+			strategyNew := strategy
+			strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Name:  genName("nginx-"),
+					Image: *dummyImage,
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: 80,
+						},
+					},
+					ImagePullPolicy: corev1.PullIfNotPresent,
+				},
+			}
+
+			// Also set something outside the spec template - this should be ignored
+			var five int32 = 5
+			strategyNew.DeploymentSpecs[0].Spec.Replicas = &five
+
+			Expect(err).ShouldNot(HaveOccurred())
+
+			fetchedCSV.Spec.InstallStrategy.StrategySpec = strategyNew
+
+			// Update CSV directly
+			_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Update(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// wait for deployment spec to be updated
+			Eventually(func() (string, error) {
+				fetched, err := c.GetDeployment(ns.GetName(), strategyNew.DeploymentSpecs[0].Name)
+				if err != nil {
+					return "", err
 				}
+				ctx.Ctx().Logf("waiting for deployment to update...")
+				return fetched.Spec.Template.Spec.Containers[0].Name, nil
+			}).Should(Equal(strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Name))
+
+			// Wait for updated CSV to succeed
+			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			depUpdated, err := c.GetDeployment(ns.GetName(), strategyNew.DeploymentSpecs[0].Name)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(depUpdated).ShouldNot(BeNil())
+
+			// Deployment should have changed even though the CSV is otherwise the same
+			Expect(strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Name).Should(Equal(depUpdated.Spec.Template.Spec.Containers[0].Name))
+			Expect(strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Image).Should(Equal(depUpdated.Spec.Template.Spec.Containers[0].Image))
+
+			// Field updated even though template spec didn't change, because it was part of a template spec change as well
+			Expect(*strategyNew.DeploymentSpecs[0].Spec.Replicas).Should(Equal(*depUpdated.Spec.Replicas))
+		})
+		It("update multiple version CRD", func() {
+
+			// Create initial CRD which has 2 versions: v1alpha1 & v1alpha2
+			crdPlural := genName("ins4")
+			crdName := crdPlural + ".cluster.com"
+			cleanupCRD, err := createCRD(c, apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: crdName,
+				},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "cluster.com",
+					Versions: []apiextensions.CustomResourceDefinitionVersion{
+						{
+							Name:    "v1alpha1",
+							Served:  true,
+							Storage: true,
+							Schema: &apiextensions.CustomResourceValidation{
+								OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+									Type:        "object",
+									Description: "my crd schema",
+								},
+							},
+						},
+						{
+							Name:    "v1alpha2",
+							Served:  true,
+							Storage: false,
+							Schema: &apiextensions.CustomResourceValidation{
+								OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+									Type:        "object",
+									Description: "my crd schema",
+								},
+							},
+						},
+					},
+					Names: apiextensions.CustomResourceDefinitionNames{
+						Plural:   crdPlural,
+						Singular: crdPlural,
+						Kind:     crdPlural,
+						ListKind: "list" + crdPlural,
+					},
+					Scope: apiextensions.NamespaceScoped,
+				},
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCRD()
+
+			// create initial deployment strategy
+			strategy := operatorsv1alpha1.StrategyDetailsDeployment{
+				DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
+					{
+						Name: genName("dep1-"),
+						Spec: newNginxDeployment(genName("nginx-")),
+					},
+				},
 			}
-			return false
-		}
 
-		fetchedCSV, err := fetchCSV(crc, csv.Name, testNamespace, csvCheckPhaseAndRequirementStatus)
-		Expect(err).ShouldNot(HaveOccurred())
+			Expect(err).ShouldNot(HaveOccurred())
 
-		Expect(fetchedCSV.Status.RequirementStatus).Should(ContainElement(notServedStatus))
-	})
-
-	It("api service resource migrated if adoptable", func() {
-
-		depName := genName("hat-server")
-		mockGroup := fmt.Sprintf("hats.%s.redhat.com", genName(""))
-		version := "v1alpha1"
-		mockGroupVersion := strings.Join([]string{mockGroup, version}, "/")
-		mockKinds := []string{"fedora"}
-		depSpec := newMockExtServerDeployment(depName, []mockGroupVersionKind{{depName, mockGroupVersion, mockKinds, 5443}})
-		apiServiceName := strings.Join([]string{version, mockGroup}, ".")
-
-		// Create CSVs for the hat-server
-		strategy := operatorsv1alpha1.StrategyDetailsDeployment{
-			DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
-				{
-					Name: depName,
-					Spec: depSpec,
+			// First CSV with owning CRD v1alpha1
+			csv := operatorsv1alpha1.ClusterServiceVersion{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+					APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
 				},
-			},
-		}
-
-		owned := make([]operatorsv1alpha1.APIServiceDescription, len(mockKinds))
-		for i, kind := range mockKinds {
-			owned[i] = operatorsv1alpha1.APIServiceDescription{
-				Name:           apiServiceName,
-				Group:          mockGroup,
-				Version:        version,
-				Kind:           kind,
-				DeploymentName: depName,
-				ContainerPort:  int32(5443),
-				DisplayName:    kind,
-				Description:    fmt.Sprintf("A %s", kind),
+				ObjectMeta: metav1.ObjectMeta{
+					Name: genName("csv"),
+				},
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					MinKubeVersion: "0.0.0",
+					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
+					},
+					InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+						StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
+						StrategySpec: strategy,
+					},
+					CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
+						Owned: []operatorsv1alpha1.CRDDescription{
+							{
+								Name:        crdName,
+								Version:     "v1alpha1",
+								Kind:        crdPlural,
+								DisplayName: crdName,
+								Description: "In the cluster4",
+							},
+						},
+					},
+				},
 			}
-		}
 
-		csv := operatorsv1alpha1.ClusterServiceVersion{
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				MinKubeVersion: "0.0.0",
-				InstallModes: []operatorsv1alpha1.InstallMode{
+			// CSV will be deleted by the upgrade process later
+			_, err = createCSV(c, crc, csv, ns.GetName(), false, false)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Wait for current CSV to succeed
+			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Should have created deployment
+			dep, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[0].Name)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(dep).ShouldNot(BeNil())
+
+			// Create updated deployment strategy
+			strategyNew := operatorsv1alpha1.StrategyDetailsDeployment{
+				DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
 					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
+						Name: genName("dep2-"),
+						Spec: newNginxDeployment(genName("nginx-")),
 					},
 				},
-				InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
-					StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
-					StrategySpec: strategy,
-				},
-				APIServiceDefinitions: operatorsv1alpha1.APIServiceDefinitions{
-					Owned: owned,
-				},
-			},
-		}
-		csv.SetName("csv-hat-1")
-		csv.SetNamespace(testNamespace)
-
-		createLegacyAPIResources(&csv, owned[0])
-
-		// Create the APIService CSV
-		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCSV()
-
-		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		checkLegacyAPIResources(owned[0], true)
-	})
-
-	It("API service resource not migrated if not adoptable", func() {
-
-		depName := genName("hat-server")
-		mockGroup := fmt.Sprintf("hats.%s.redhat.com", genName(""))
-		version := "v1alpha1"
-		mockGroupVersion := strings.Join([]string{mockGroup, version}, "/")
-		mockKinds := []string{"fedora"}
-		depSpec := newMockExtServerDeployment(depName, []mockGroupVersionKind{{depName, mockGroupVersion, mockKinds, 5443}})
-		apiServiceName := strings.Join([]string{version, mockGroup}, ".")
-
-		// Create CSVs for the hat-server
-		strategy := operatorsv1alpha1.StrategyDetailsDeployment{
-			DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
-				{
-					Name: depName,
-					Spec: depSpec,
-				},
-			},
-		}
-
-		owned := make([]operatorsv1alpha1.APIServiceDescription, len(mockKinds))
-		for i, kind := range mockKinds {
-			owned[i] = operatorsv1alpha1.APIServiceDescription{
-				Name:           apiServiceName,
-				Group:          mockGroup,
-				Version:        version,
-				Kind:           kind,
-				DeploymentName: depName,
-				ContainerPort:  int32(5443),
-				DisplayName:    kind,
-				Description:    fmt.Sprintf("A %s", kind),
 			}
-		}
 
-		csv := operatorsv1alpha1.ClusterServiceVersion{
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				MinKubeVersion: "0.0.0",
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Second CSV with owning CRD v1alpha1 and v1alpha2
+			csvNew := operatorsv1alpha1.ClusterServiceVersion{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+					APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: genName("csv2"),
+				},
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					Replaces: csv.Name,
+					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
 					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
+					InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+						StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
+						StrategySpec: strategyNew,
 					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
+					CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
+						Owned: []operatorsv1alpha1.CRDDescription{
+							{
+								Name:        crdName,
+								Version:     "v1alpha1",
+								Kind:        crdPlural,
+								DisplayName: crdName,
+								Description: "In the cluster4",
+							},
+							{
+								Name:        crdName,
+								Version:     "v1alpha2",
+								Kind:        crdPlural,
+								DisplayName: crdName,
+								Description: "In the cluster4",
+							},
+						},
 					},
 				},
-				InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
-					StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
-					StrategySpec: strategy,
-				},
-				APIServiceDefinitions: operatorsv1alpha1.APIServiceDefinitions{
-					Owned: owned,
-				},
-			},
-		}
-		csv.SetName("csv-hat-1")
-		csv.SetNamespace(testNamespace)
+			}
 
-		createLegacyAPIResources(nil, owned[0])
+			// Create newly updated CSV
+			_, err = createCSV(c, crc, csvNew, ns.GetName(), false, false)
+			Expect(err).ShouldNot(HaveOccurred())
 
-		// Create the APIService CSV
-		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCSV()
+			// Wait for updated CSV to succeed
+			fetchedCSV, err := fetchCSV(crc, csvNew.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
 
-		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
+			// Fetch cluster service version again to check for unnecessary control loops
+			sameCSV, err := fetchCSV(crc, csvNew.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
 
-		checkLegacyAPIResources(owned[0], false)
+			// Should have created new deployment and deleted old one
+			depNew, err := c.GetDeployment(ns.GetName(), strategyNew.DeploymentSpecs[0].Name)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(depNew).ShouldNot(BeNil())
+			err = waitForDeploymentToDelete(ns.GetName(), c, strategy.DeploymentSpecs[0].Name)
+			Expect(err).ShouldNot(HaveOccurred())
 
-		// Cleanup the resources created for this test that were not cleaned up.
-		deleteLegacyAPIResources(owned[0])
-	})
-
-	It("multiple API services on a single pod", func() {
-
-		// Create the deployment that both APIServices will be deployed to.
-		depName := genName("hat-server")
-
-		// Define the expected mock APIService settings.
-		version := "v1alpha1"
-		apiService1Group := fmt.Sprintf("hats.%s.redhat.com", genName(""))
-		apiService1GroupVersion := strings.Join([]string{apiService1Group, version}, "/")
-		apiService1Kinds := []string{"fedora"}
-		apiService1Name := strings.Join([]string{version, apiService1Group}, ".")
-
-		apiService2Group := fmt.Sprintf("hats.%s.redhat.com", genName(""))
-		apiService2GroupVersion := strings.Join([]string{apiService2Group, version}, "/")
-		apiService2Kinds := []string{"fez"}
-		apiService2Name := strings.Join([]string{version, apiService2Group}, ".")
-
-		// Create the deployment spec with the two APIServices.
-		mockGroupVersionKinds := []mockGroupVersionKind{
-			{
-				depName,
-				apiService1GroupVersion,
-				apiService1Kinds,
-				5443,
-			},
-			{
-				depName,
-				apiService2GroupVersion,
-				apiService2Kinds,
-				5444,
-			},
-		}
-		depSpec := newMockExtServerDeployment(depName, mockGroupVersionKinds)
-
-		// Create the CSV.
-		strategy := operatorsv1alpha1.StrategyDetailsDeployment{
-			DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
-				{
-					Name: depName,
-					Spec: depSpec,
-				},
-			},
-		}
-
-		// Update the owned APIServices two include the two APIServices.
-		owned := []operatorsv1alpha1.APIServiceDescription{
-			{
-				Name:           apiService1Name,
-				Group:          apiService1Group,
-				Version:        version,
-				Kind:           apiService1Kinds[0],
-				DeploymentName: depName,
-				ContainerPort:  int32(5443),
-				DisplayName:    apiService1Kinds[0],
-				Description:    fmt.Sprintf("A %s", apiService1Kinds[0]),
-			},
-			{
-				Name:           apiService2Name,
-				Group:          apiService2Group,
-				Version:        version,
-				Kind:           apiService2Kinds[0],
-				DeploymentName: depName,
-				ContainerPort:  int32(5444),
-				DisplayName:    apiService2Kinds[0],
-				Description:    fmt.Sprintf("A %s", apiService2Kinds[0]),
-			},
-		}
-
-		csv := operatorsv1alpha1.ClusterServiceVersion{
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				MinKubeVersion: "0.0.0",
-				InstallModes: []operatorsv1alpha1.InstallMode{
+			// Create updated deployment strategy
+			strategyNew2 := operatorsv1alpha1.StrategyDetailsDeployment{
+				DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
 					{
-						Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
-						Supported: true,
-					},
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
+						Name: genName("dep3-"),
+						Spec: newNginxDeployment(genName("nginx-")),
 					},
 				},
-				InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
-					StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
-					StrategySpec: strategy,
+			}
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Third CSV with owning CRD v1alpha2
+			csvNew2 := operatorsv1alpha1.ClusterServiceVersion{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+					APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
 				},
-				APIServiceDefinitions: operatorsv1alpha1.APIServiceDefinitions{
-					Owned: owned,
+				ObjectMeta: metav1.ObjectMeta{
+					Name: genName("csv3"),
 				},
-			},
-		}
-		csv.SetName("csv-hat-1")
-		csv.SetNamespace(testNamespace)
-
-		// Create the APIService CSV
-		cleanupCSV, err := createCSV(c, crc, csv, testNamespace, false, false)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer cleanupCSV()
-
-		_, err = fetchCSV(crc, csv.Name, testNamespace, csvSucceededChecker)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Check that the APIService caBundles are equal
-		apiService1, err := c.GetAPIService(apiService1Name)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		apiService2, err := c.GetAPIService(apiService2Name)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		Expect(apiService2.Spec.CABundle).Should(Equal(apiService1.Spec.CABundle))
-	})
-})
-
-var _ = Describe("Disabling copied CSVs", func() {
-	var (
-		ns  corev1.Namespace
-		csv operatorsv1alpha1.ClusterServiceVersion
-	)
-
-	BeforeEach(func() {
-		nsname := genName("csv-toggle-test-")
-		og := operatorsv1.OperatorGroup{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-operatorgroup", nsname),
-				Namespace: nsname,
-			},
-		}
-		ns = SetupGeneratedTestNamespaceWithOperatorGroup(nsname, og)
-
-		csv = operatorsv1alpha1.ClusterServiceVersion{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      genName("csv-toggle-test-"),
-				Namespace: nsname,
-			},
-			Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
-				InstallStrategy: newNginxInstallStrategy(genName("csv-toggle-test-"), nil, nil),
-				InstallModes: []operatorsv1alpha1.InstallMode{
-					{
-						Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
-						Supported: true,
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					Replaces: csvNew.Name,
+					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
+					},
+					InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+						StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
+						StrategySpec: strategyNew2,
+					},
+					CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
+						Owned: []operatorsv1alpha1.CRDDescription{
+							{
+								Name:        crdName,
+								Version:     "v1alpha2",
+								Kind:        crdPlural,
+								DisplayName: crdName,
+								Description: "In the cluster4",
+							},
+						},
 					},
 				},
-			},
-		}
-		err := ctx.Ctx().Client().Create(context.Background(), &csv)
-		Expect(err).ShouldNot(HaveOccurred())
-	})
-	AfterEach(func() {
-		Eventually(func() error {
-			err := ctx.Ctx().Client().Delete(context.Background(), &csv)
-			if err != nil && apierrors.IsNotFound(err) {
+			}
+
+			// Create newly updated CSV
+			cleanupNewCSV, err := createCSV(c, crc, csvNew2, ns.GetName(), true, false)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupNewCSV()
+
+			// Wait for updated CSV to succeed
+			fetchedCSV, err = fetchCSV(crc, csvNew2.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Fetch cluster service version again to check for unnecessary control loops
+			sameCSV, err = fetchCSV(crc, csvNew2.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
+
+			// Should have created new deployment and deleted old one
+			depNew, err = c.GetDeployment(ns.GetName(), strategyNew2.DeploymentSpecs[0].Name)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(depNew).ShouldNot(BeNil())
+			err = waitForDeploymentToDelete(ns.GetName(), c, strategyNew.DeploymentSpecs[0].Name)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Should clean up the CSV
+			Eventually(func() bool {
+				return csvExists(ns.GetName(), crc, csvNew.Name)
+			}).Should(BeFalse())
+		})
+
+		It("update modify deployment name", func() {
+
+			// Create dependency first (CRD)
+			crdPlural := genName("ins2")
+			crdName := crdPlural + ".cluster.com"
+			cleanupCRD, err := createCRD(c, apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: crdName,
+				},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "cluster.com",
+					Versions: []apiextensions.CustomResourceDefinitionVersion{
+						{
+							Name:    "v1alpha1",
+							Served:  true,
+							Storage: true,
+							Schema: &apiextensions.CustomResourceValidation{
+								OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+									Type:        "object",
+									Description: "my crd schema",
+								},
+							},
+						},
+					},
+					Names: apiextensions.CustomResourceDefinitionNames{
+						Plural:   crdPlural,
+						Singular: crdPlural,
+						Kind:     crdPlural,
+						ListKind: "list" + crdPlural,
+					},
+					Scope: apiextensions.NamespaceScoped,
+				},
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCRD()
+
+			// create "current" CSV
+			strategy := operatorsv1alpha1.StrategyDetailsDeployment{
+				DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
+					{
+						Name: genName("dep-"),
+						Spec: newNginxDeployment(genName("nginx-")),
+					},
+					{
+						Name: "dep2-test",
+						Spec: newNginxDeployment("nginx2"),
+					},
+				},
+			}
+
+			Expect(err).ShouldNot(HaveOccurred())
+
+			csv := operatorsv1alpha1.ClusterServiceVersion{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+					APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: genName("csv"),
+				},
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
+					},
+					InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+						StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
+						StrategySpec: strategy,
+					},
+					CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
+						Owned: []operatorsv1alpha1.CRDDescription{
+							{
+								Name:        crdName,
+								Version:     "v1alpha1",
+								Kind:        crdPlural,
+								DisplayName: crdName,
+								Description: "In the cluster2",
+							},
+						},
+					},
+				},
+			}
+
+			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), true, false)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCSV()
+
+			// Wait for current CSV to succeed
+			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Should have created deployments
+			dep, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[0].Name)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(dep).ShouldNot(BeNil())
+			dep2, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[1].Name)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(dep2).ShouldNot(BeNil())
+
+			// Create "updated" CSV
+			strategyNew := operatorsv1alpha1.StrategyDetailsDeployment{
+				DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
+					{
+						Name: genName("dep3-"),
+						Spec: newNginxDeployment(genName("nginx3-")),
+					},
+					{
+						Name: "dep2-test",
+						Spec: newNginxDeployment("nginx2"),
+					},
+				},
+			}
+
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Fetch the current csv
+			fetchedCSV, err := fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Update csv with same strategy with different deployment's name
+			fetchedCSV.Spec.InstallStrategy.StrategySpec = strategyNew
+
+			// Update the current csv with the new csv
+			_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Update(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Wait for new deployment to exist
+			err = waitForDeployment(ns.GetName(), c, strategyNew.DeploymentSpecs[0].Name)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Wait for updated CSV to succeed
+			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Should have created new deployment and deleted old
+			depNew, err := c.GetDeployment(ns.GetName(), strategyNew.DeploymentSpecs[0].Name)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(depNew).ShouldNot(BeNil())
+
+			// Make sure the unchanged deployment still exists
+			depNew2, err := c.GetDeployment(ns.GetName(), strategyNew.DeploymentSpecs[1].Name)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(depNew2).ShouldNot(BeNil())
+
+			err = waitForDeploymentToDelete(ns.GetName(), c, strategy.DeploymentSpecs[0].Name)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("update deployment spec in an existing CSV for a hotfix", func() {
+
+			c := newKubeClient()
+			crc := newCRClient()
+
+			// Create dependency first (CRD)
+			crdPlural := genName("ins")
+			crdName := crdPlural + ".cluster.com"
+			cleanupCRD, err := createCRD(c, apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: crdName,
+				},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "cluster.com",
+					Versions: []apiextensions.CustomResourceDefinitionVersion{
+						{
+							Name:    "v1alpha1",
+							Served:  true,
+							Storage: true,
+							Schema: &apiextensions.CustomResourceValidation{
+								OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+									Type:        "object",
+									Description: "my crd schema",
+								},
+							},
+						},
+					},
+					Names: apiextensions.CustomResourceDefinitionNames{
+						Plural:   crdPlural,
+						Singular: crdPlural,
+						Kind:     crdPlural,
+						ListKind: "list" + crdPlural,
+					},
+					Scope: apiextensions.NamespaceScoped,
+				},
+			})
+			defer cleanupCRD()
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Create "current" CSV
+			nginxName := genName("nginx-")
+			strategy := operatorsv1alpha1.StrategyDetailsDeployment{
+				DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
+					{
+						Name: genName("dep-"),
+						Spec: newNginxDeployment(nginxName),
+					},
+				},
+			}
+
+			csv := operatorsv1alpha1.ClusterServiceVersion{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+					APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: genName("csv"),
+				},
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					MinKubeVersion: "0.0.0",
+					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
+					},
+					InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+						StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
+						StrategySpec: strategy,
+					},
+					CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
+						Owned: []operatorsv1alpha1.CRDDescription{
+							{
+								Name:        crdName,
+								Version:     "v1alpha1",
+								Kind:        crdPlural,
+								DisplayName: crdName,
+								Description: "In the cluster",
+							},
+						},
+					},
+				},
+			}
+
+			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), true, false)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCSV()
+
+			// Wait for current CSV to succeed
+			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Should have created deployment
+			dep, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[0].Name)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(dep).ShouldNot(BeNil())
+
+			// Create "updated" CSV
+			strategyNew := operatorsv1alpha1.StrategyDetailsDeployment{
+				DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
+					{
+						// Same name
+						Name: strategy.DeploymentSpecs[0].Name,
+						// Different spec
+						Spec: newNginxDeployment(nginxName),
+					},
+				},
+			}
+
+			// Fetch the current csv
+			fetchedCSV, err := fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Update csv with modified deployment spec
+			fetchedCSV.Spec.InstallStrategy.StrategySpec = strategyNew
+
+			Eventually(func() error {
+				// Update the current csv
+				_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Update(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
 				return err
+			}).Should(Succeed())
+
+			// Wait for updated CSV to succeed
+			_, err = fetchCSV(crc, csv.Name, ns.GetName(), func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
+
+				// Should have updated existing deployment
+				depUpdated, err := c.GetDeployment(ns.GetName(), strategyNew.DeploymentSpecs[0].Name)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(depUpdated).ShouldNot(BeNil())
+				// container name has been updated and differs from initial CSV spec and updated CSV spec
+				Expect(depUpdated.Spec.Template.Spec.Containers[0].Name).ShouldNot(Equal(strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Name))
+
+				// Check for success
+				return csvSucceededChecker(csv)
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+
+		})
+		It("emits CSV requirement events", func() {
+
+			csv := &operatorsv1alpha1.ClusterServiceVersion{
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					MinKubeVersion: "0.0.0",
+					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
+					},
+					InstallStrategy: newNginxInstallStrategy(genName("dep-"), nil, nil),
+					APIServiceDefinitions: operatorsv1alpha1.APIServiceDefinitions{
+						// Require an API that we know won't exist under our domain
+						Required: []operatorsv1alpha1.APIServiceDescription{
+							{
+								Group:   "bad.packages.operators.coreos.com",
+								Version: "v1",
+								Kind:    "PackageManifest",
+							},
+						},
+					},
+				},
+			}
+			csv.SetNamespace(ns.GetName())
+			csv.SetName(genName("csv-"))
+
+			clientCtx := context.Background()
+			listOpts := metav1.ListOptions{
+				FieldSelector: "involvedObject.kind=ClusterServiceVersion",
+			}
+			events, err := c.KubernetesInterface().CoreV1().Events(csv.GetNamespace()).List(clientCtx, listOpts)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Watch latest events from test namespace for CSV
+			listOpts.ResourceVersion = events.ResourceVersion
+			w, err := c.KubernetesInterface().CoreV1().Events(ns.GetName()).Watch(context.Background(), listOpts)
+			Expect(err).ToNot(HaveOccurred())
+			defer w.Stop()
+
+			cleanupCSV, err := createCSV(c, crc, *csv, csv.GetNamespace(), false, false)
+			Expect(err).ToNot(HaveOccurred())
+			defer cleanupCSV()
+
+			By("emitting when requirements are not met")
+			nextReason := func() string {
+				if e := <-w.ResultChan(); e.Object != nil {
+					return e.Object.(*corev1.Event).Reason
+				}
+				return ""
+			}
+			Eventually(nextReason).Should(Equal("RequirementsNotMet"))
+
+			// Patch the CSV to require an API that we know exists
+			Eventually(ctx.Ctx().SSAClient().Apply(clientCtx, csv, func(c *operatorsv1alpha1.ClusterServiceVersion) error {
+				c.Spec.APIServiceDefinitions.Required[0].Group = "packages.operators.coreos.com"
+				return nil
+			})).Should(Succeed())
+
+			By("emitting when requirements are met")
+			Eventually(nextReason).Should(Equal("AllRequirementsMet"))
+		})
+
+		// TODO: test behavior when replaces field doesn't point to existing CSV
+		It("status invalid CSV", func() {
+
+			// Create CRD
+			crdPlural := genName("ins")
+			crdName := crdPlural + ".cluster.com"
+			cleanupCRD, err := createCRD(c, apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: crdName,
+				},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "cluster.com",
+					Versions: []apiextensions.CustomResourceDefinitionVersion{
+						{
+							Name:    "v1alpha1",
+							Served:  true,
+							Storage: true,
+							Schema: &apiextensions.CustomResourceValidation{
+								OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+									Type:        "object",
+									Description: "my crd schema",
+								},
+							},
+						},
+					},
+					Names: apiextensions.CustomResourceDefinitionNames{
+						Plural:   crdPlural,
+						Singular: crdPlural,
+						Kind:     crdPlural,
+						ListKind: "list" + crdPlural,
+					},
+					Scope: apiextensions.NamespaceScoped,
+				},
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCRD()
+
+			// create CSV
+			strategy := operatorsv1alpha1.StrategyDetailsDeployment{
+				DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
+					{
+						Name: genName("dep-"),
+						Spec: newNginxDeployment(genName("nginx-")),
+					},
+				},
+			}
+			Expect(err).ShouldNot(HaveOccurred())
+
+			csv := operatorsv1alpha1.ClusterServiceVersion{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+					APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: genName("csv"),
+				},
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
+					},
+					InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+						StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
+						StrategySpec: strategy,
+					},
+					CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
+						Owned: []operatorsv1alpha1.CRDDescription{
+							{
+								Name:        crdName,
+								Version:     "apiextensions.k8s.io/v1alpha1", // purposely invalid, should be just v1alpha1 to match CRD
+								Kind:        crdPlural,
+								DisplayName: crdName,
+								Description: "In the cluster2",
+							},
+						},
+					},
+				},
 			}
 
-			return nil
-		}).Should(Succeed())
-		TeardownNamespace(ns.GetName())
-		Eventually(func() error {
-			var namespace corev1.Namespace
-			return ctx.Ctx().Client().Get(context.Background(), client.ObjectKeyFromObject(&ns), &namespace)
-		}).Should(WithTransform(apierrors.IsNotFound, BeTrue()))
-	})
+			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), true, false)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCSV()
 
-	When("an operator is installed in AllNamespace mode", func() {
-		// issue: https://github.com/operator-framework/operator-lifecycle-manager/issues/2643
-		It("[FLAKE] should have Copied CSVs in all other namespaces", func() {
-			Eventually(func() error {
-				requirement, err := k8slabels.NewRequirement(operatorsv1alpha1.CopiedLabelKey, selection.Equals, []string{csv.GetNamespace()})
-				if err != nil {
-					return err
-				}
-
-				var copiedCSVs operatorsv1alpha1.ClusterServiceVersionList
-				err = ctx.Ctx().Client().List(context.TODO(), &copiedCSVs, &client.ListOptions{
-					LabelSelector: k8slabels.NewSelector().Add(*requirement),
-				})
-				if err != nil {
-					return err
-				}
-
-				var namespaces corev1.NamespaceList
-				if err := ctx.Ctx().Client().List(context.TODO(), &namespaces, &client.ListOptions{}); err != nil {
-					return err
-				}
-
-				if len(namespaces.Items)-1 != len(copiedCSVs.Items) {
-					return fmt.Errorf("%d copied CSVs found, expected %d", len(copiedCSVs.Items), len(namespaces.Items)-1)
-				}
-
-				return nil
-			}).Should(Succeed())
-		})
-	})
-
-	When("Copied CSVs are disabled", func() {
-		BeforeEach(func() {
-			Eventually(func() error {
-				var olmConfig operatorsv1.OLMConfig
-				if err := ctx.Ctx().Client().Get(context.TODO(), apitypes.NamespacedName{Name: "cluster"}, &olmConfig); err != nil {
-					ctx.Ctx().Logf("Error getting olmConfig %v", err)
-					return err
-				}
-
-				// Exit early if copied CSVs are disabled.
-				if !olmConfig.CopiedCSVsAreEnabled() {
-					return nil
-				}
-
-				olmConfig.Spec = operatorsv1.OLMConfigSpec{
-					Features: &operatorsv1.Features{
-						DisableCopiedCSVs: getPointer(true),
-					},
-				}
-
-				if err := ctx.Ctx().Client().Update(context.TODO(), &olmConfig); err != nil {
-					ctx.Ctx().Logf("Error setting olmConfig %v", err)
-					return err
-				}
-
-				return nil
-			}).Should(Succeed())
-		})
-
-		It("should not have any copied CSVs", func() {
-			Eventually(func() error {
-				requirement, err := k8slabels.NewRequirement(operatorsv1alpha1.CopiedLabelKey, selection.Equals, []string{csv.GetNamespace()})
-				if err != nil {
-					return err
-				}
-
-				var copiedCSVs operatorsv1alpha1.ClusterServiceVersionList
-				err = ctx.Ctx().Client().List(context.TODO(), &copiedCSVs, &client.ListOptions{
-					LabelSelector: k8slabels.NewSelector().Add(*requirement),
-				})
-				if err != nil {
-					return err
-				}
-
-				if numCSVs := len(copiedCSVs.Items); numCSVs != 0 {
-					return fmt.Errorf("Found %d copied CSVs, should be 0", numCSVs)
-				}
-				return nil
-			}).Should(Succeed())
-		})
-
-		// issue: https://github.com/operator-framework/operator-lifecycle-manager/issues/2634
-		It("[FLAKE] should be reflected in the olmConfig.Status.Condition array that the expected number of copied CSVs exist", func() {
-			Eventually(func() error {
-				var olmConfig operatorsv1.OLMConfig
-				if err := ctx.Ctx().Client().Get(context.TODO(), apitypes.NamespacedName{Name: "cluster"}, &olmConfig); err != nil {
-					return err
-				}
-
-				foundCondition := meta.FindStatusCondition(olmConfig.Status.Conditions, operatorsv1.DisabledCopiedCSVsConditionType)
-				if foundCondition == nil {
-					return fmt.Errorf("%s condition not found", operatorsv1.DisabledCopiedCSVsConditionType)
-				}
-
-				expectedCondition := metav1.Condition{
-					Reason:  "NoCopiedCSVsFound",
-					Message: "Copied CSVs are disabled and none were found for operators installed in AllNamespace mode",
-					Status:  metav1.ConditionTrue,
-				}
-
-				if foundCondition.Reason != expectedCondition.Reason ||
-					foundCondition.Message != expectedCondition.Message ||
-					foundCondition.Status != expectedCondition.Status {
-					return fmt.Errorf("condition does not have expected reason, message, and status. Expected %v, got %v", expectedCondition, foundCondition)
-				}
-
-				return nil
-			}).Should(Succeed())
-		})
-	})
-
-	When("Copied CSVs are toggled back on", func() {
-		BeforeEach(func() {
-			Eventually(func() error {
-				var olmConfig operatorsv1.OLMConfig
-				if err := ctx.Ctx().Client().Get(context.TODO(), apitypes.NamespacedName{Name: "cluster"}, &olmConfig); err != nil {
-					return err
-				}
-
-				// Exit early if copied CSVs are enabled.
-				if olmConfig.CopiedCSVsAreEnabled() {
-					return nil
-				}
-
-				olmConfig.Spec = operatorsv1.OLMConfigSpec{
-					Features: &operatorsv1.Features{
-						DisableCopiedCSVs: getPointer(false),
-					},
-				}
-
-				if err := ctx.Ctx().Client().Update(context.TODO(), &olmConfig); err != nil {
-					return err
-				}
-
-				return nil
-			}).Should(Succeed())
-		})
-
-		// issue: https://github.com/operator-framework/operator-lifecycle-manager/issues/2634
-		It("[FLAKE] should have copied CSVs in all other Namespaces", func() {
-			Eventually(func() error {
-				// find copied csvs...
-				requirement, err := k8slabels.NewRequirement(operatorsv1alpha1.CopiedLabelKey, selection.Equals, []string{csv.GetNamespace()})
-				if err != nil {
-					return err
-				}
-
-				var copiedCSVs operatorsv1alpha1.ClusterServiceVersionList
-				err = ctx.Ctx().Client().List(context.TODO(), &copiedCSVs, &client.ListOptions{
-					LabelSelector: k8slabels.NewSelector().Add(*requirement),
-				})
-				if err != nil {
-					return err
-				}
-
-				var namespaces corev1.NamespaceList
-				if err := ctx.Ctx().Client().List(context.TODO(), &namespaces, &client.ListOptions{FieldSelector: fields.SelectorFromSet(map[string]string{"status.phase": "Active"})}); err != nil {
-					return err
-				}
-
-				targetNamespaces := len(namespaces.Items) - 1
-				for _, ns := range namespaces.Items {
-					// filter out any namespaces that are currently reporting a Terminating phase
-					// as the API server will reject any resource events in terminating namespaces.
-					if ns.Status.Phase == "Terminating" {
-						targetNamespaces--
+			notServedStatus := operatorsv1alpha1.RequirementStatus{
+				Group:   "apiextensions.k8s.io",
+				Version: "v1",
+				Kind:    "CustomResourceDefinition",
+				Name:    crdName,
+				Status:  operatorsv1alpha1.RequirementStatusReasonNotPresent,
+				Message: "CRD version not served",
+			}
+			csvCheckPhaseAndRequirementStatus := func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
+				if csv.Status.Phase == operatorsv1alpha1.CSVPhasePending {
+					for _, status := range csv.Status.RequirementStatus {
+						if status.Message == notServedStatus.Message {
+							return true
+						}
 					}
 				}
-				if targetNamespaces != len(copiedCSVs.Items) {
-					return fmt.Errorf("%d copied CSVs found, expected %d", len(copiedCSVs.Items), targetNamespaces)
-				}
-				return nil
-			}).Should(Succeed())
+				return false
+			}
+
+			fetchedCSV, err := fetchCSV(crc, csv.Name, ns.GetName(), csvCheckPhaseAndRequirementStatus)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(fetchedCSV.Status.RequirementStatus).Should(ContainElement(notServedStatus))
 		})
 
-		// issue: https://github.com/operator-framework/operator-lifecycle-manager/issues/2641
-		It("[FLAKE] should be reflected in the olmConfig.Status.Condition array that the expected number of copied CSVs exist", func() {
-			Eventually(func() error {
-				var olmConfig operatorsv1.OLMConfig
-				if err := ctx.Ctx().Client().Get(context.TODO(), apitypes.NamespacedName{Name: "cluster"}, &olmConfig); err != nil {
-					return err
-				}
-				foundCondition := meta.FindStatusCondition(olmConfig.Status.Conditions, operatorsv1.DisabledCopiedCSVsConditionType)
-				if foundCondition == nil {
-					return fmt.Errorf("%s condition not found", operatorsv1.DisabledCopiedCSVsConditionType)
-				}
+		It("api service resource migrated if adoptable", func() {
 
-				expectedCondition := metav1.Condition{
-					Reason:  "CopiedCSVsEnabled",
-					Message: "Copied CSVs are enabled and present across the cluster",
-					Status:  metav1.ConditionFalse,
-				}
+			depName := genName("hat-server")
+			mockGroup := fmt.Sprintf("hats.%s.redhat.com", genName(""))
+			version := "v1alpha1"
+			mockGroupVersion := strings.Join([]string{mockGroup, version}, "/")
+			mockKinds := []string{"fedora"}
+			depSpec := newMockExtServerDeployment(depName, []mockGroupVersionKind{{depName, mockGroupVersion, mockKinds, 5443}})
+			apiServiceName := strings.Join([]string{version, mockGroup}, ".")
 
-				if foundCondition.Reason != expectedCondition.Reason ||
-					foundCondition.Message != expectedCondition.Message ||
-					foundCondition.Status != expectedCondition.Status {
-					return fmt.Errorf("condition does not have expected reason, message, and status. Expected %v, got %v", expectedCondition, foundCondition)
-				}
+			// Create CSVs for the hat-server
+			strategy := operatorsv1alpha1.StrategyDetailsDeployment{
+				DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
+					{
+						Name: depName,
+						Spec: depSpec,
+					},
+				},
+			}
 
-				return nil
-			}).Should(Succeed())
+			owned := make([]operatorsv1alpha1.APIServiceDescription, len(mockKinds))
+			for i, kind := range mockKinds {
+				owned[i] = operatorsv1alpha1.APIServiceDescription{
+					Name:           apiServiceName,
+					Group:          mockGroup,
+					Version:        version,
+					Kind:           kind,
+					DeploymentName: depName,
+					ContainerPort:  int32(5443),
+					DisplayName:    kind,
+					Description:    fmt.Sprintf("A %s", kind),
+				}
+			}
+
+			csv := operatorsv1alpha1.ClusterServiceVersion{
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					MinKubeVersion: "0.0.0",
+					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
+					},
+					InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+						StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
+						StrategySpec: strategy,
+					},
+					APIServiceDefinitions: operatorsv1alpha1.APIServiceDefinitions{
+						Owned: owned,
+					},
+				},
+			}
+			csv.SetName("csv-hat-1")
+			csv.SetNamespace(ns.GetName())
+
+			createLegacyAPIResources(ns.GetName(), &csv, owned[0])
+
+			// Create the APIService CSV
+			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCSV()
+
+			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			checkLegacyAPIResources(ns.GetName(), owned[0], true)
+		})
+
+		It("API service resource not migrated if not adoptable", func() {
+
+			depName := genName("hat-server")
+			mockGroup := fmt.Sprintf("hats.%s.redhat.com", genName(""))
+			version := "v1alpha1"
+			mockGroupVersion := strings.Join([]string{mockGroup, version}, "/")
+			mockKinds := []string{"fedora"}
+			depSpec := newMockExtServerDeployment(depName, []mockGroupVersionKind{{depName, mockGroupVersion, mockKinds, 5443}})
+			apiServiceName := strings.Join([]string{version, mockGroup}, ".")
+
+			// Create CSVs for the hat-server
+			strategy := operatorsv1alpha1.StrategyDetailsDeployment{
+				DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
+					{
+						Name: depName,
+						Spec: depSpec,
+					},
+				},
+			}
+
+			owned := make([]operatorsv1alpha1.APIServiceDescription, len(mockKinds))
+			for i, kind := range mockKinds {
+				owned[i] = operatorsv1alpha1.APIServiceDescription{
+					Name:           apiServiceName,
+					Group:          mockGroup,
+					Version:        version,
+					Kind:           kind,
+					DeploymentName: depName,
+					ContainerPort:  int32(5443),
+					DisplayName:    kind,
+					Description:    fmt.Sprintf("A %s", kind),
+				}
+			}
+
+			csv := operatorsv1alpha1.ClusterServiceVersion{
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					MinKubeVersion: "0.0.0",
+					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
+					},
+					InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+						StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
+						StrategySpec: strategy,
+					},
+					APIServiceDefinitions: operatorsv1alpha1.APIServiceDefinitions{
+						Owned: owned,
+					},
+				},
+			}
+			csv.SetName("csv-hat-1")
+			csv.SetNamespace(ns.GetName())
+
+			createLegacyAPIResources(ns.GetName(), nil, owned[0])
+
+			// Create the APIService CSV
+			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCSV()
+
+			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			checkLegacyAPIResources(ns.GetName(), owned[0], false)
+
+			// Cleanup the resources created for this test that were not cleaned up.
+			deleteLegacyAPIResources(ns.GetName(), owned[0])
+		})
+
+		It("multiple API services on a single pod", func() {
+
+			// Create the deployment that both APIServices will be deployed to.
+			depName := genName("hat-server")
+
+			// Define the expected mock APIService settings.
+			version := "v1alpha1"
+			apiService1Group := fmt.Sprintf("hats.%s.redhat.com", genName(""))
+			apiService1GroupVersion := strings.Join([]string{apiService1Group, version}, "/")
+			apiService1Kinds := []string{"fedora"}
+			apiService1Name := strings.Join([]string{version, apiService1Group}, ".")
+
+			apiService2Group := fmt.Sprintf("hats.%s.redhat.com", genName(""))
+			apiService2GroupVersion := strings.Join([]string{apiService2Group, version}, "/")
+			apiService2Kinds := []string{"fez"}
+			apiService2Name := strings.Join([]string{version, apiService2Group}, ".")
+
+			// Create the deployment spec with the two APIServices.
+			mockGroupVersionKinds := []mockGroupVersionKind{
+				{
+					depName,
+					apiService1GroupVersion,
+					apiService1Kinds,
+					5443,
+				},
+				{
+					depName,
+					apiService2GroupVersion,
+					apiService2Kinds,
+					5444,
+				},
+			}
+			depSpec := newMockExtServerDeployment(depName, mockGroupVersionKinds)
+
+			// Create the CSV.
+			strategy := operatorsv1alpha1.StrategyDetailsDeployment{
+				DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
+					{
+						Name: depName,
+						Spec: depSpec,
+					},
+				},
+			}
+
+			// Update the owned APIServices two include the two APIServices.
+			owned := []operatorsv1alpha1.APIServiceDescription{
+				{
+					Name:           apiService1Name,
+					Group:          apiService1Group,
+					Version:        version,
+					Kind:           apiService1Kinds[0],
+					DeploymentName: depName,
+					ContainerPort:  int32(5443),
+					DisplayName:    apiService1Kinds[0],
+					Description:    fmt.Sprintf("A %s", apiService1Kinds[0]),
+				},
+				{
+					Name:           apiService2Name,
+					Group:          apiService2Group,
+					Version:        version,
+					Kind:           apiService2Kinds[0],
+					DeploymentName: depName,
+					ContainerPort:  int32(5444),
+					DisplayName:    apiService2Kinds[0],
+					Description:    fmt.Sprintf("A %s", apiService2Kinds[0]),
+				},
+			}
+
+			csv := operatorsv1alpha1.ClusterServiceVersion{
+				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+					MinKubeVersion: "0.0.0",
+					InstallModes: []operatorsv1alpha1.InstallMode{
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeOwnNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeSingleNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeMultiNamespace,
+							Supported: true,
+						},
+						{
+							Type:      operatorsv1alpha1.InstallModeTypeAllNamespaces,
+							Supported: true,
+						},
+					},
+					InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+						StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
+						StrategySpec: strategy,
+					},
+					APIServiceDefinitions: operatorsv1alpha1.APIServiceDefinitions{
+						Owned: owned,
+					},
+				},
+			}
+			csv.SetName("csv-hat-1")
+			csv.SetNamespace(ns.GetName())
+
+			// Create the APIService CSV
+			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cleanupCSV()
+
+			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Check that the APIService caBundles are equal
+			apiService1, err := c.GetAPIService(apiService1Name)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			apiService2, err := c.GetAPIService(apiService2Name)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(apiService2.Spec.CABundle).Should(Equal(apiService1.Spec.CABundle))
 		})
 	})
 })
@@ -4745,9 +4468,9 @@ func awaitCSV(c versioned.Interface, namespace, name string, checker csvConditio
 	return fetched, err
 }
 
-func waitForDeployment(c operatorclient.ClientInterface, name string) error {
+func waitForDeployment(namespace string, c operatorclient.ClientInterface, name string) error {
 	return wait.Poll(pollInterval, pollDuration, func() (bool, error) {
-		_, err := c.GetDeployment(testNamespace, name)
+		_, err := c.GetDeployment(namespace, name)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return false, nil
@@ -4758,12 +4481,12 @@ func waitForDeployment(c operatorclient.ClientInterface, name string) error {
 	})
 }
 
-func waitForDeploymentToDelete(c operatorclient.ClientInterface, name string) error {
+func waitForDeploymentToDelete(namespace string, c operatorclient.ClientInterface, name string) error {
 	var err error
 
 	Eventually(func() (bool, error) {
 		ctx.Ctx().Logf("waiting for deployment %s to delete", name)
-		_, err := c.GetDeployment(testNamespace, name)
+		_, err := c.GetDeployment(namespace, name)
 		if apierrors.IsNotFound(err) {
 			ctx.Ctx().Logf("deleted %s", name)
 			return true, nil
@@ -4777,8 +4500,8 @@ func waitForDeploymentToDelete(c operatorclient.ClientInterface, name string) er
 	return err
 }
 
-func csvExists(c versioned.Interface, name string) bool {
-	fetched, err := c.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Get(context.TODO(), name, metav1.GetOptions{})
+func csvExists(namespace string, c versioned.Interface, name string) bool {
+	fetched, err := c.OperatorsV1alpha1().ClusterServiceVersions(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		return false
 	}
@@ -4789,21 +4512,21 @@ func csvExists(c versioned.Interface, name string) bool {
 	return true
 }
 
-func deleteLegacyAPIResources(desc operatorsv1alpha1.APIServiceDescription) {
+func deleteLegacyAPIResources(namespace string, desc operatorsv1alpha1.APIServiceDescription) {
 	c := newKubeClient()
 
 	apiServiceName := fmt.Sprintf("%s.%s", desc.Version, desc.Group)
 
-	err := c.DeleteService(testNamespace, strings.Replace(apiServiceName, ".", "-", -1), &metav1.DeleteOptions{})
+	err := c.DeleteService(namespace, strings.Replace(apiServiceName, ".", "-", -1), &metav1.DeleteOptions{})
 	Expect(err).ShouldNot(HaveOccurred())
 
-	err = c.DeleteSecret(testNamespace, apiServiceName+"-cert", &metav1.DeleteOptions{})
+	err = c.DeleteSecret(namespace, apiServiceName+"-cert", &metav1.DeleteOptions{})
 	Expect(err).ShouldNot(HaveOccurred())
 
-	err = c.DeleteRole(testNamespace, apiServiceName+"-cert", &metav1.DeleteOptions{})
+	err = c.DeleteRole(namespace, apiServiceName+"-cert", &metav1.DeleteOptions{})
 	Expect(err).ShouldNot(HaveOccurred())
 
-	err = c.DeleteRoleBinding(testNamespace, apiServiceName+"-cert", &metav1.DeleteOptions{})
+	err = c.DeleteRoleBinding(namespace, apiServiceName+"-cert", &metav1.DeleteOptions{})
 	Expect(err).ShouldNot(HaveOccurred())
 
 	err = c.DeleteClusterRoleBinding(apiServiceName+"-system:auth-delegator", &metav1.DeleteOptions{})
@@ -4813,7 +4536,7 @@ func deleteLegacyAPIResources(desc operatorsv1alpha1.APIServiceDescription) {
 	Expect(err).ShouldNot(HaveOccurred())
 }
 
-func createLegacyAPIResources(csv *operatorsv1alpha1.ClusterServiceVersion, desc operatorsv1alpha1.APIServiceDescription) {
+func createLegacyAPIResources(namespace string, csv *operatorsv1alpha1.ClusterServiceVersion, desc operatorsv1alpha1.APIServiceDescription) {
 	c := newKubeClient()
 
 	apiServiceName := fmt.Sprintf("%s.%s", desc.Version, desc.Group)
@@ -4821,7 +4544,7 @@ func createLegacyAPIResources(csv *operatorsv1alpha1.ClusterServiceVersion, desc
 	// Attempt to create the legacy service
 	service := corev1.Service{}
 	service.SetName(strings.Replace(apiServiceName, ".", "-", -1))
-	service.SetNamespace(testNamespace)
+	service.SetNamespace(namespace)
 	if csv != nil {
 		err := ownerutil.AddOwnerLabels(&service, csv)
 		Expect(err).ShouldNot(HaveOccurred())
@@ -4834,7 +4557,7 @@ func createLegacyAPIResources(csv *operatorsv1alpha1.ClusterServiceVersion, desc
 	// Attempt to create the legacy secret
 	secret := corev1.Secret{}
 	secret.SetName(apiServiceName + "-cert")
-	secret.SetNamespace(testNamespace)
+	secret.SetNamespace(namespace)
 	if csv != nil {
 		err = ownerutil.AddOwnerLabels(&secret, csv)
 		Expect(err).ShouldNot(HaveOccurred())
@@ -4848,7 +4571,7 @@ func createLegacyAPIResources(csv *operatorsv1alpha1.ClusterServiceVersion, desc
 	// Attempt to create the legacy secret role
 	role := rbacv1.Role{}
 	role.SetName(apiServiceName + "-cert")
-	role.SetNamespace(testNamespace)
+	role.SetNamespace(namespace)
 	if csv != nil {
 		err = ownerutil.AddOwnerLabels(&role, csv)
 		Expect(err).ShouldNot(HaveOccurred())
@@ -4859,7 +4582,7 @@ func createLegacyAPIResources(csv *operatorsv1alpha1.ClusterServiceVersion, desc
 	// Attempt to create the legacy secret role binding
 	roleBinding := rbacv1.RoleBinding{}
 	roleBinding.SetName(apiServiceName + "-cert")
-	roleBinding.SetNamespace(testNamespace)
+	roleBinding.SetNamespace(namespace)
 	roleBinding.RoleRef = rbacv1.RoleRef{
 		APIGroup: "rbac.authorization.k8s.io",
 		Kind:     "Role",
@@ -4900,24 +4623,24 @@ func createLegacyAPIResources(csv *operatorsv1alpha1.ClusterServiceVersion, desc
 	Expect(err).ShouldNot(HaveOccurred())
 }
 
-func checkLegacyAPIResources(desc operatorsv1alpha1.APIServiceDescription, expectedIsNotFound bool) {
+func checkLegacyAPIResources(namespace string, desc operatorsv1alpha1.APIServiceDescription, expectedIsNotFound bool) {
 	c := newKubeClient()
 	apiServiceName := fmt.Sprintf("%s.%s", desc.Version, desc.Group)
 
 	// Attempt to create the legacy service
-	_, err := c.GetService(testNamespace, strings.Replace(apiServiceName, ".", "-", -1))
+	_, err := c.GetService(namespace, strings.Replace(apiServiceName, ".", "-", -1))
 	Expect(apierrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy secret
-	_, err = c.GetSecret(testNamespace, apiServiceName+"-cert")
+	_, err = c.GetSecret(namespace, apiServiceName+"-cert")
 	Expect(apierrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy secret role
-	_, err = c.GetRole(testNamespace, apiServiceName+"-cert")
+	_, err = c.GetRole(namespace, apiServiceName+"-cert")
 	Expect(apierrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy secret role binding
-	_, err = c.GetRoleBinding(testNamespace, apiServiceName+"-cert")
+	_, err = c.GetRoleBinding(namespace, apiServiceName+"-cert")
 	Expect(apierrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy authDelegatorClusterRoleBinding

--- a/staging/operator-lifecycle-manager/test/e2e/ctx/ctx.go
+++ b/staging/operator-lifecycle-manager/test/e2e/ctx/ctx.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	g "github.com/onsi/ginkgo"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
@@ -173,12 +174,12 @@ func setDerivedFields(ctx *TestContext) error {
 
 	ctx.scheme = runtime.NewScheme()
 	localSchemeBuilder := runtime.NewSchemeBuilder(
-		apiextensionsv1.AddToScheme,
 		kscheme.AddToScheme,
 		operatorsv1alpha1.AddToScheme,
 		operatorsv1.AddToScheme,
 		operatorsv2.AddToScheme,
 		apiextensionsv1.AddToScheme,
+		apiextensions.AddToScheme,
 	)
 	if err := localSchemeBuilder.AddToScheme(ctx.scheme); err != nil {
 		return err

--- a/staging/operator-lifecycle-manager/test/e2e/ctx/provisioner_kind.go
+++ b/staging/operator-lifecycle-manager/test/e2e/ctx/provisioner_kind.go
@@ -1,3 +1,4 @@
+//go:build kind
 // +build kind
 
 package ctx
@@ -135,10 +136,6 @@ func Provision(ctx *TestContext) (func(), error) {
 		return nil, fmt.Errorf("error loading kubeconfig: %s", err.Error())
 	}
 	ctx.restConfig = restConfig
-
-	if artifactsDir := os.Getenv("ARTIFACTS_DIR"); artifactsDir != "" {
-		ctx.artifactsDir = artifactsDir
-	}
 	ctx.kubeconfigPath = kubeconfigPath
 
 	var once sync.Once

--- a/staging/operator-lifecycle-manager/test/e2e/deprecated_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/deprecated_e2e_test.go
@@ -2,89 +2,92 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/blang/semver/v4"
 	. "github.com/onsi/ginkgo"
-	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/ctx"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/ctx"
 )
 
 var missingAPI = `{"apiVersion":"verticalpodautoscalers.autoscaling.k8s.io/v1","kind":"VerticalPodAutoscaler","metadata":{"name":"my.thing","namespace":"foo"}}`
 
 var _ = Describe("Not found APIs", func() {
+
+	var ns corev1.Namespace
+
 	BeforeEach(func() {
-		csv := newCSV("test-csv", testNamespace, "", semver.Version{}, nil, nil, nil)
+		namespaceName := genName("deprecated-e2e-")
+		og := operatorsv1.OperatorGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-operatorgroup", namespaceName),
+				Namespace: namespaceName,
+			},
+		}
+		ns = SetupGeneratedTestNamespaceWithOperatorGroup(namespaceName, og)
+
+		csv := newCSV("test-csv", ns.GetName(), "", semver.Version{}, nil, nil, nil)
 		Expect(ctx.Ctx().Client().Create(context.TODO(), &csv)).To(Succeed())
 	})
+
 	AfterEach(func() {
-		TearDown(testNamespace)
+		TeardownNamespace(ns.GetName())
 	})
 
-	When("objects with APIs that are not on-cluster are created in the installplan", func() {
-		// each entry is an installplan with a deprecated resource
-		type payload struct {
-			name       string
-			IP         *operatorsv1alpha1.InstallPlan
-			errMessage string
-		}
-
-		tableEntries := []table.TableEntry{
-			table.Entry("contains an entry with a missing API not found on cluster ", payload{
-				name: "installplan contains a missing API",
-				IP: &operatorsv1alpha1.InstallPlan{
+	Context("objects with APIs that are not on-cluster are created in the installplan", func() {
+		When("installplan contains a missing API", func() {
+			It("the ip enters a failed state with a helpful error message", func() {
+				ip := &operatorsv1alpha1.InstallPlan{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: *namespace, // this is necessary due to ginkgo table semantics, see https://github.com/onsi/ginkgo/issues/378
 						Name:      "test-plan-api",
+						Namespace: ns.GetName(),
 					},
 					Spec: operatorsv1alpha1.InstallPlanSpec{
 						Approval:                   operatorsv1alpha1.ApprovalAutomatic,
 						Approved:                   true,
 						ClusterServiceVersionNames: []string{},
 					},
-				},
-				errMessage: "api-server resource not found installing VerticalPodAutoscaler my.thing: GroupVersionKind " +
-					"verticalpodautoscalers.autoscaling.k8s.io/v1, Kind=VerticalPodAutoscaler not found on the cluster",
-			}),
-		}
+				}
+				Expect(ctx.Ctx().Client().Create(context.Background(), ip)).To(Succeed())
 
-		table.DescribeTable("the ip enters a failed state with a helpful error message", func(tt payload) {
-			Expect(ctx.Ctx().Client().Create(context.Background(), tt.IP)).To(Succeed())
-
-			tt.IP.Status = operatorsv1alpha1.InstallPlanStatus{
-				Phase:          operatorsv1alpha1.InstallPlanPhaseInstalling,
-				CatalogSources: []string{},
-				Plan: []*operatorsv1alpha1.Step{
-					{
-						Resolving: "test-csv",
-						Status:    operatorsv1alpha1.StepStatusUnknown,
-						Resource: operatorsv1alpha1.StepResource{
-							Name:     "my.thing",
-							Group:    "verticalpodautoscalers.autoscaling.k8s.io",
-							Version:  "v1",
-							Kind:     "VerticalPodAutoscaler",
-							Manifest: missingAPI,
+				ip.Status = operatorsv1alpha1.InstallPlanStatus{
+					Phase:          operatorsv1alpha1.InstallPlanPhaseInstalling,
+					CatalogSources: []string{},
+					Plan: []*operatorsv1alpha1.Step{
+						{
+							Resolving: "test-csv",
+							Status:    operatorsv1alpha1.StepStatusUnknown,
+							Resource: operatorsv1alpha1.StepResource{
+								Name:     "my.thing",
+								Group:    "verticalpodautoscalers.autoscaling.k8s.io",
+								Version:  "v1",
+								Kind:     "VerticalPodAutoscaler",
+								Manifest: missingAPI,
+							},
 						},
 					},
-				},
-			}
+				}
 
-			Expect(ctx.Ctx().Client().Status().Update(context.Background(), tt.IP)).To(Succeed(), "failed to update the resource")
+				Expect(ctx.Ctx().Client().Status().Update(context.Background(), ip)).To(Succeed(), "failed to update the resource")
 
-			// The IP sits in the Installing phase with the GVK missing error
-			Eventually(func() (*operatorsv1alpha1.InstallPlan, error) {
-				return tt.IP, ctx.Ctx().Client().Get(context.Background(), client.ObjectKeyFromObject(tt.IP), tt.IP)
-			}).Should(And(HavePhase(operatorsv1alpha1.InstallPlanPhaseInstalling)), HaveMessage(tt.errMessage))
+				errMessage := "api-server resource not found installing VerticalPodAutoscaler my.thing: GroupVersionKind " +
+					"verticalpodautoscalers.autoscaling.k8s.io/v1, Kind=VerticalPodAutoscaler not found on the cluster"
+				// The IP sits in the Installing phase with the GVK missing error
+				Eventually(func() (*operatorsv1alpha1.InstallPlan, error) {
+					return ip, ctx.Ctx().Client().Get(context.Background(), client.ObjectKeyFromObject(ip), ip)
+				}).Should(And(HavePhase(operatorsv1alpha1.InstallPlanPhaseInstalling)), HaveMessage(errMessage))
 
-			// Eventually the IP fails with the GVK missing error, after installplan retries, which is by default 1 minute.
-			Eventually(func() (*operatorsv1alpha1.InstallPlan, error) {
-				return tt.IP, ctx.Ctx().Client().Get(context.Background(), client.ObjectKeyFromObject(tt.IP), tt.IP)
-			}, 2*time.Minute).Should(And(HavePhase(operatorsv1alpha1.InstallPlanPhaseFailed)), HaveMessage(tt.errMessage))
-		}, tableEntries...)
+				// Eventually the IP fails with the GVK missing error, after installplan retries, which is by default 1 minute.
+				Eventually(func() (*operatorsv1alpha1.InstallPlan, error) {
+					return ip, ctx.Ctx().Client().Get(context.Background(), client.ObjectKeyFromObject(ip), ip)
+				}, 2*time.Minute).Should(And(HavePhase(operatorsv1alpha1.InstallPlanPhaseFailed)), HaveMessage(errMessage))
+			})
+		})
 	})
 })

--- a/staging/operator-lifecycle-manager/test/e2e/e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/e2e_test.go
@@ -42,6 +42,12 @@ var (
 		"dummy image to treat as an operator in tests",
 	)
 
+	collectArtifactsScriptPath = flag.String(
+		"gather-artifacts-script-path",
+		"./collect-ci-artifacts.sh",
+		"configures the relative/absolute path to the script resposible for collecting CI artifacts",
+	)
+
 	testdataPath = flag.String(
 		"test-data-dir",
 		"./testdata",
@@ -81,6 +87,9 @@ var _ = BeforeSuite(func() {
 	if kubeConfigPath != nil && *kubeConfigPath != "" {
 		// This flag can be deprecated in favor of the kubeconfig provisioner:
 		os.Setenv("KUBECONFIG", *kubeConfigPath)
+	}
+	if collectArtifactsScriptPath != nil && *collectArtifactsScriptPath != "" {
+		os.Setenv("E2E_ARTIFACTS_SCRIPT", *collectArtifactsScriptPath)
 	}
 
 	testNamespace = *namespace

--- a/staging/operator-lifecycle-manager/test/e2e/gc_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/gc_e2e_test.go
@@ -11,7 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
@@ -113,14 +113,14 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 				// Delete CRD
 				Eventually(func() bool {
 					err := kubeClient.ApiextensionsInterface().ApiextensionsV1().CustomResourceDefinitions().Delete(context.Background(), crd.GetName(), metav1.DeleteOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 			})
 
 			It("should delete the associated ClusterRole", func() {
 				Eventually(func() bool {
 					_, err := kubeClient.GetClusterRole(cr.GetName())
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue(), "get cluster role should eventually return \"not found\"")
 			})
 
@@ -183,14 +183,14 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 				// Delete API service
 				Eventually(func() bool {
 					err := kubeClient.DeleteAPIService(apiService.GetName(), &metav1.DeleteOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 			})
 
 			It("should delete the associated ClusterRole", func() {
 				Eventually(func() bool {
 					_, err := kubeClient.GetClusterRole(cr.GetName())
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue(), "get cluster role should eventually return \"not found\"")
 			})
 
@@ -260,13 +260,13 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 				// delete ownerA in the foreground (to ensure any "blocking" dependents are deleted before ownerA)
 				Eventually(func() bool {
 					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Delete(context.Background(), fetchedA.GetName(), options)
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// wait for deletion of ownerA
 				Eventually(func() bool {
 					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Get(context.Background(), ownerA.GetName(), metav1.GetOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 			})
 
@@ -285,32 +285,32 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 				// delete ownerA in the foreground (to ensure any "blocking" dependents are deleted before ownerA)
 				Eventually(func() bool {
 					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Delete(context.Background(), fetchedA.GetName(), options)
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// wait for deletion of ownerA
 				Eventually(func() bool {
 					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Get(context.Background(), ownerA.GetName(), metav1.GetOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// delete ownerB in the foreground (to ensure any "blocking" dependents are deleted before ownerB)
 				Eventually(func() bool {
 					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Delete(context.Background(), fetchedB.GetName(), options)
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// wait for deletion of ownerB
 				Eventually(func() bool {
 					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Get(context.Background(), ownerB.GetName(), metav1.GetOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 			})
 
 			It("should have deleted the dependent since both the owners were deleted", func() {
 				Eventually(func() bool {
 					_, err := kubeClient.KubernetesInterface().CoreV1().ConfigMaps(ns.GetName()).Get(context.Background(), dependent.GetName(), metav1.GetOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue(), "expected dependency configmap would be properly garabage collected")
 				ctx.Ctx().Logf("dependent successfully garbage collected after both owners were deleted")
 			})
@@ -400,25 +400,25 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 				// Delete subscription first
 				Eventually(func() bool {
 					err := operatorClient.OperatorsV1alpha1().Subscriptions(ns.GetName()).Delete(context.Background(), subName, metav1.DeleteOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// wait for deletion
 				Eventually(func() bool {
 					_, err := operatorClient.OperatorsV1alpha1().Subscriptions(ns.GetName()).Get(context.Background(), subName, metav1.GetOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// Delete CSV
 				Eventually(func() bool {
 					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Delete(context.Background(), csvName, metav1.DeleteOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// wait for deletion
 				Eventually(func() bool {
 					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Get(context.Background(), csvName, metav1.GetOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 			})
 
@@ -426,12 +426,12 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 				// confirm extra bundle objects (secret and configmap) are no longer installed on the cluster
 				Eventually(func() bool {
 					_, err := kubeClient.GetSecret(ns.GetName(), secretName)
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				Eventually(func() bool {
 					_, err := kubeClient.GetConfigMap(ns.GetName(), configmapName)
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 				ctx.Ctx().Logf("dependent successfully garbage collected after csv owner was deleted")
 			})
@@ -654,7 +654,7 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 			It("[FLAKE] should have removed the old configmap and put the new configmap in place", func() {
 				Eventually(func() bool {
 					_, err := kubeClient.GetConfigMap(ns.GetName(), configmapName)
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				Eventually(func() error {

--- a/staging/operator-lifecycle-manager/test/e2e/installplan_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/installplan_e2e_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -450,11 +450,11 @@ var _ = Describe("Install Plan", func() {
 		AfterEach(func() {
 			Expect(ctx.Ctx().Client().Delete(context.Background(), owned)).To(Or(
 				Succeed(),
-				WithTransform(k8serrors.IsNotFound, BeTrue()),
+				WithTransform(apierrors.IsNotFound, BeTrue()),
 			))
 			Expect(ctx.Ctx().Client().Delete(context.Background(), plan)).To(Or(
 				Succeed(),
-				WithTransform(k8serrors.IsNotFound, BeTrue()),
+				WithTransform(apierrors.IsNotFound, BeTrue()),
 			))
 		})
 
@@ -555,19 +555,19 @@ var _ = Describe("Install Plan", func() {
 		AfterEach(func() {
 			Expect(ctx.Ctx().Client().Delete(context.Background(), &sa)).To(Or(
 				Succeed(),
-				WithTransform(k8serrors.IsNotFound, BeTrue()),
+				WithTransform(apierrors.IsNotFound, BeTrue()),
 			))
 			Expect(ctx.Ctx().Client().Delete(context.Background(), &csv1)).To(Or(
 				Succeed(),
-				WithTransform(k8serrors.IsNotFound, BeTrue()),
+				WithTransform(apierrors.IsNotFound, BeTrue()),
 			))
 			Expect(ctx.Ctx().Client().Delete(context.Background(), &csv2)).To(Or(
 				Succeed(),
-				WithTransform(k8serrors.IsNotFound, BeTrue()),
+				WithTransform(apierrors.IsNotFound, BeTrue()),
 			))
 			Expect(ctx.Ctx().Client().Delete(context.Background(), &plan)).To(Or(
 				Succeed(),
-				WithTransform(k8serrors.IsNotFound, BeTrue()),
+				WithTransform(apierrors.IsNotFound, BeTrue()),
 			))
 		})
 
@@ -2859,7 +2859,7 @@ var _ = Describe("Install Plan", func() {
 				err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 					_, err = c.GetClusterRole(step.Resource.Name)
 					if err != nil {
-						if k8serrors.IsNotFound(err) {
+						if apierrors.IsNotFound(err) {
 							return false, nil
 						}
 						return false, err
@@ -2872,7 +2872,7 @@ var _ = Describe("Install Plan", func() {
 				err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 					_, err = c.GetClusterRoleBinding(step.Resource.Name)
 					if err != nil {
-						if k8serrors.IsNotFound(err) {
+						if apierrors.IsNotFound(err) {
 							return false, nil
 						}
 						return false, err
@@ -2967,7 +2967,7 @@ var _ = Describe("Install Plan", func() {
 			if err == nil {
 				return fmt.Errorf("The %v/%v ServiceAccount should have been deleted", ns.GetName(), serviceAccountName)
 			}
-			if !k8serrors.IsNotFound(err) {
+			if !apierrors.IsNotFound(err) {
 				return err
 			}
 			return nil
@@ -4306,7 +4306,7 @@ func waitForInstallPlan(c versioned.Interface, name string, namespace string, ch
 
 	err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 		fetchedInstallPlan, err = c.OperatorsV1alpha1().InstallPlans(namespace).Get(context.Background(), name, metav1.GetOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return false, err
 		}
 

--- a/staging/operator-lifecycle-manager/test/e2e/operator_condition_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/operator_condition_e2e_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	meta "k8s.io/apimachinery/pkg/api/meta"
@@ -18,8 +19,17 @@ import (
 )
 
 var _ = Describe("Operator Condition", func() {
+
+	var (
+		generatedNamespace corev1.Namespace
+	)
+
+	BeforeEach(func() {
+		generatedNamespace = SetupGeneratedTestNamespace(genName("operator-conditions-e2e-"))
+	})
+
 	AfterEach(func() {
-		TearDown(testNamespace)
+		TeardownNamespace(generatedNamespace.GetName())
 	})
 
 	It("OperatorCondition Upgradeable type and overrides", func() {
@@ -44,9 +54,9 @@ var _ = Describe("Operator Condition", func() {
 		strategyB := newNginxInstallStrategy(pkgBStable, nil, nil)
 		strategyD := newNginxInstallStrategy(pkgDStable, nil, nil)
 		crd := newCRD(genName(pkgA))
-		csvA := newCSV(pkgAStable, testNamespace, "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd}, nil, &strategyA)
-		csvB := newCSV(pkgBStable, testNamespace, pkgAStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{crd}, nil, &strategyB)
-		csvD := newCSV(pkgDStable, testNamespace, pkgBStable, semver.MustParse("0.3.0"), []apiextensions.CustomResourceDefinition{crd}, nil, &strategyD)
+		csvA := newCSV(pkgAStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd}, nil, &strategyA)
+		csvB := newCSV(pkgBStable, generatedNamespace.GetName(), pkgAStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{crd}, nil, &strategyB)
+		csvD := newCSV(pkgDStable, generatedNamespace.GetName(), pkgBStable, semver.MustParse("0.3.0"), []apiextensions.CustomResourceDefinition{crd}, nil, &strategyD)
 
 		// Create the initial catalogsources
 		manifests := []registry.PackageManifest{
@@ -60,15 +70,15 @@ var _ = Describe("Operator Condition", func() {
 		}
 
 		catalog := genName("catalog-")
-		_, cleanupCatalogSource := createInternalCatalogSource(c, crc, catalog, testNamespace, manifests, []apiextensions.CustomResourceDefinition{crd}, []operatorsv1alpha1.ClusterServiceVersion{csvA})
+		_, cleanupCatalogSource := createInternalCatalogSource(c, crc, catalog, generatedNamespace.GetName(), manifests, []apiextensions.CustomResourceDefinition{crd}, []operatorsv1alpha1.ClusterServiceVersion{csvA})
 		defer cleanupCatalogSource()
-		_, err := fetchCatalogSourceOnStatus(crc, catalog, testNamespace, catalogSourceRegistryPodSynced)
+		_, err := fetchCatalogSourceOnStatus(crc, catalog, generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 		subName := genName("sub-")
-		cleanupSub := createSubscriptionForCatalog(crc, testNamespace, subName, catalog, pkgA, stableChannel, pkgAStable, operatorsv1alpha1.ApprovalAutomatic)
+		cleanupSub := createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subName, catalog, pkgA, stableChannel, pkgAStable, operatorsv1alpha1.ApprovalAutomatic)
 		defer cleanupSub()
 
 		// Await csvA's success
-		_, err = awaitCSV(crc, testNamespace, csvA.GetName(), csvSucceededChecker)
+		_, err = awaitCSV(crc, generatedNamespace.GetName(), csvA.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Get the OperatorCondition for csvA and report that it is not upgradeable
@@ -83,14 +93,14 @@ var _ = Describe("Operator Condition", func() {
 
 		var currentGen int64
 		Eventually(func() error {
-			cond, err := crc.OperatorsV2().OperatorConditions(testNamespace).Get(context.TODO(), csvA.GetName(), metav1.GetOptions{})
+			cond, err := crc.OperatorsV2().OperatorConditions(generatedNamespace.GetName()).Get(context.TODO(), csvA.GetName(), metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
 			currentGen = cond.ObjectMeta.GetGeneration()
 			upgradeableFalseCondition.ObservedGeneration = currentGen
 			meta.SetStatusCondition(&cond.Spec.Conditions, upgradeableFalseCondition)
-			_, err = crc.OperatorsV2().OperatorConditions(testNamespace).Update(context.TODO(), cond, metav1.UpdateOptions{})
+			_, err = crc.OperatorsV2().OperatorConditions(generatedNamespace.GetName()).Update(context.TODO(), cond, metav1.UpdateOptions{})
 			return err
 		}, pollInterval, pollDuration).Should(Succeed())
 
@@ -104,14 +114,14 @@ var _ = Describe("Operator Condition", func() {
 				DefaultChannelName: stableChannel,
 			},
 		}
-		updateInternalCatalog(GinkgoT(), c, crc, catalog, testNamespace, []apiextensions.CustomResourceDefinition{crd}, []operatorsv1alpha1.ClusterServiceVersion{csvA, csvB}, manifests)
+		updateInternalCatalog(GinkgoT(), c, crc, catalog, generatedNamespace.GetName(), []apiextensions.CustomResourceDefinition{crd}, []operatorsv1alpha1.ClusterServiceVersion{csvA, csvB}, manifests)
 
 		// Attempt to get the catalog source before creating install plan(s)
-		_, err = fetchCatalogSourceOnStatus(crc, catalog, testNamespace, catalogSourceRegistryPodSynced)
+		_, err = fetchCatalogSourceOnStatus(crc, catalog, generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 		require.NoError(GinkgoT(), err)
 
 		// csvB will be in Pending phase due to csvA reports Upgradeable=False condition
-		fetchedCSV, err := fetchCSV(crc, csvB.GetName(), testNamespace, buildCSVReasonChecker(operatorsv1alpha1.CSVReasonOperatorConditionNotUpgradeable))
+		fetchedCSV, err := fetchCSV(crc, csvB.GetName(), generatedNamespace.GetName(), buildCSVReasonChecker(operatorsv1alpha1.CSVReasonOperatorConditionNotUpgradeable))
 		require.NoError(GinkgoT(), err)
 		require.Equal(GinkgoT(), fetchedCSV.Status.Phase, operatorsv1alpha1.CSVPhasePending)
 
@@ -124,32 +134,32 @@ var _ = Describe("Operator Condition", func() {
 			LastTransitionTime: metav1.Now(),
 		}
 		Eventually(func() error {
-			cond, err = crc.OperatorsV2().OperatorConditions(testNamespace).Get(context.TODO(), csvA.GetName(), metav1.GetOptions{})
+			cond, err = crc.OperatorsV2().OperatorConditions(generatedNamespace.GetName()).Get(context.TODO(), csvA.GetName(), metav1.GetOptions{})
 			if err != nil || currentGen == cond.ObjectMeta.GetGeneration() {
 				return err
 			}
 			currentGen = cond.ObjectMeta.GetGeneration()
 			upgradeableTrueCondition.ObservedGeneration = cond.ObjectMeta.GetGeneration()
 			meta.SetStatusCondition(&cond.Spec.Conditions, upgradeableTrueCondition)
-			_, err = crc.OperatorsV2().OperatorConditions(testNamespace).Update(context.TODO(), cond, metav1.UpdateOptions{})
+			_, err = crc.OperatorsV2().OperatorConditions(generatedNamespace.GetName()).Update(context.TODO(), cond, metav1.UpdateOptions{})
 			return err
 		}, pollInterval, pollDuration).Should(Succeed())
 
 		// Await csvB's success
-		_, err = awaitCSV(crc, testNamespace, csvB.GetName(), csvSucceededChecker)
+		_, err = awaitCSV(crc, generatedNamespace.GetName(), csvB.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Get the OperatorCondition for csvB and purposedly change ObservedGeneration
 		// to cause mismatch generation situation
 		Eventually(func() error {
-			cond, err = crc.OperatorsV2().OperatorConditions(testNamespace).Get(context.TODO(), csvB.GetName(), metav1.GetOptions{})
+			cond, err = crc.OperatorsV2().OperatorConditions(generatedNamespace.GetName()).Get(context.TODO(), csvB.GetName(), metav1.GetOptions{})
 			if err != nil || currentGen == cond.ObjectMeta.GetGeneration() {
 				return err
 			}
 			currentGen = cond.ObjectMeta.GetGeneration()
 			upgradeableTrueCondition.ObservedGeneration = currentGen + 1
 			meta.SetStatusCondition(&cond.Status.Conditions, upgradeableTrueCondition)
-			_, err = crc.OperatorsV2().OperatorConditions(testNamespace).UpdateStatus(context.TODO(), cond, metav1.UpdateOptions{})
+			_, err = crc.OperatorsV2().OperatorConditions(generatedNamespace.GetName()).UpdateStatus(context.TODO(), cond, metav1.UpdateOptions{})
 			return err
 		}, pollInterval, pollDuration).Should(Succeed())
 
@@ -164,31 +174,31 @@ var _ = Describe("Operator Condition", func() {
 			},
 		}
 
-		updateInternalCatalog(GinkgoT(), c, crc, catalog, testNamespace, []apiextensions.CustomResourceDefinition{crd}, []operatorsv1alpha1.ClusterServiceVersion{csvA, csvB, csvD}, manifests)
+		updateInternalCatalog(GinkgoT(), c, crc, catalog, generatedNamespace.GetName(), []apiextensions.CustomResourceDefinition{crd}, []operatorsv1alpha1.ClusterServiceVersion{csvA, csvB, csvD}, manifests)
 		// Attempt to get the catalog source before creating install plan(s)
-		_, err = fetchCatalogSourceOnStatus(crc, catalog, testNamespace, catalogSourceRegistryPodSynced)
+		_, err = fetchCatalogSourceOnStatus(crc, catalog, generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 		require.NoError(GinkgoT(), err)
 
 		// CSVD will be in Pending status due to overrides in csvB's condition
-		fetchedCSV, err = fetchCSV(crc, csvD.GetName(), testNamespace, buildCSVReasonChecker(operatorsv1alpha1.CSVReasonOperatorConditionNotUpgradeable))
+		fetchedCSV, err = fetchCSV(crc, csvD.GetName(), generatedNamespace.GetName(), buildCSVReasonChecker(operatorsv1alpha1.CSVReasonOperatorConditionNotUpgradeable))
 		require.NoError(GinkgoT(), err)
 		require.Equal(GinkgoT(), fetchedCSV.Status.Phase, operatorsv1alpha1.CSVPhasePending)
 
 		// Get the OperatorCondition for csvB and override the upgradeable false condition
 		Eventually(func() error {
-			cond, err = crc.OperatorsV2().OperatorConditions(testNamespace).Get(context.TODO(), csvB.GetName(), metav1.GetOptions{})
+			cond, err = crc.OperatorsV2().OperatorConditions(generatedNamespace.GetName()).Get(context.TODO(), csvB.GetName(), metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
 			meta.SetStatusCondition(&cond.Spec.Overrides, upgradeableTrueCondition)
 			// Update the condition
-			_, err = crc.OperatorsV2().OperatorConditions(testNamespace).Update(context.TODO(), cond, metav1.UpdateOptions{})
+			_, err = crc.OperatorsV2().OperatorConditions(generatedNamespace.GetName()).Update(context.TODO(), cond, metav1.UpdateOptions{})
 			return err
 		}, pollInterval, pollDuration).Should(Succeed())
 		require.NoError(GinkgoT(), err)
 
 		require.NoError(GinkgoT(), err)
-		_, err = awaitCSV(crc, testNamespace, csvD.GetName(), csvSucceededChecker)
+		_, err = awaitCSV(crc, generatedNamespace.GetName(), csvD.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 	})
 })

--- a/staging/operator-lifecycle-manager/test/e2e/operator_groups_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/operator_groups_e2e_test.go
@@ -1084,7 +1084,7 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), awaitAnnotations(GinkgoT(), q, map[string]string{v1.OperatorGroupProvidedAPIsAnnotationKey: ""}))
 
 		// Ensure csvA's deployment is deleted
-		require.NoError(GinkgoT(), waitForDeploymentToDelete(c, pkgAStable))
+		require.NoError(GinkgoT(), waitForDeploymentToDelete(testNamespace, c, pkgAStable))
 
 		// Await csvB's success
 		_, err = awaitCSV(crc, nsB, csvB.GetName(), csvSucceededChecker)

--- a/staging/operator-lifecycle-manager/test/e2e/operator_groups_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/operator_groups_e2e_test.go
@@ -14,7 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -218,7 +218,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(opGroupNamespace).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if k8serrors.IsNotFound(fetchErr) {
+				if apierrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				log(fmt.Sprintf("Error (in %v): %v", testNamespace, fetchErr.Error()))
@@ -235,7 +235,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if k8serrors.IsNotFound(fetchErr) {
+				if apierrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				log(fmt.Sprintf("Error (in %v): %v", otherNamespaceName, fetchErr.Error()))
@@ -252,7 +252,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if k8serrors.IsNotFound(fetchErr) {
+				if apierrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", otherNamespaceName, fetchErr.Error())
@@ -269,7 +269,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			createdDeployment, err := c.GetDeployment(opGroupNamespace, deploymentName)
 			if err != nil {
-				if k8serrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					return false, nil
 				}
 				return false, err
@@ -387,7 +387,7 @@ var _ = Describe("Operator Group", func() {
 			}
 			return true, err
 		})
-		require.True(GinkgoT(), k8serrors.IsNotFound(err))
+		require.True(GinkgoT(), apierrors.IsNotFound(err))
 
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			_, err := c.KubernetesInterface().RbacV1().ClusterRoles().Get(context.TODO(), operatorGroup.Name+"-edit", metav1.GetOptions{})
@@ -396,7 +396,7 @@ var _ = Describe("Operator Group", func() {
 			}
 			return true, err
 		})
-		require.True(GinkgoT(), k8serrors.IsNotFound(err))
+		require.True(GinkgoT(), apierrors.IsNotFound(err))
 
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			_, err := c.KubernetesInterface().RbacV1().ClusterRoles().Get(context.TODO(), operatorGroup.Name+"-view", metav1.GetOptions{})
@@ -405,7 +405,7 @@ var _ = Describe("Operator Group", func() {
 			}
 			return true, err
 		})
-		require.True(GinkgoT(), k8serrors.IsNotFound(err))
+		require.True(GinkgoT(), apierrors.IsNotFound(err))
 	})
 	It("role aggregation", func() {
 
@@ -1440,7 +1440,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedRole, err = c.GetClusterRole(role.GetName())
 			if err != nil {
-				if k8serrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					return false, nil
 				}
 				return false, err
@@ -1456,7 +1456,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedRoleBinding, err = c.GetClusterRoleBinding(roleBinding.GetName())
 			if err != nil {
-				if k8serrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					return false, nil
 				}
 				return false, err
@@ -1485,7 +1485,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(opGroupNamespace).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if k8serrors.IsNotFound(fetchErr) {
+				if apierrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", testNamespace, fetchErr.Error())
@@ -1518,7 +1518,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if k8serrors.IsNotFound(fetchErr) {
+				if apierrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", otherNamespaceName, fetchErr.Error())
@@ -1549,7 +1549,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, 2*pollDuration, func() (bool, error) {
 			_, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if k8serrors.IsNotFound(fetchErr) {
+				if apierrors.IsNotFound(fetchErr) {
 					return true, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", opGroupNamespace, fetchErr.Error())
@@ -1921,7 +1921,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedRole, err = c.GetClusterRole(role.GetName())
 			if err != nil {
-				if k8serrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					return false, nil
 				}
 				return false, err
@@ -1937,7 +1937,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedRoleBinding, err = c.GetClusterRoleBinding(roleBinding.GetName())
 			if err != nil {
-				if k8serrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					return false, nil
 				}
 				return false, err
@@ -1966,7 +1966,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(opGroupNamespace).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if k8serrors.IsNotFound(fetchErr) {
+				if apierrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", testNamespace, fetchErr.Error())
@@ -1999,7 +1999,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if k8serrors.IsNotFound(fetchErr) {
+				if apierrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", otherNamespaceName, fetchErr.Error())
@@ -2026,7 +2026,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, 2*pollDuration, func() (bool, error) {
 			csv, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if k8serrors.IsNotFound(fetchErr) {
+				if apierrors.IsNotFound(fetchErr) {
 					return true, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", opGroupNamespace, fetchErr.Error())

--- a/staging/operator-lifecycle-manager/test/e2e/scoped_client_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/scoped_client_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
@@ -55,7 +55,7 @@ var _ = Describe("Scoped Client bound to a service account can be used to make A
 			// We expect the get api call to return 'Forbidden' error due to
 			// lack of permission.
 			assertFunc: func(errGot error) {
-				Expect(k8serrors.IsForbidden(errGot)).To(BeTrue())
+				Expect(apierrors.IsForbidden(errGot)).To(BeTrue())
 			},
 		}),
 		table.Entry("successfully allows API calls to be made when ServiceAccount has permission", testParameter{
@@ -66,7 +66,7 @@ var _ = Describe("Scoped Client bound to a service account can be used to make A
 				return
 			},
 			assertFunc: func(errGot error) {
-				Expect(k8serrors.IsNotFound(errGot)).To(BeTrue())
+				Expect(apierrors.IsNotFound(errGot)).To(BeTrue())
 			},
 		}),
 	}

--- a/staging/operator-lifecycle-manager/test/e2e/setup_bare_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/setup_bare_test.go
@@ -1,3 +1,4 @@
+//go:build bare
 // +build bare
 
 package e2e
@@ -18,7 +19,7 @@ import (
 	utilclock "k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/client-go/tools/clientcmd"
 
-	v1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm"

--- a/staging/operator-lifecycle-manager/test/e2e/subscription_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/subscription_e2e_test.go
@@ -586,11 +586,11 @@ var _ = Describe("Subscription", func() {
 
 		// Should eventually GC the CSVs
 		Eventually(func() bool {
-			return csvExists(crc, csvA.Name)
+			return csvExists(generatedNamespace.GetName(), crc, csvA.Name)
 		}).Should(BeFalse())
 
 		Eventually(func() bool {
-			return csvExists(crc, csvB.Name)
+			return csvExists(generatedNamespace.GetName(), crc, csvB.Name)
 		}).Should(BeFalse())
 
 		// TODO: check installplans, subscription status, etc

--- a/staging/operator-lifecycle-manager/test/e2e/subscription_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/subscription_e2e_test.go
@@ -19,7 +19,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -1210,7 +1210,7 @@ var _ = Describe("Subscription", func() {
 			}
 
 			proxy, getErr := client.Proxies().Get(context.Background(), "cluster", metav1.GetOptions{})
-			if k8serrors.IsNotFound(getErr) {
+			if apierrors.IsNotFound(getErr) {
 				return nil
 			}
 			require.NoError(GinkgoT(), getErr)
@@ -2561,7 +2561,7 @@ func init() {
 func initCatalog(t GinkgoTInterface, namespace string, c operatorclient.ClientInterface, crc versioned.Interface) error {
 	dummyCatalogConfigMap.SetNamespace(namespace)
 	if _, err := c.KubernetesInterface().CoreV1().ConfigMaps(namespace).Create(context.Background(), dummyCatalogConfigMap, metav1.CreateOptions{}); err != nil {
-		if k8serrors.IsAlreadyExists(err) {
+		if apierrors.IsAlreadyExists(err) {
 			return fmt.Errorf("E2E bug detected: %v", err)
 		}
 		return err
@@ -2569,7 +2569,7 @@ func initCatalog(t GinkgoTInterface, namespace string, c operatorclient.ClientIn
 
 	dummyCatalogSource.SetNamespace(namespace)
 	if _, err := crc.OperatorsV1alpha1().CatalogSources(namespace).Create(context.Background(), &dummyCatalogSource, metav1.CreateOptions{}); err != nil {
-		if k8serrors.IsAlreadyExists(err) {
+		if apierrors.IsAlreadyExists(err) {
 			return fmt.Errorf("E2E bug detected: %v", err)
 		}
 		return err

--- a/staging/operator-lifecycle-manager/test/e2e/user_defined_sa_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/user_defined_sa_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/apis/rbac"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
+	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/ctx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -23,8 +24,23 @@ import (
 )
 
 var _ = Describe("User defined service account", func() {
+	var (
+		generatedNamespace corev1.Namespace
+	)
+
+	BeforeEach(func() {
+		generatedNamespace = corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: genName("user-defined-sa-e2e-"),
+			},
+		}
+		Eventually(func() error {
+			return ctx.Ctx().Client().Create(context.Background(), &generatedNamespace)
+		}).Should(Succeed())
+	})
+
 	AfterEach(func() {
-		TearDown(testNamespace)
+		TeardownNamespace(generatedNamespace.GetName())
 	})
 
 	It("with no permission", func() {
@@ -32,47 +48,43 @@ var _ = Describe("User defined service account", func() {
 		kubeclient := newKubeClient()
 		crclient := newCRClient()
 
-		namespace := genName("scoped-ns-")
-		_, cleanupNS := newNamespace(kubeclient, namespace)
-		defer cleanupNS()
-
 		// Create a service account, but add no permission to it.
 		saName := genName("scoped-sa-")
-		_, cleanupSA := newServiceAccount(kubeclient, namespace, saName)
+		_, cleanupSA := newServiceAccount(kubeclient, generatedNamespace.GetName(), saName)
 		defer cleanupSA()
 
 		// Add an OperatorGroup and specify the service account.
 		ogName := genName("scoped-og-")
-		_, cleanupOG := newOperatorGroupWithServiceAccount(crclient, namespace, ogName, saName)
+		_, cleanupOG := newOperatorGroupWithServiceAccount(crclient, generatedNamespace.GetName(), ogName, saName)
 		defer cleanupOG()
 
 		permissions := deploymentPermissions()
-		catsrc, subSpec, catsrcCleanup := newCatalogSource(GinkgoT(), kubeclient, crclient, "scoped", namespace, permissions)
+		catsrc, subSpec, catsrcCleanup := newCatalogSource(GinkgoT(), kubeclient, crclient, "scoped", generatedNamespace.GetName(), permissions)
 		defer catsrcCleanup()
 
 		// Ensure that the catalog source is resolved before we create a subscription.
-		_, err := fetchCatalogSourceOnStatus(crclient, catsrc.GetName(), namespace, catalogSourceRegistryPodSynced)
+		_, err := fetchCatalogSourceOnStatus(crclient, catsrc.GetName(), generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 		require.NoError(GinkgoT(), err)
 
 		subscriptionName := genName("scoped-sub-")
-		cleanupSubscription := createSubscriptionForCatalog(crclient, namespace, subscriptionName, catsrc.GetName(), subSpec.Package, subSpec.Channel, subSpec.StartingCSV, subSpec.InstallPlanApproval)
+		cleanupSubscription := createSubscriptionForCatalog(crclient, generatedNamespace.GetName(), subscriptionName, catsrc.GetName(), subSpec.Package, subSpec.Channel, subSpec.StartingCSV, subSpec.InstallPlanApproval)
 		defer cleanupSubscription()
 
 		// Wait until an install plan is created.
-		subscription, err := fetchSubscription(crclient, namespace, subscriptionName, subscriptionHasInstallPlanChecker)
+		subscription, err := fetchSubscription(crclient, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
 
 		// We expect the InstallPlan to be in status: Failed.
 		ipName := subscription.Status.Install.Name
 		ipPhaseCheckerFunc := buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseFailed)
-		ipGot, err := fetchInstallPlanWithNamespace(GinkgoT(), crclient, ipName, namespace, ipPhaseCheckerFunc)
+		ipGot, err := fetchInstallPlanWithNamespace(GinkgoT(), crclient, ipName, generatedNamespace.GetName(), ipPhaseCheckerFunc)
 		require.NoError(GinkgoT(), err)
 
 		conditionGot := mustHaveCondition(GinkgoT(), ipGot, v1alpha1.InstallPlanInstalled)
 		assert.Equal(GinkgoT(), corev1.ConditionFalse, conditionGot.Status)
 		assert.Equal(GinkgoT(), v1alpha1.InstallPlanReasonComponentFailed, conditionGot.Reason)
-		assert.Contains(GinkgoT(), conditionGot.Message, fmt.Sprintf("is forbidden: User \"system:serviceaccount:%s:%s\" cannot create resource", namespace, saName))
+		assert.Contains(GinkgoT(), conditionGot.Message, fmt.Sprintf("is forbidden: User \"system:serviceaccount:%s:%s\" cannot create resource", generatedNamespace.GetName(), saName))
 
 		// Verify that all step resources are in Unknown state.
 		for _, step := range ipGot.Status.Plan {
@@ -85,43 +97,39 @@ var _ = Describe("User defined service account", func() {
 		kubeclient := newKubeClient()
 		crclient := newCRClient()
 
-		namespace := genName("scoped-ns-")
-		_, cleanupNS := newNamespace(kubeclient, namespace)
-		defer cleanupNS()
-
 		// Create a service account, add enough permission to it so that operator install is successful.
 		saName := genName("scoped-sa")
-		_, cleanupSA := newServiceAccount(kubeclient, namespace, saName)
+		_, cleanupSA := newServiceAccount(kubeclient, generatedNamespace.GetName(), saName)
 		defer cleanupSA()
-		cleanupPerm := grantPermission(GinkgoT(), kubeclient, namespace, saName)
+		cleanupPerm := grantPermission(GinkgoT(), kubeclient, generatedNamespace.GetName(), saName)
 		defer cleanupPerm()
 
 		// Add an OperatorGroup and specify the service account.
 		ogName := genName("scoped-og-")
-		_, cleanupOG := newOperatorGroupWithServiceAccount(crclient, namespace, ogName, saName)
+		_, cleanupOG := newOperatorGroupWithServiceAccount(crclient, generatedNamespace.GetName(), ogName, saName)
 		defer cleanupOG()
 
 		permissions := deploymentPermissions()
-		catsrc, subSpec, catsrcCleanup := newCatalogSource(GinkgoT(), kubeclient, crclient, "scoped", namespace, permissions)
+		catsrc, subSpec, catsrcCleanup := newCatalogSource(GinkgoT(), kubeclient, crclient, "scoped", generatedNamespace.GetName(), permissions)
 		defer catsrcCleanup()
 
 		// Ensure that the catalog source is resolved before we create a subscription.
-		_, err := fetchCatalogSourceOnStatus(crclient, catsrc.GetName(), namespace, catalogSourceRegistryPodSynced)
+		_, err := fetchCatalogSourceOnStatus(crclient, catsrc.GetName(), generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 		require.NoError(GinkgoT(), err)
 
 		subscriptionName := genName("scoped-sub-")
-		cleanupSubscription := createSubscriptionForCatalog(crclient, namespace, subscriptionName, catsrc.GetName(), subSpec.Package, subSpec.Channel, subSpec.StartingCSV, subSpec.InstallPlanApproval)
+		cleanupSubscription := createSubscriptionForCatalog(crclient, generatedNamespace.GetName(), subscriptionName, catsrc.GetName(), subSpec.Package, subSpec.Channel, subSpec.StartingCSV, subSpec.InstallPlanApproval)
 		defer cleanupSubscription()
 
 		// Wait until an install plan is created.
-		subscription, err := fetchSubscription(crclient, namespace, subscriptionName, subscriptionHasInstallPlanChecker)
+		subscription, err := fetchSubscription(crclient, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
 
 		// We expect the InstallPlan to be in status: Complete.
 		ipName := subscription.Status.Install.Name
 		ipPhaseCheckerFunc := buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete)
-		ipGot, err := fetchInstallPlanWithNamespace(GinkgoT(), crclient, ipName, namespace, ipPhaseCheckerFunc)
+		ipGot, err := fetchInstallPlanWithNamespace(GinkgoT(), crclient, ipName, generatedNamespace.GetName(), ipPhaseCheckerFunc)
 		require.NoError(GinkgoT(), err)
 
 		conditionGot := mustHaveCondition(GinkgoT(), ipGot, v1alpha1.InstallPlanInstalled)
@@ -141,50 +149,46 @@ var _ = Describe("User defined service account", func() {
 		kubeclient := newKubeClient()
 		crclient := newCRClient()
 
-		namespace := genName("scoped-ns-")
-		_, cleanupNS := newNamespace(kubeclient, namespace)
-		defer cleanupNS()
-
 		// Create a service account, but add no permission to it.
 		saName := genName("scoped-sa-")
-		_, cleanupSA := newServiceAccount(kubeclient, namespace, saName)
+		_, cleanupSA := newServiceAccount(kubeclient, generatedNamespace.GetName(), saName)
 		defer cleanupSA()
 
 		// Add an OperatorGroup and specify the service account.
 		ogName := genName("scoped-og-")
-		_, cleanupOG := newOperatorGroupWithServiceAccount(crclient, namespace, ogName, saName)
+		_, cleanupOG := newOperatorGroupWithServiceAccount(crclient, generatedNamespace.GetName(), ogName, saName)
 		defer cleanupOG()
 
 		permissions := deploymentPermissions()
-		catsrc, subSpec, catsrcCleanup := newCatalogSource(GinkgoT(), kubeclient, crclient, "scoped", namespace, permissions)
+		catsrc, subSpec, catsrcCleanup := newCatalogSource(GinkgoT(), kubeclient, crclient, "scoped", generatedNamespace.GetName(), permissions)
 		defer catsrcCleanup()
 
 		// Ensure that the catalog source is resolved before we create a subscription.
-		_, err := fetchCatalogSourceOnStatus(crclient, catsrc.GetName(), namespace, catalogSourceRegistryPodSynced)
+		_, err := fetchCatalogSourceOnStatus(crclient, catsrc.GetName(), generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 		require.NoError(GinkgoT(), err)
 
 		subscriptionName := genName("scoped-sub-")
-		cleanupSubscription := createSubscriptionForCatalog(crclient, namespace, subscriptionName, catsrc.GetName(), subSpec.Package, subSpec.Channel, subSpec.StartingCSV, subSpec.InstallPlanApproval)
+		cleanupSubscription := createSubscriptionForCatalog(crclient, generatedNamespace.GetName(), subscriptionName, catsrc.GetName(), subSpec.Package, subSpec.Channel, subSpec.StartingCSV, subSpec.InstallPlanApproval)
 		defer cleanupSubscription()
 
 		// Wait until an install plan is created.
-		subscription, err := fetchSubscription(crclient, namespace, subscriptionName, subscriptionHasInstallPlanChecker)
+		subscription, err := fetchSubscription(crclient, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
 
 		// We expect the InstallPlan to be in status: Failed.
 		ipNameOld := subscription.Status.InstallPlanRef.Name
 		ipPhaseCheckerFunc := buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseFailed)
-		ipGotOld, err := fetchInstallPlanWithNamespace(GinkgoT(), crclient, ipNameOld, namespace, ipPhaseCheckerFunc)
+		ipGotOld, err := fetchInstallPlanWithNamespace(GinkgoT(), crclient, ipNameOld, generatedNamespace.GetName(), ipPhaseCheckerFunc)
 		require.NoError(GinkgoT(), err)
 		require.Equal(GinkgoT(), v1alpha1.InstallPlanPhaseFailed, ipGotOld.Status.Phase)
 
 		// Grant permission now and this should trigger an retry of InstallPlan.
-		cleanupPerm := grantPermission(GinkgoT(), kubeclient, namespace, saName)
+		cleanupPerm := grantPermission(GinkgoT(), kubeclient, generatedNamespace.GetName(), saName)
 		defer cleanupPerm()
 
 		ipPhaseCheckerFunc = buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete)
-		ipGotNew, err := fetchInstallPlanWithNamespace(GinkgoT(), crclient, ipNameOld, namespace, ipPhaseCheckerFunc)
+		ipGotNew, err := fetchInstallPlanWithNamespace(GinkgoT(), crclient, ipNameOld, generatedNamespace.GetName(), ipPhaseCheckerFunc)
 		require.NoError(GinkgoT(), err)
 		require.Equal(GinkgoT(), v1alpha1.InstallPlanPhaseComplete, ipGotNew.Status.Phase)
 	})

--- a/staging/operator-lifecycle-manager/test/e2e/util.go
+++ b/staging/operator-lifecycle-manager/test/e2e/util.go
@@ -509,7 +509,11 @@ func buildCatalogSourceCleanupFunc(crc versioned.Interface, namespace string, ca
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(func() (bool, error) {
-			fetched, err := newKubeClient().KubernetesInterface().CoreV1().Pods(catalogSource.GetNamespace()).List(context.Background(), metav1.ListOptions{LabelSelector: "olm.catalogSource=" + catalogSource.GetName()})
+			listOpts := metav1.ListOptions{
+				LabelSelector: "olm.catalogSource=" + catalogSource.GetName(),
+				FieldSelector: "status.phase=Running",
+			}
+			fetched, err := newKubeClient().KubernetesInterface().CoreV1().Pods(catalogSource.GetNamespace()).List(context.Background(), listOpts)
 			if err != nil {
 				return false, err
 			}
@@ -956,6 +960,12 @@ func Apply(obj controllerclient.Object, changeFunc interface{}) func() error {
 func HavePhase(goal operatorsv1alpha1.InstallPlanPhase) gtypes.GomegaMatcher {
 	return WithTransform(func(plan *operatorsv1alpha1.InstallPlan) operatorsv1alpha1.InstallPlanPhase {
 		return plan.Status.Phase
+	}, Equal(goal))
+}
+
+func CSVHasPhase(goal operatorsv1alpha1.ClusterServiceVersionPhase) gtypes.GomegaMatcher {
+	return WithTransform(func(csv *operatorsv1alpha1.ClusterServiceVersion) operatorsv1alpha1.ClusterServiceVersionPhase {
+		return csv.Status.Phase
 	}, Equal(goal))
 }
 

--- a/staging/operator-lifecycle-manager/test/e2e/webhook_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/webhook_e2e_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/ctx"
 	"github.com/stretchr/testify/require"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -30,39 +31,34 @@ const (
 )
 
 var _ = Describe("CSVs with a Webhook", func() {
-	var c operatorclient.ClientInterface
-	var crc versioned.Interface
-	var namespace *corev1.Namespace
-	var nsCleanupFunc cleanupFunc
-	var nsLabels map[string]string
+
+	var (
+		generatedNamespace corev1.Namespace
+		c                  operatorclient.ClientInterface
+		crc                versioned.Interface
+		nsLabels           map[string]string
+	)
+
 	BeforeEach(func() {
 		c = newKubeClient()
 		crc = newCRClient()
-		nsLabels = map[string]string{
-			"foo": "bar",
-		}
-		namespace = &corev1.Namespace{
+		generatedNamespace = corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   genName("webhook-test-"),
-				Labels: nsLabels,
+				Name: genName("webhook-e2e-"),
+				Labels: map[string]string{
+					"foo": "bar",
+				},
 			},
 		}
-
-		var err error
-		namespace, err = c.KubernetesInterface().CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})
-		Expect(err).Should(BeNil())
-		Expect(namespace).ShouldNot(BeNil())
-
-		nsCleanupFunc = func() {
-			err := c.KubernetesInterface().CoreV1().Namespaces().Delete(context.TODO(), namespace.GetName(), metav1.DeleteOptions{})
-			Expect(err).Should(BeNil())
-		}
+		Eventually(func() error {
+			return ctx.Ctx().Client().Create(context.Background(), &generatedNamespace)
+		}).Should(Succeed())
 	})
+
 	AfterEach(func() {
-		if nsCleanupFunc != nil {
-			nsCleanupFunc()
-		}
+		TeardownNamespace(generatedNamespace.GetName())
 	})
+
 	When("Installed in an OperatorGroup that defines a selector", func() {
 		var cleanupCSV cleanupFunc
 		var ogSelector *metav1.LabelSelector
@@ -71,8 +67,8 @@ var _ = Describe("CSVs with a Webhook", func() {
 				MatchLabels: nsLabels,
 			}
 
-			og := newOperatorGroup(namespace.Name, genName("selector-og-"), nil, ogSelector, nil, false)
-			_, err := crc.OperatorsV1().OperatorGroups(namespace.Name).Create(context.TODO(), og, metav1.CreateOptions{})
+			og := newOperatorGroup(generatedNamespace.GetName(), genName("selector-og-"), nil, ogSelector, nil, false)
+			_, err := crc.OperatorsV1().OperatorGroups(generatedNamespace.GetName()).Create(context.TODO(), og, metav1.CreateOptions{})
 			Expect(err).Should(BeNil())
 		})
 		AfterEach(func() {
@@ -91,12 +87,12 @@ var _ = Describe("CSVs with a Webhook", func() {
 				SideEffects:             &sideEffect,
 			}
 
-			csv := createCSVWithWebhook(namespace.GetName(), webhook)
+			csv := createCSVWithWebhook(generatedNamespace.GetName(), webhook)
 			var err error
-			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(crc, csv.Name, namespace.Name, csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).Should(BeNil())
 
 			actualWebhook, err := getWebhookWithGenerateName(c, webhook.GenerateName)
@@ -109,9 +105,9 @@ var _ = Describe("CSVs with a Webhook", func() {
 		var cleanupCSV cleanupFunc
 		var og *v1.OperatorGroup
 		BeforeEach(func() {
-			og = newOperatorGroup(namespace.Name, genName("single-namespace-og-"), nil, nil, []string{namespace.Name}, false)
+			og = newOperatorGroup(generatedNamespace.GetName(), genName("single-namespace-og-"), nil, nil, []string{generatedNamespace.GetName()}, false)
 			var err error
-			og, err = crc.OperatorsV1().OperatorGroups(namespace.Name).Create(context.TODO(), og, metav1.CreateOptions{})
+			og, err = crc.OperatorsV1().OperatorGroups(generatedNamespace.GetName()).Create(context.TODO(), og, metav1.CreateOptions{})
 			Expect(err).Should(BeNil())
 		})
 		AfterEach(func() {
@@ -130,12 +126,12 @@ var _ = Describe("CSVs with a Webhook", func() {
 				SideEffects:             &sideEffect,
 			}
 
-			csv := createCSVWithWebhook(namespace.GetName(), webhook)
+			csv := createCSVWithWebhook(generatedNamespace.GetName(), webhook)
 			var err error
-			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(crc, csv.Name, namespace.Name, csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).Should(BeNil())
 
 			actualWebhook, err := getWebhookWithGenerateName(c, webhook.GenerateName)
@@ -153,13 +149,13 @@ var _ = Describe("CSVs with a Webhook", func() {
 			// Ensure that changes to the WebhookDescription within the CSV trigger an update to on cluster resources
 			changedGenerateName := webhookName + "-changed"
 			Eventually(func() error {
-				existingCSV, err := crc.OperatorsV1alpha1().ClusterServiceVersions(namespace.Name).Get(context.TODO(), csv.GetName(), metav1.GetOptions{})
+				existingCSV, err := crc.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Get(context.TODO(), csv.GetName(), metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
 				existingCSV.Spec.WebhookDefinitions[0].GenerateName = changedGenerateName
 
-				existingCSV, err = crc.OperatorsV1alpha1().ClusterServiceVersions(namespace.Name).Update(context.TODO(), existingCSV, metav1.UpdateOptions{})
+				existingCSV, err = crc.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Update(context.TODO(), existingCSV, metav1.UpdateOptions{})
 				return err
 			}, time.Minute, 5*time.Second).Should(Succeed())
 			Eventually(func() bool {
@@ -184,39 +180,39 @@ var _ = Describe("CSVs with a Webhook", func() {
 				AdmissionReviewVersions: []string{"v1beta1", "v1"},
 				SideEffects:             &sideEffect,
 			}
-			csv := createCSVWithWebhook(namespace.GetName(), webhook)
+			csv := createCSVWithWebhook(generatedNamespace.GetName(), webhook)
 
 			var err error
-			cleanupCSV, err = createCSV(c, crc, csv, namespace.GetName(), false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(crc, csv.Name, namespace.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).Should(BeNil())
 
 			// Get the existing secret
 			webhookSecretName := webhook.DeploymentName + "-service-cert"
-			existingSecret, err := c.KubernetesInterface().CoreV1().Secrets(namespace.GetName()).Get(context.TODO(), webhookSecretName, metav1.GetOptions{})
+			existingSecret, err := c.KubernetesInterface().CoreV1().Secrets(generatedNamespace.GetName()).Get(context.TODO(), webhookSecretName, metav1.GetOptions{})
 			require.NoError(GinkgoT(), err)
 
 			// Modify the phase
 			Eventually(func() bool {
-				fetchedCSV, err := crc.OperatorsV1alpha1().ClusterServiceVersions(namespace.GetName()).Get(context.TODO(), csv.GetName(), metav1.GetOptions{})
+				fetchedCSV, err := crc.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Get(context.TODO(), csv.GetName(), metav1.GetOptions{})
 				if err != nil {
 					return false
 				}
 
 				fetchedCSV.Status.Phase = operatorsv1alpha1.CSVPhasePending
 
-				_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(namespace.GetName()).UpdateStatus(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
+				_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).UpdateStatus(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
 				return err == nil
 			}).Should(BeTrue(), "Unable to set CSV phase to Pending")
 
 			// Wait for webhook-operator to succeed
-			_, err = awaitCSV(crc, namespace.GetName(), csv.GetName(), csvSucceededChecker)
+			_, err = awaitCSV(crc, generatedNamespace.GetName(), csv.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Get the updated secret
-			updatedSecret, err := c.KubernetesInterface().CoreV1().Secrets(namespace.GetName()).Get(context.TODO(), webhookSecretName, metav1.GetOptions{})
+			updatedSecret, err := c.KubernetesInterface().CoreV1().Secrets(generatedNamespace.GetName()).Get(context.TODO(), webhookSecretName, metav1.GetOptions{})
 			require.NoError(GinkgoT(), err)
 
 			require.Equal(GinkgoT(), existingSecret.GetAnnotations()[install.OLMCAHashAnnotationKey], updatedSecret.GetAnnotations()[install.OLMCAHashAnnotationKey])
@@ -233,13 +229,13 @@ var _ = Describe("CSVs with a Webhook", func() {
 				SideEffects:             &sideEffect,
 			}
 
-			csv := createCSVWithWebhook(namespace.GetName(), webhook)
+			csv := createCSVWithWebhook(generatedNamespace.GetName(), webhook)
 			csv.Spec.WebhookDefinitions = append(csv.Spec.WebhookDefinitions, webhook)
 			var err error
-			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(crc, csv.Name, namespace.Name, csvFailedChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvFailedChecker)
 			Expect(err).Should(BeNil())
 		})
 		It("Fails if the webhooks intercepts all resources", func() {
@@ -263,13 +259,13 @@ var _ = Describe("CSVs with a Webhook", func() {
 				},
 			}
 
-			csv := createCSVWithWebhook(namespace.GetName(), webhook)
+			csv := createCSVWithWebhook(generatedNamespace.GetName(), webhook)
 
 			var err error
-			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			failedCSV, err := fetchCSV(crc, csv.Name, namespace.Name, csvFailedChecker)
+			failedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvFailedChecker)
 			Expect(err).Should(BeNil())
 			Expect(failedCSV.Status.Message).Should(Equal("webhook rules cannot include all groups"))
 		})
@@ -294,13 +290,13 @@ var _ = Describe("CSVs with a Webhook", func() {
 				},
 			}
 
-			csv := createCSVWithWebhook(namespace.GetName(), webhook)
+			csv := createCSVWithWebhook(generatedNamespace.GetName(), webhook)
 
 			var err error
-			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			failedCSV, err := fetchCSV(crc, csv.Name, namespace.Name, csvFailedChecker)
+			failedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvFailedChecker)
 			Expect(err).Should(BeNil())
 			Expect(failedCSV.Status.Message).Should(Equal("webhook rules cannot include the OLM group"))
 		})
@@ -325,13 +321,13 @@ var _ = Describe("CSVs with a Webhook", func() {
 				},
 			}
 
-			csv := createCSVWithWebhook(namespace.GetName(), webhook)
+			csv := createCSVWithWebhook(generatedNamespace.GetName(), webhook)
 
 			var err error
-			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			failedCSV, err := fetchCSV(crc, csv.Name, namespace.Name, csvFailedChecker)
+			failedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvFailedChecker)
 			Expect(err).Should(BeNil())
 			Expect(failedCSV.Status.Message).Should(Equal("webhook rules cannot include MutatingWebhookConfiguration or ValidatingWebhookConfiguration resources"))
 		})
@@ -358,13 +354,13 @@ var _ = Describe("CSVs with a Webhook", func() {
 				},
 			}
 
-			csv := createCSVWithWebhook(namespace.GetName(), webhook)
+			csv := createCSVWithWebhook(generatedNamespace.GetName(), webhook)
 
 			var err error
-			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(crc, csv.Name, namespace.Name, csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).Should(BeNil())
 		})
 		It("Can be installed and upgraded successfully", func() {
@@ -390,13 +386,13 @@ var _ = Describe("CSVs with a Webhook", func() {
 				},
 			}
 
-			csv := createCSVWithWebhook(namespace.GetName(), webhook)
+			csv := createCSVWithWebhook(generatedNamespace.GetName(), webhook)
 
-			_, err := createCSV(c, crc, csv, namespace.Name, false, false)
+			_, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 			// cleanup by upgrade
 
-			_, err = fetchCSV(crc, csv.Name, namespace.Name, csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).Should(BeNil())
 
 			_, err = getWebhookWithGenerateName(c, webhook.GenerateName)
@@ -408,10 +404,10 @@ var _ = Describe("CSVs with a Webhook", func() {
 			previousWebhookName := webhook.GenerateName
 			webhook.GenerateName = "webhook2.test.com"
 			csv.Spec.WebhookDefinitions[0] = webhook
-			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(crc, csv.GetName(), namespace.Name, csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.GetName(), generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).Should(BeNil())
 
 			_, err = getWebhookWithGenerateName(c, webhook.GenerateName)
@@ -446,13 +442,13 @@ var _ = Describe("CSVs with a Webhook", func() {
 				SideEffects:             &sideEffect,
 			}
 
-			csv := createCSVWithWebhook(namespace.GetName(), webhook)
+			csv := createCSVWithWebhook(generatedNamespace.GetName(), webhook)
 
 			var err error
-			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			fetchedCSV, err := fetchCSV(crc, csv.Name, namespace.Name, csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).Should(BeNil())
 
 			actualWebhook, err := getWebhookWithGenerateName(c, webhook.GenerateName)
@@ -461,7 +457,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 			oldWebhookCABundle := actualWebhook.Webhooks[0].ClientConfig.CABundle
 
 			// Get the deployment
-			dep, err := c.KubernetesInterface().AppsV1().Deployments(namespace.Name).Get(context.TODO(), csv.Spec.WebhookDefinitions[0].DeploymentName, metav1.GetOptions{})
+			dep, err := c.KubernetesInterface().AppsV1().Deployments(generatedNamespace.GetName()).Get(context.TODO(), csv.Spec.WebhookDefinitions[0].DeploymentName, metav1.GetOptions{})
 			Expect(err).Should(BeNil())
 
 			//Store the ca sha annotation
@@ -476,9 +472,9 @@ var _ = Describe("CSVs with a Webhook", func() {
 				return nil
 			})).Should(Succeed())
 
-			_, err = fetchCSV(crc, csv.Name, namespace.Name, func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
 				// Should create deployment
-				dep, err = c.GetDeployment(namespace.Name, csv.Spec.WebhookDefinitions[0].DeploymentName)
+				dep, err = c.GetDeployment(generatedNamespace.GetName(), csv.Spec.WebhookDefinitions[0].DeploymentName)
 				if err != nil {
 					return false
 				}
@@ -509,8 +505,8 @@ var _ = Describe("CSVs with a Webhook", func() {
 	When("Installed in a Global OperatorGroup", func() {
 		var cleanupCSV cleanupFunc
 		BeforeEach(func() {
-			og := newOperatorGroup(namespace.Name, genName("global-og-"), nil, nil, []string{}, false)
-			og, err := crc.OperatorsV1().OperatorGroups(namespace.Name).Create(context.TODO(), og, metav1.CreateOptions{})
+			og := newOperatorGroup(generatedNamespace.GetName(), genName("global-og-"), nil, nil, []string{}, false)
+			og, err := crc.OperatorsV1().OperatorGroups(generatedNamespace.GetName()).Create(context.TODO(), og, metav1.CreateOptions{})
 			Expect(err).Should(BeNil())
 		})
 		AfterEach(func() {
@@ -529,13 +525,13 @@ var _ = Describe("CSVs with a Webhook", func() {
 				SideEffects:             &sideEffect,
 			}
 
-			csv := createCSVWithWebhook(namespace.GetName(), webhook)
+			csv := createCSVWithWebhook(generatedNamespace.GetName(), webhook)
 
 			var err error
-			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(crc, csv.Name, namespace.Name, csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).Should(BeNil())
 			actualWebhook, err := getWebhookWithGenerateName(c, webhook.GenerateName)
 			Expect(err).Should(BeNil())
@@ -588,7 +584,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 			SideEffects:             &sideEffect,
 		}
 
-		csv := createCSVWithWebhook(namespace.GetName(), webhook)
+		csv := createCSVWithWebhook(generatedNamespace.GetName(), webhook)
 
 		csv.Namespace = namespace1.GetName()
 		var cleanupCSV cleanupFunc
@@ -636,6 +632,9 @@ var _ = Describe("CSVs with a Webhook", func() {
 		var cleanupCatSrc cleanupFunc
 		var cleanupSubscription cleanupFunc
 		BeforeEach(func() {
+			og := newOperatorGroup(generatedNamespace.GetName(), genName("og-"), nil, nil, []string{}, false)
+			_, err := crc.OperatorsV1().OperatorGroups(generatedNamespace.GetName()).Create(context.TODO(), og, metav1.CreateOptions{})
+			Expect(err).Should(BeNil())
 
 			// Create a catalogSource which has the webhook-operator
 			sourceName := genName("catalog-")
@@ -652,7 +651,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      sourceName,
-					Namespace: testNamespace,
+					Namespace: generatedNamespace.GetName(),
 				},
 				Spec: operatorsv1alpha1.CatalogSourceSpec{
 					SourceType: operatorsv1alpha1.SourceTypeGrpc,
@@ -661,7 +660,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 			}
 
 			crc := newCRClient()
-			source, err := crc.OperatorsV1alpha1().CatalogSources(source.GetNamespace()).Create(context.TODO(), source, metav1.CreateOptions{})
+			source, err = crc.OperatorsV1alpha1().CatalogSources(source.GetNamespace()).Create(context.TODO(), source, metav1.CreateOptions{})
 			require.NoError(GinkgoT(), err)
 			cleanupCatSrc = func() {
 				require.NoError(GinkgoT(), crc.OperatorsV1alpha1().CatalogSources(source.GetNamespace()).Delete(context.TODO(), source.GetName(), metav1.DeleteOptions{}))
@@ -673,14 +672,14 @@ var _ = Describe("CSVs with a Webhook", func() {
 
 			// Create a Subscription for the webhook-operator
 			subscriptionName := genName("sub-")
-			cleanupSubscription := createSubscriptionForCatalog(crc, testNamespace, subscriptionName, source.GetName(), packageName, channelName, "", operatorsv1alpha1.ApprovalAutomatic)
+			cleanupSubscription := createSubscriptionForCatalog(crc, source.GetNamespace(), subscriptionName, source.GetName(), packageName, channelName, "", operatorsv1alpha1.ApprovalAutomatic)
 			defer cleanupSubscription()
 
 			// Wait for webhook-operator v2 csv to succeed
-			csv, err := awaitCSV(crc, testNamespace, "webhook-operator.v0.0.1", csvSucceededChecker)
+			csv, err := awaitCSV(crc, source.GetNamespace(), "webhook-operator.v0.0.1", csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
-			cleanupCSV = buildCSVCleanupFunc(c, crc, *csv, testNamespace, true, true)
+			cleanupCSV = buildCSVCleanupFunc(c, crc, *csv, source.GetNamespace(), true, true)
 		})
 		AfterEach(func() {
 			if cleanupCSV != nil {
@@ -700,7 +699,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 					"apiVersion": "webhook.operators.coreos.io/v1",
 					"kind":       "webhooktests",
 					"metadata": map[string]interface{}{
-						"namespace": testNamespace,
+						"namespace": generatedNamespace.GetName(),
 						"name":      "my-cr-1",
 					},
 					"spec": map[string]interface{}{
@@ -723,7 +722,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 					"apiVersion": "webhook.operators.coreos.io/v1",
 					"kind":       "webhooktests",
 					"metadata": map[string]interface{}{
-						"namespace": testNamespace,
+						"namespace": generatedNamespace.GetName(),
 						"name":      "my-cr-1",
 					},
 					"spec": map[string]interface{}{
@@ -731,12 +730,12 @@ var _ = Describe("CSVs with a Webhook", func() {
 					},
 				},
 			}
-			crCleanupFunc, err := createCR(c, validCR, "webhook.operators.coreos.io", "v1", testNamespace, "webhooktests", "my-cr-1")
+			crCleanupFunc, err := createCR(c, validCR, "webhook.operators.coreos.io", "v1", generatedNamespace.GetName(), "webhooktests", "my-cr-1")
 			defer crCleanupFunc()
 			require.NoError(GinkgoT(), err, "The valid CR should have been approved by the validating webhook")
 
 			// Check that you can get v1 of the webhooktest cr
-			v1UnstructuredObject, err := c.GetCustomResource("webhook.operators.coreos.io", "v1", testNamespace, "webhooktests", "my-cr-1")
+			v1UnstructuredObject, err := c.GetCustomResource("webhook.operators.coreos.io", "v1", generatedNamespace.GetName(), "webhooktests", "my-cr-1")
 			require.NoError(GinkgoT(), err, "Unable to get the v1 of the valid CR")
 			v1Object := v1UnstructuredObject.Object
 			v1Spec, ok := v1Object["spec"].(map[string]interface{})
@@ -750,7 +749,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 			require.True(GinkgoT(), v1SpecValid, "The validating webhook should have required that the CR's spec.valid field is true")
 
 			// Check that you can get v2 of the webhooktest cr
-			v2UnstructuredObject, err := c.GetCustomResource("webhook.operators.coreos.io", "v2", testNamespace, "webhooktests", "my-cr-1")
+			v2UnstructuredObject, err := c.GetCustomResource("webhook.operators.coreos.io", "v2", generatedNamespace.GetName(), "webhooktests", "my-cr-1")
 			require.NoError(GinkgoT(), err, "Unable to get the v2 of the valid CR")
 			v2Object := v2UnstructuredObject.Object
 			v2Spec := v2Object["spec"].(map[string]interface{})
@@ -769,8 +768,8 @@ var _ = Describe("CSVs with a Webhook", func() {
 		var cleanupCSV cleanupFunc
 		BeforeEach(func() {
 			// global operator group
-			og := newOperatorGroup(namespace.Name, genName("global-og-"), nil, nil, []string{}, false)
-			og, err := crc.OperatorsV1().OperatorGroups(namespace.Name).Create(context.TODO(), og, metav1.CreateOptions{})
+			og := newOperatorGroup(generatedNamespace.GetName(), genName("global-og-"), nil, nil, []string{}, false)
+			og, err := crc.OperatorsV1().OperatorGroups(generatedNamespace.GetName()).Create(context.TODO(), og, metav1.CreateOptions{})
 			Expect(err).Should(BeNil())
 		})
 		AfterEach(func() {
@@ -808,13 +807,13 @@ var _ = Describe("CSVs with a Webhook", func() {
 			ownedCRDDescs := make([]operatorsv1alpha1.CRDDescription, 0)
 
 			// create CSV
-			csv := createCSVWithWebhookAndCrds(namespace.GetName(), webhook, ownedCRDDescs)
+			csv := createCSVWithWebhookAndCrds(generatedNamespace.GetName(), webhook, ownedCRDDescs)
 
 			var err error
-			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(crc, csv.Name, namespace.Name, csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).Should(BeNil())
 			actualWebhook, err := getWebhookWithGenerateName(c, webhook.GenerateName)
 			Expect(err).Should(BeNil())
@@ -871,13 +870,13 @@ var _ = Describe("CSVs with a Webhook", func() {
 			ownedCRDDescs = append(ownedCRDDescs, operatorsv1alpha1.CRDDescription{Name: crdA.GetName(), Version: crdA.Spec.Versions[0].Name, Kind: crdA.Spec.Names.Kind})
 
 			// create CSV
-			csv := createCSVWithWebhookAndCrdsAndInvalidInstallModes(namespace.GetName(), webhook, ownedCRDDescs)
+			csv := createCSVWithWebhookAndCrdsAndInvalidInstallModes(generatedNamespace.GetName(), webhook, ownedCRDDescs)
 
 			var err error
-			cleanupCSV, err = createCSV(c, crc, csv, namespace.Name, false, false)
+			cleanupCSV, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).Should(BeNil())
 
-			_, err = fetchCSV(crc, csv.Name, namespace.Name, csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).Should(BeNil())
 			actualWebhook, err := getWebhookWithGenerateName(c, webhook.GenerateName)
 			Expect(err).Should(BeNil())

--- a/staging/operator-lifecycle-manager/test/e2e/webhook_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/webhook_e2e_test.go
@@ -415,7 +415,7 @@ var _ = Describe("CSVs with a Webhook", func() {
 
 			// Make sure old resources are cleaned up.
 			Eventually(func() bool {
-				return csvExists(crc, csv.Spec.Replaces)
+				return csvExists(generatedNamespace.GetName(), crc, csv.Spec.Replaces)
 			}).Should(BeFalse())
 
 			// Wait until previous webhook is cleaned up


### PR DESCRIPTION
Ensure the `make e2e/olm ARTIFACTS_DIR=...` works when running the upstream OLM e2e suite in downstream CI environments.