### PR TITLE
Bug 2074612: Fix GRPC CheckRegistryServer function (#2756)

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator_test.go
@@ -1037,6 +1037,7 @@ func TestSyncCatalogSources(t *testing.T) {
 			k8sObjs: []runtime.Object{
 				pod(*grpcCatalog),
 				service(grpcCatalog.GetName(), grpcCatalog.GetNamespace()),
+				serviceAccount(grpcCatalog.GetName(), grpcCatalog.GetNamespace(), "", objectReference("init secret")),
 			},
 			existingSources: []sourceAddress{
 				{

--- a/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/grpc_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/grpc_test.go
@@ -485,6 +485,18 @@ func TestGrpcRegistryChecker(t *testing.T) {
 			},
 		},
 		{
+			testName: "Grpc/ExistingRegistry/Image/BadServiceAccount",
+			in: in{
+				cluster: cluster{
+					k8sObjs: modifyObjName(objectsForCatalogSource(validGrpcCatalogSource("test-img", "")), &corev1.ServiceAccount{}, "badName"),
+				},
+				catsrc: validGrpcCatalogSource("test-img", ""),
+			},
+			out: out{
+				healthy: false,
+			},
+		},
+		{
 			testName: "Grpc/ExistingRegistry/Image/BadPod",
 			in: in{
 				cluster: cluster{


### PR DESCRIPTION
Problem: The CheckRegistryServer function used by grpc catalogSources
does not confirm that the serviceAccount associated with the
catalogSource exists.

Solution: Update the GRPC CheckRegistryServer function to check if the
serviceAccount exists.

Signed-off-by: Alexander Greene <greene.al1991@gmail.com>

Upstream-repository: operator-lifecycle-manager
Upstream-commit: 7e8e9f77d08d1bf451ce61b7bb2610473e793ded