### PR TITLE
Makefile: Revert back to using kubectl instead of oc during tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ e2e/operator-registry: ## Run e2e registry tests
 	$(MAKE) e2e WHAT=operator-registry
 
 e2e/olm: ## Run e2e olm tests
-	$(MAKE) e2e WHAT=operator-lifecycle-manager E2E_INSTALL_NS=openshift-operator-lifecycle-manager E2E_TEST_NS=openshift-operators E2E_TIMEOUT=120m KUBECTL=oc
+	$(MAKE) e2e WHAT=operator-lifecycle-manager E2E_INSTALL_NS=openshift-operator-lifecycle-manager E2E_TEST_NS=openshift-operators E2E_TIMEOUT=120m KUBECTL=kubectl
 
 .PHONY: vendor
 vendor:


### PR DESCRIPTION
Over the last month or so, it looks like we're no longer able to run out
scripts that are responsible for gathering test artifacts as the 'oc'
executable isn't present in $PATH. After diving into the terminal for
recent CI runs, it looks like 'oc' isn't present in the container that
runs the e2e tests, but 'kubectl' is present. This updates the KUBECTL
environment variable that the staging OLM e2e suite consumes to ensure
we can correctly gather testing artifacts.

Signed-off-by: timflannagan <timflannagan@gmail.com>