### PR TITLE
manifests/*: comply to restricted pod security level

### DIFF
--- a/manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
+++ b/manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
@@ -21,10 +21,19 @@ spec:
       labels:
         app: package-server-manager
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: olm-operator-serviceaccount
       priorityClassName: "system-cluster-critical"
       containers:
         - name: package-server-manager
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           command:
             - /bin/psm
             - start

--- a/manifests/0000_50_olm_06-psm-operator.deployment.yaml
+++ b/manifests/0000_50_olm_06-psm-operator.deployment.yaml
@@ -21,10 +21,19 @@ spec:
       labels:
         app: package-server-manager
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: olm-operator-serviceaccount
       priorityClassName: "system-cluster-critical"
       containers:
         - name: package-server-manager
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           command:
             - /bin/psm
             - start

--- a/manifests/0000_50_olm_07-collect-profiles.cronjob.yaml
+++ b/manifests/0000_50_olm_07-collect-profiles.cronjob.yaml
@@ -13,10 +13,19 @@ spec:
     spec:
       template:
         spec:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: collect-profiles
           priorityClassName: openshift-user-critical
           containers:
             - name: collect-profiles
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
               image: quay.io/operator-framework/olm@sha256:de396b540b82219812061d0d753440d5655250c621c753ed1dc67d6154741607
               imagePullPolicy: IfNotPresent
               command:

--- a/manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
+++ b/manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
@@ -21,6 +21,11 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: olm-operator-serviceaccount
       volumes:
         - name: srv-cert
@@ -31,6 +36,10 @@ spec:
             secretName: pprof-cert
       containers:
         - name: olm-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - name: srv-cert
               mountPath: "/srv-cert"

--- a/manifests/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/manifests/0000_50_olm_07-olm-operator.deployment.yaml
@@ -21,6 +21,11 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: olm-operator-serviceaccount
       volumes:
         - name: srv-cert
@@ -31,6 +36,10 @@ spec:
             secretName: pprof-cert
       containers:
         - name: olm-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - name: srv-cert
               mountPath: "/srv-cert"

--- a/manifests/0000_50_olm_08-catalog-operator.deployment.ibm-cloud-managed.yaml
+++ b/manifests/0000_50_olm_08-catalog-operator.deployment.ibm-cloud-managed.yaml
@@ -21,6 +21,11 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: olm-operator-serviceaccount
       volumes:
         - name: srv-cert
@@ -31,6 +36,10 @@ spec:
             secretName: pprof-cert
       containers:
         - name: catalog-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - name: srv-cert
               mountPath: "/srv-cert"

--- a/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -21,6 +21,11 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: olm-operator-serviceaccount
       volumes:
         - name: srv-cert
@@ -31,6 +36,10 @@ spec:
             secretName: pprof-cert
       containers:
         - name: catalog-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - name: srv-cert
               mountPath: "/srv-cert"

--- a/pkg/manifests/csv.yaml
+++ b/pkg/manifests/csv.yaml
@@ -88,6 +88,11 @@ spec:
                   target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
                 creationTimestamp: null
               spec:
+                securityContext:
+                  runAsNonRoot: true
+                  runAsUser: 65534
+                  seccompProfile:
+                    type: RuntimeDefault
                 serviceAccountName: olm-operator-serviceaccount
                 nodeSelector:
                   kubernetes.io/os: linux
@@ -106,6 +111,10 @@ spec:
                     tolerationSeconds: 120
                 containers:
                   - name: packageserver
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop: ["ALL"]
                     command:
                       - /bin/package-server
                       - -v=4

--- a/scripts/generate_crds_manifests.sh
+++ b/scripts/generate_crds_manifests.sh
@@ -114,10 +114,19 @@ spec:
       labels:
         app: package-server-manager
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: olm-operator-serviceaccount
       priorityClassName: "system-cluster-critical"
       containers:
         - name: package-server-manager
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           command:
             - /bin/psm
             - start
@@ -262,10 +271,19 @@ spec:
     spec:
       template:
         spec:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: collect-profiles
           priorityClassName: openshift-user-critical
           containers:
           - name: collect-profiles
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
             image: quay.io/operator-framework/olm@sha256:de396b540b82219812061d0d753440d5655250c621c753ed1dc67d6154741607
             imagePullPolicy: IfNotPresent
             command:

--- a/staging/operator-lifecycle-manager/deploy/chart/templates/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/staging/operator-lifecycle-manager/deploy/chart/templates/0000_50_olm_07-olm-operator.deployment.yaml
@@ -17,6 +17,11 @@ spec:
       labels:
         app: olm-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: olm-operator-serviceaccount
       {{- if or .Values.olm.tlsSecret .Values.olm.clientCASecret }}
       volumes: 
@@ -33,6 +38,10 @@ spec:
       {{- end }}
       containers:
         - name: olm-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           {{- if or .Values.olm.tlsSecret .Values.olm.clientCASecret }}
           volumeMounts:
           {{- end }}

--- a/staging/operator-lifecycle-manager/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/staging/operator-lifecycle-manager/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -17,6 +17,11 @@ spec:
       labels:
         app: catalog-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: olm-operator-serviceaccount
       {{- if or .Values.catalog.tlsSecret .Values.catalog.clientCASecret }}
       volumes:
@@ -33,6 +38,10 @@ spec:
       {{- end }}
       containers:
         - name: catalog-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           {{- if or .Values.catalog.tlsSecret .Values.catalog.clientCASecret }}
           volumeMounts:
           {{- end }}

--- a/staging/operator-lifecycle-manager/deploy/chart/templates/_packageserver.deployment-spec.yaml
+++ b/staging/operator-lifecycle-manager/deploy/chart/templates/_packageserver.deployment-spec.yaml
@@ -14,6 +14,11 @@ spec:
       labels:
         app: packageserver
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: olm-operator-serviceaccount
       {{- if .Values.package.nodeSelector }}
       nodeSelector:
@@ -25,6 +30,10 @@ spec:
       {{- end }}
       containers:
       - name: packageserver
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
         command:
         - /bin/package-server
         - -v=4


### PR DESCRIPTION
Starting from OpenShift 4.11 pod security admission is being activated. In OpenShift the default pod security admission level is going to be `restricted`. This PR fixes workloads from this repository. Concretely, the following violations have been detected:

```
{
  "objectRef": "openshift-operator-lifecycle-manager/deployments/olm-operator",
  "pod-security.kubernetes.io/audit-violations": "would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"olm-operator\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities
(container \"olm-operator\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (pod or container \"olm-operator\" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container \"olm-operator\" must set se
curityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")"
}

{
  "objectRef": "openshift-operator-lifecycle-manager/deployments/package-server-manager",
  "pod-security.kubernetes.io/audit-violations": "would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"package-server-manager\" must set securityContext.allowPrivilegeEscalation=false), unrestricted cap
abilities (container \"package-server-manager\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (pod or container \"package-server-manager\" must set securityContext.runAsNonRoot=true), seccompProfile (pod or containe
r \"package-server-manager\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")"
}

{
  "objectRef": "openshift-operator-lifecycle-manager/deployments/catalog-operator",
  "pod-security.kubernetes.io/audit-violations": "would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"catalog-operator\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilit
ies (container \"catalog-operator\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (pod or container \"catalog-operator\" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container \"catalog-operat
or\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")"
}

{
  "objectRef": "openshift-operator-lifecycle-manager/cronjobs/collect-profiles",
  "pod-security.kubernetes.io/audit-violations": "would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"collect-profiles\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilit
ies (container \"collect-profiles\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (pod or container \"collect-profiles\" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container \"collect-profil
es\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")"
}
```

/cc @stlaz 