### PR TITLE
Bug 2093288: fix(grpc): Add startupProbe to check for grpc health readiness (#2791)

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
@@ -151,6 +151,15 @@ func Pod(source *operatorsv1alpha1.CatalogSource, name string, image string, saN
 						InitialDelaySeconds: livenessDelay,
 						TimeoutSeconds:      5,
 					},
+					StartupProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							Exec: &corev1.ExecAction{
+								Command: []string{"grpc_health_probe", "-addr=:50051"},
+							},
+						},
+						FailureThreshold: 15,
+						PeriodSeconds:    10,
+					},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("10m"),

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
@@ -151,6 +151,15 @@ func Pod(source *operatorsv1alpha1.CatalogSource, name string, image string, saN
 						InitialDelaySeconds: livenessDelay,
 						TimeoutSeconds:      5,
 					},
+					StartupProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							Exec: &corev1.ExecAction{
+								Command: []string{"grpc_health_probe", "-addr=:50051"},
+							},
+						},
+						FailureThreshold: 15,
+						PeriodSeconds:    10,
+					},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("10m"),


### PR DESCRIPTION
Currently, liveness and readiness probes may fail due to grpc is not
ready. Adding a startupProbe will ensure grpc is ready before
liveness and readiness probes are triggered.

Upstream-repository: operator-lifecycle-manager
Upstream-commit: 8987522f97ea3726b42ce6fe23ce5aa75efa83ba

Signed-off-by: Vu Dinh <vudinh@outlook.com>