### PR TITLE
Support Global Operators in Console

### DIFF
--- a/manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
+++ b/manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
@@ -53,6 +53,8 @@ spec:
             - /srv-cert/tls.key
             - --client-ca
             - /profile-collector-cert/tls.crt
+            - --protectedCopiedCSVNamespaces
+            - openshift
           image: quay.io/operator-framework/olm@sha256:de396b540b82219812061d0d753440d5655250c621c753ed1dc67d6154741607
           imagePullPolicy: IfNotPresent
           ports:

--- a/manifests/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/manifests/0000_50_olm_07-olm-operator.deployment.yaml
@@ -53,6 +53,8 @@ spec:
             - /srv-cert/tls.key
             - --client-ca
             - /profile-collector-cert/tls.crt
+            - --protectedCopiedCSVNamespaces
+            - openshift
           image: quay.io/operator-framework/olm@sha256:de396b540b82219812061d0d753440d5655250c621c753ed1dc67d6154741607
           imagePullPolicy: IfNotPresent
           ports:

--- a/manifests/0000_50_olm_15-csv-viewer.rbac.yaml
+++ b/manifests/0000_50_olm_15-csv-viewer.rbac.yaml
@@ -1,0 +1,36 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+  name: copied-csv-viewer
+  namespace: openshift
+rules:
+  - apiGroups:
+      - "operators.coreos.com"
+    resources:
+      - "clusterserviceversions"
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+  name: copied-csv-viewers
+  namespace: openshift
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: copied-csv-viewer
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated

--- a/scripts/generate_crds_manifests.sh
+++ b/scripts/generate_crds_manifests.sh
@@ -363,6 +363,41 @@ metadata:
     release.openshift.io/delete: "true"
 EOF
 
+cat << EOF > manifests/0000_50_olm_15-csv-viewer.rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: copied-csv-viewer
+  namespace: openshift
+rules:
+- apiGroups:
+  - "operators.coreos.com"
+  resources:
+  - "clusterserviceversions"
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: copied-csv-viewers
+  namespace: openshift
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: copied-csv-viewer
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+EOF
+
 add_ibm_managed_cloud_annotations "${ROOT_DIR}/manifests"
 
 find "${ROOT_DIR}/manifests" -type f -exec $SED -i "/^#/d" {} \;

--- a/scripts/olm-deployment.patch.yaml
+++ b/scripts/olm-deployment.patch.yaml
@@ -10,6 +10,14 @@
     name: RELEASE_VERSION
     value: "0.0.1-snapshot"
 - command: update
+  path: spec.template.spec.containers[0].args[+]
+  value:
+    --protectedCopiedCSVNamespaces
+- command: update
+  path: spec.template.spec.containers[0].args[+]
+  value:
+    openshift
+- command: update
   path: spec.template.spec.containers[*].securityContext
   value:
     allowPrivilegeEscalation: false

