### PR TITLE
Bug 1982737: Make malformed CSV fail nicely (#2673)

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/errors/errors.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/errors/errors.go
@@ -47,6 +47,21 @@ func IsMultipleExistingCRDOwnersError(err error) bool {
 	return false
 }
 
+type FatalError struct {
+	error
+}
+
+func NewFatalError(err error) FatalError {
+	return FatalError{err}
+}
+func IsFatal(err error) bool {
+	switch err.(type) {
+	case FatalError:
+		return true
+	}
+	return false
+}
+
 // GroupVersionKindNotFoundError occurs when we can't find an API via discovery
 type GroupVersionKindNotFoundError struct {
 	Group   string

--- a/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/steps.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/steps.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	olmerrors "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/errors"
 	"github.com/operator-framework/operator-registry/pkg/api"
 	extScheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -116,6 +117,15 @@ func NewStepResourceFromBundle(bundle *api.Bundle, namespace, replaces, catalogS
 	csv, err := V1alpha1CSVFromBundle(bundle)
 	if err != nil {
 		return nil, err
+	}
+
+	// Check unpacked bundled for for missing APIVersion or Kind
+	if csv.APIVersion == "" {
+		return nil, olmerrors.NewFatalError(fmt.Errorf("bundle CSV %s missing APIVersion", csv.Name))
+	}
+
+	if csv.Kind == "" {
+		return nil, olmerrors.NewFatalError(fmt.Errorf("bundle CSV %s missing Kind", csv.Name))
 	}
 
 	csv.SetNamespace(namespace)

--- a/staging/operator-lifecycle-manager/test/e2e/testdata/bad-csv/bad-csv.yaml
+++ b/staging/operator-lifecycle-manager/test/e2e/testdata/bad-csv/bad-csv.yaml
@@ -1,0 +1,25 @@
+---
+schema: olm.package
+name: packageA
+defaultChannel: stable
+---
+schema: olm.channel
+package: packageA
+name: stable
+entries:
+  - name: bad-csv
+---
+schema: olm.bundle
+name: bad-csv
+package: packageA
+image: quay.io/olmtest/missing_api_version:latest
+properties:
+  - type: olm.gvk
+    value:
+      group: example.com
+      kind: TestA
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: packageA
+      version: 1.0.0

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/errors/errors.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/errors/errors.go
@@ -47,6 +47,21 @@ func IsMultipleExistingCRDOwnersError(err error) bool {
 	return false
 }
 
+type FatalError struct {
+	error
+}
+
+func NewFatalError(err error) FatalError {
+	return FatalError{err}
+}
+func IsFatal(err error) bool {
+	switch err.(type) {
+	case FatalError:
+		return true
+	}
+	return false
+}
+
 // GroupVersionKindNotFoundError occurs when we can't find an API via discovery
 type GroupVersionKindNotFoundError struct {
 	Group   string

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/steps.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/steps.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	olmerrors "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/errors"
 	"github.com/operator-framework/operator-registry/pkg/api"
 	extScheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -116,6 +117,15 @@ func NewStepResourceFromBundle(bundle *api.Bundle, namespace, replaces, catalogS
 	csv, err := V1alpha1CSVFromBundle(bundle)
 	if err != nil {
 		return nil, err
+	}
+
+	// Check unpacked bundled for for missing APIVersion or Kind
+	if csv.APIVersion == "" {
+		return nil, olmerrors.NewFatalError(fmt.Errorf("bundle CSV %s missing APIVersion", csv.Name))
+	}
+
+	if csv.Kind == "" {
+		return nil, olmerrors.NewFatalError(fmt.Errorf("bundle CSV %s missing Kind", csv.Name))
 	}
 
 	csv.SetNamespace(namespace)


### PR DESCRIPTION
- Modified bundle unpacking to fail installPlan with a nice message if
after unbundling csv manifests APIVersion or Kind are blank.

- Adds FatalError type to return to checked when syncing install plans
 to see if the error causing issues is fatal or should cause the
 IP to be transitioned to failed state.

- Makes installPlan fail with a nicer more user friendly message than
the current difficult to understand message regarding serviceAccounts.

- Adds tests using internal magic-catalog library to  confirm that unpacking
fails when APIVersion is blank.

Signed-off-by: Noah Sapse <nsapse@redhat.com>

Co-authored-by: Noah Sapse <nsapse@redhat.com>
Upstream-repository: operator-lifecycle-manager
Upstream-commit: 3002cf79ce867e32d30d2190df642eaa7f449294