--- a/staging/operator-lifecycle-manager/cmd/olm/main.go
+++ b/staging/operator-lifecycle-manager/cmd/olm/main.go
@@ -60,6 +60,9 @@ var (
 	tlsKeyPath = pflag.String(
 		"tls-key", "", "Path to use for private key (requires tls-cert)")
 
+	protectedCopiedCSVNamespaces = pflag.String("protectedCopiedCSVNamespaces",
+		"", "A comma-delimited set of namespaces where global Copied CSVs will always appear, even if Copied CSVs are disabled")
+
 	tlsCertPath = pflag.String(
 		"tls-cert", "", "Path to use for certificate key (requires tls-key)")
 
@@ -162,6 +165,7 @@ func main() {
 		olm.WithOperatorClient(opClient),
 		olm.WithRestConfig(config),
 		olm.WithConfigClient(versionedConfigClient),
+		olm.WithProtectedCopiedCSVNamespaces(*protectedCopiedCSVNamespaces),
 	)
 	if err != nil {
 		logger.WithError(err).Fatal("error configuring operator")

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/config.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/config.go
@@ -1,6 +1,7 @@
 package olm
 
 import (
+	"strings"
 	"time"
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
@@ -21,18 +22,19 @@ import (
 type OperatorOption func(*operatorConfig)
 
 type operatorConfig struct {
-	resyncPeriod      func() time.Duration
-	operatorNamespace string
-	watchedNamespaces []string
-	clock             utilclock.Clock
-	logger            *logrus.Logger
-	operatorClient    operatorclient.ClientInterface
-	externalClient    versioned.Interface
-	strategyResolver  install.StrategyResolverInterface
-	apiReconciler     APIIntersectionReconciler
-	apiLabeler        labeler.Labeler
-	restConfig        *rest.Config
-	configClient      configv1client.Interface
+	protectedCopiedCSVNamespaces map[string]struct{}
+	resyncPeriod                 func() time.Duration
+	operatorNamespace            string
+	watchedNamespaces            []string
+	clock                        utilclock.Clock
+	logger                       *logrus.Logger
+	operatorClient               operatorclient.ClientInterface
+	externalClient               versioned.Interface
+	strategyResolver             install.StrategyResolverInterface
+	apiReconciler                APIIntersectionReconciler
+	apiLabeler                   labeler.Labeler
+	restConfig                   *rest.Config
+	configClient                 configv1client.Interface
 }
 
 func (o *operatorConfig) apply(options []OperatorOption) {
@@ -77,14 +79,15 @@ func (o *operatorConfig) validate() (err error) {
 
 func defaultOperatorConfig() *operatorConfig {
 	return &operatorConfig{
-		resyncPeriod:      queueinformer.ResyncWithJitter(30*time.Second, 0.2),
-		operatorNamespace: "default",
-		watchedNamespaces: []string{metav1.NamespaceAll},
-		clock:             utilclock.RealClock{},
-		logger:            logrus.New(),
-		strategyResolver:  &install.StrategyResolver{},
-		apiReconciler:     APIIntersectionReconcileFunc(ReconcileAPIIntersection),
-		apiLabeler:        labeler.Func(LabelSetsFor),
+		resyncPeriod:                 queueinformer.ResyncWithJitter(30*time.Second, 0.2),
+		operatorNamespace:            "default",
+		watchedNamespaces:            []string{metav1.NamespaceAll},
+		clock:                        utilclock.RealClock{},
+		logger:                       logrus.New(),
+		strategyResolver:             &install.StrategyResolver{},
+		apiReconciler:                APIIntersectionReconcileFunc(ReconcileAPIIntersection),
+		apiLabeler:                   labeler.Func(LabelSetsFor),
+		protectedCopiedCSVNamespaces: map[string]struct{}{},
 	}
 }
 
@@ -109,6 +112,18 @@ func WithWatchedNamespaces(namespaces ...string) OperatorOption {
 func WithLogger(logger *logrus.Logger) OperatorOption {
 	return func(config *operatorConfig) {
 		config.logger = logger
+	}
+}
+
+func WithProtectedCopiedCSVNamespaces(namespaces string) OperatorOption {
+	return func(config *operatorConfig) {
+		if namespaces == "" {
+			return
+		}
+
+		for _, ns := range strings.Split(namespaces, ",") {
+			config.protectedCopiedCSVNamespaces[ns] = struct{}{}
+		}
 	}
 }
 

--- a/staging/operator-lifecycle-manager/test/e2e/disabling_copied_csv_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/disabling_copied_csv_e2e_test.go
@@ -3,12 +3,14 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/ctx"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,11 +21,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	olmDeploymentName                       = "olm-operator"
+	protectedCopiedCSVNamespacesRuntimeFlag = "--protectedCopiedCSVNamespaces"
+)
+
 var _ = Describe("Disabling copied CSVs", func() {
 	var (
 		ns                              corev1.Namespace
 		csv                             operatorsv1alpha1.ClusterServiceVersion
 		nonTerminatingNamespaceSelector = fields.ParseSelectorOrDie("status.phase!=Terminating")
+		protectedCopiedCSVNamespaces    = map[string]struct{}{}
 	)
 
 	BeforeEach(func() {
@@ -95,7 +103,6 @@ var _ = Describe("Disabling copied CSVs", func() {
 	})
 
 	When("Copied CSVs are disabled", func() {
-
 		BeforeEach(func() {
 			Eventually(func() error {
 				var olmConfig operatorsv1.OLMConfig
@@ -122,6 +129,10 @@ var _ = Describe("Disabling copied CSVs", func() {
 
 				return nil
 			}).Should(Succeed())
+
+			Eventually(func() error {
+				return setProtectedCopiedCSVNamespaces(protectedCopiedCSVNamespaces)
+			}).Should(Succeed())
 		})
 
 		It("should not have any copied CSVs", func() {
@@ -139,8 +150,14 @@ var _ = Describe("Disabling copied CSVs", func() {
 					return err
 				}
 
-				if numCSVs := len(copiedCSVs.Items); numCSVs != 0 {
-					return fmt.Errorf("Found %d copied CSVs, should be 0", numCSVs)
+				if numCSVs := len(copiedCSVs.Items); numCSVs != len(protectedCopiedCSVNamespaces) {
+					return fmt.Errorf("Found %d copied CSVs, should be %d", numCSVs, len(protectedCopiedCSVNamespaces))
+				}
+
+				for _, csv := range copiedCSVs.Items {
+					if _, ok := protectedCopiedCSVNamespaces[csv.GetNamespace()]; !ok {
+						return fmt.Errorf("copied CSV %s/%s should not exist in the given namespace", csv.GetNamespace(), csv.GetName())
+					}
 				}
 				return nil
 			}).Should(Succeed())
@@ -159,8 +176,8 @@ var _ = Describe("Disabling copied CSVs", func() {
 				}
 
 				expectedCondition := metav1.Condition{
-					Reason:  "NoCopiedCSVsFound",
-					Message: "Copied CSVs are disabled and none were found for operators installed in AllNamespace mode",
+					Reason:  "CopiedCSVsDisabled",
+					Message: "Copied CSVs are disabled and no unexpected copied CSVs were found for operators installed in AllNamespace mode",
 					Status:  metav1.ConditionTrue,
 				}
 
@@ -260,3 +277,31 @@ var _ = Describe("Disabling copied CSVs", func() {
 		})
 	})
 })
+
+func setProtectedCopiedCSVNamespaces(protectedCopiedCSVNamespaces map[string]struct{}) error {
+	var olmDeployment appsv1.Deployment
+	if err := ctx.Ctx().Client().Get(context.TODO(), apitypes.NamespacedName{Name: olmDeploymentName, Namespace: operatorNamespace}, &olmDeployment); err != nil {
+		return err
+	}
+
+	if protectedNamespaceArgument := getRuntimeFlagValue(&olmDeployment, olmDeploymentName, protectedCopiedCSVNamespacesRuntimeFlag); protectedNamespaceArgument != "" {
+		for _, namespace := range strings.Split(protectedNamespaceArgument, ",") {
+			protectedCopiedCSVNamespaces[namespace] = struct{}{}
+		}
+	}
+
+	return nil
+}
+
+func getRuntimeFlagValue(deployment *appsv1.Deployment, containerName string, runtimeFlag string) string {
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		if container.Name == containerName {
+			for i := range container.Args {
+				if container.Args[i] == runtimeFlag && len(container.Args) > i+1 {
+					return container.Args[i+1]
+				}
+			}
+		}
+	}
+	return ""
+}

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/cmd/olm/main.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/cmd/olm/main.go
@@ -60,6 +60,9 @@ var (
 	tlsKeyPath = pflag.String(
 		"tls-key", "", "Path to use for private key (requires tls-cert)")
 
+	protectedCopiedCSVNamespaces = pflag.String("protectedCopiedCSVNamespaces",
+		"", "A comma-delimited set of namespaces where global Copied CSVs will always appear, even if Copied CSVs are disabled")
+
 	tlsCertPath = pflag.String(
 		"tls-cert", "", "Path to use for certificate key (requires tls-key)")
 
@@ -162,6 +165,7 @@ func main() {
 		olm.WithOperatorClient(opClient),
 		olm.WithRestConfig(config),
 		olm.WithConfigClient(versionedConfigClient),
+		olm.WithProtectedCopiedCSVNamespaces(*protectedCopiedCSVNamespaces),
 	)
 	if err != nil {
 		logger.WithError(err).Fatal("error configuring operator")

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/config.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/config.go
@@ -1,6 +1,7 @@
 package olm
 
 import (
+	"strings"
 	"time"
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
@@ -21,18 +22,19 @@ import (
 type OperatorOption func(*operatorConfig)
 
 type operatorConfig struct {
-	resyncPeriod      func() time.Duration
-	operatorNamespace string
-	watchedNamespaces []string
-	clock             utilclock.Clock
-	logger            *logrus.Logger
-	operatorClient    operatorclient.ClientInterface
-	externalClient    versioned.Interface
-	strategyResolver  install.StrategyResolverInterface
-	apiReconciler     APIIntersectionReconciler
-	apiLabeler        labeler.Labeler
-	restConfig        *rest.Config
-	configClient      configv1client.Interface
+	protectedCopiedCSVNamespaces map[string]struct{}
+	resyncPeriod                 func() time.Duration
+	operatorNamespace            string
+	watchedNamespaces            []string
+	clock                        utilclock.Clock
+	logger                       *logrus.Logger
+	operatorClient               operatorclient.ClientInterface
+	externalClient               versioned.Interface
+	strategyResolver             install.StrategyResolverInterface
+	apiReconciler                APIIntersectionReconciler
+	apiLabeler                   labeler.Labeler
+	restConfig                   *rest.Config
+	configClient                 configv1client.Interface
 }
 
 func (o *operatorConfig) apply(options []OperatorOption) {
@@ -77,14 +79,15 @@ func (o *operatorConfig) validate() (err error) {
 
 func defaultOperatorConfig() *operatorConfig {
 	return &operatorConfig{
-		resyncPeriod:      queueinformer.ResyncWithJitter(30*time.Second, 0.2),
-		operatorNamespace: "default",
-		watchedNamespaces: []string{metav1.NamespaceAll},
-		clock:             utilclock.RealClock{},
-		logger:            logrus.New(),
-		strategyResolver:  &install.StrategyResolver{},
-		apiReconciler:     APIIntersectionReconcileFunc(ReconcileAPIIntersection),
-		apiLabeler:        labeler.Func(LabelSetsFor),
+		resyncPeriod:                 queueinformer.ResyncWithJitter(30*time.Second, 0.2),
+		operatorNamespace:            "default",
+		watchedNamespaces:            []string{metav1.NamespaceAll},
+		clock:                        utilclock.RealClock{},
+		logger:                       logrus.New(),
+		strategyResolver:             &install.StrategyResolver{},
+		apiReconciler:                APIIntersectionReconcileFunc(ReconcileAPIIntersection),
+		apiLabeler:                   labeler.Func(LabelSetsFor),
+		protectedCopiedCSVNamespaces: map[string]struct{}{},
 	}
 }
 
@@ -109,6 +112,18 @@ func WithWatchedNamespaces(namespaces ...string) OperatorOption {
 func WithLogger(logger *logrus.Logger) OperatorOption {
 	return func(config *operatorConfig) {
 		config.logger = logger
+	}
+}
+
+func WithProtectedCopiedCSVNamespaces(namespaces string) OperatorOption {
+	return func(config *operatorConfig) {
+		if namespaces == "" {
+			return
+		}
+
+		for _, ns := range strings.Split(namespaces, ",") {
+			config.protectedCopiedCSVNamespaces[ns] = struct{}{}
+		}
 	}
 }
 


### PR DESCRIPTION
**Problem:** Users rely on Copied CSVs in order to understand which
operators are available in a given namespace. When installing All
Namespace operators, a Copied CSV is created in every namespace which
can place a huge performance strain on clusters with many namespaces.
OLM introduced the ability to disable Copied CSVs for All Namespace mode
operators  in an effort to resolve the performance issues on large clusters,
unfortunately removing the ability for console to communicate which global
operators are available in a given namespace.

**Solution:** The protectedCopiedCSVNamespaces runtime flag can be used to
prevent Copied CSVs from being deleted in certain namespaces even when
Copied CSVs are disabled. OLM has been configured to ensure that Copied CSVs
are protected in the openshift namespace. OLM's manifest yaml has also been
updated to provide authenticated users with the RBAC to view CSVs in the
openshift namespace, which console can then use to communicate which operators
are available globally.