### PR TITLE
Explicitly override the global catalog namespace 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ e2e/operator-registry: ## Run e2e registry tests
 	$(MAKE) e2e WHAT=operator-registry
 
 e2e/olm: ## Run e2e olm tests
-	$(MAKE) e2e WHAT=operator-lifecycle-manager E2E_INSTALL_NS=openshift-operator-lifecycle-manager E2E_TEST_NS=openshift-operators E2E_TIMEOUT=120m KUBECTL=oc
+	$(MAKE) e2e WHAT=operator-lifecycle-manager E2E_CATALOG_NS=openshift-marketplace E2E_INSTALL_NS=openshift-operator-lifecycle-manager E2E_TEST_NS=openshift-operators E2E_TIMEOUT=120m KUBECTL=oc
 
 .PHONY: vendor
 vendor:

--- a/staging/operator-lifecycle-manager/Makefile
+++ b/staging/operator-lifecycle-manager/Makefile
@@ -134,10 +134,11 @@ TEST := $(shell go run ./test/e2e/split/... -chunks $(E2E_TEST_NUM_CHUNKS) -prin
 endif
 E2E_OPTS ?= $(if $(E2E_SEED),-seed '$(E2E_SEED)') $(if $(SKIP), -skip '$(SKIP)') $(if $(TEST),-focus '$(TEST)') $(if $(ARTIFACT_DIR), -output-dir $(ARTIFACT_DIR) -junit-report junit_e2e.xml) -flake-attempts $(E2E_FLAKE_ATTEMPTS) -nodes $(E2E_NODES) -timeout $(E2E_TIMEOUT) -v -randomize-suites -race -trace -progress
 E2E_INSTALL_NS ?= operator-lifecycle-manager
+E2E_CATALOG_NS ?= $(E2E_INSTALL_NS)
 E2E_TEST_NS ?= operators
 
 e2e:
-	$(GINKGO) $(E2E_OPTS) $(or $(run), ./test/e2e) $< -- -namespace=$(E2E_TEST_NS) -olmNamespace=$(E2E_INSTALL_NS) -dummyImage=bitnami/nginx:latest $(or $(extra_args), -kubeconfig=${KUBECONFIG})
+	$(GINKGO) $(E2E_OPTS) $(or $(run), ./test/e2e) $< -- -namespace=$(E2E_TEST_NS) -olmNamespace=$(E2E_INSTALL_NS) -catalogNamespace=$(E2E_CATALOG_NS) -dummyImage=bitnami/nginx:latest $(or $(extra_args), -kubeconfig=${KUBECONFIG})
 
 # See workflows/e2e-tests.yml See test/e2e/README.md for details.
 .PHONY: e2e-local

--- a/staging/operator-lifecycle-manager/test/e2e/catalog_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/catalog_e2e_test.go
@@ -131,17 +131,6 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 	})
 
 	It("global update triggers subscription sync", func() {
-		globalNS := operatorNamespace
-
-		// Determine which namespace is global. Should be `openshift-marketplace` for OCP 4.2+.
-		// Locally it is `olm`
-		namespaces, _ := c.KubernetesInterface().CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
-		for _, ns := range namespaces.Items {
-			if ns.GetName() == "openshift-marketplace" {
-				globalNS = "openshift-marketplace"
-			}
-		}
-
 		mainPackageName := genName("nginx-")
 
 		mainPackageStable := fmt.Sprintf("%s-stable", mainPackageName)
@@ -179,7 +168,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 		}
 
 		// Create the initial catalog source
-		cs, cleanup := createInternalCatalogSource(c, crc, mainCatalogName, globalNS, mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []v1alpha1.ClusterServiceVersion{mainCSV})
+		cs, cleanup := createInternalCatalogSource(c, crc, mainCatalogName, globalCatalogNamespace, mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []v1alpha1.ClusterServiceVersion{mainCSV})
 		defer cleanup()
 
 		// Attempt to get the catalog source before creating install plan

--- a/staging/operator-lifecycle-manager/test/e2e/catalog_exclusion_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/catalog_exclusion_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Global Catalog Exclusion", func() {
 		globalCatalog := &v1alpha1.CatalogSource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      genName("bad-global-catalog-"),
-				Namespace: operatorNamespace,
+				Namespace: globalCatalogNamespace,
 			},
 			Spec: v1alpha1.CatalogSourceSpec{
 				DisplayName: "Broken Global Catalog Source",
@@ -105,7 +105,7 @@ var _ = Describe("Global Catalog Exclusion", func() {
 		When("the operator group is annotated with olm.operatorframework.io/exclude-global-namespace-resolution=true", func() {
 			// Note: this test flakes on openshift CI but passes running on a local openshift cluster
 			// For some reason, the subscription does not transition to a failed state in time
-			It("[FLAKE] the broken subscription should resolve and have state AtLatest", func() {
+			It("the broken subscription should resolve and have state AtLatest", func() {
 				By("checking that the subscription is not resolving and has a condition with type ResolutionFailed")
 				EventuallyResource(subscription, 5*time.Minute).Should(ContainSubscriptionConditionOfType(v1alpha1.SubscriptionResolutionFailed))
 

--- a/staging/operator-lifecycle-manager/test/e2e/e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/e2e_test.go
@@ -26,6 +26,9 @@ var (
 	olmNamespace = flag.String(
 		"olmNamespace", "", "namespace where olm is running")
 
+	catalogNamespace = flag.String(
+		"catalogNamespace", "", "namespace where the global catalog content is stored")
+
 	communityOperators = flag.String(
 		"communityOperators",
 		"quay.io/operator-framework/upstream-community-operators@sha256:098457dc5e0b6ca9599bd0e7a67809f8eca397907ca4d93597380511db478fec",
@@ -54,6 +57,7 @@ var (
 	testNamespace           = ""
 	operatorNamespace       = ""
 	communityOperatorsImage = ""
+	globalCatalogNamespace  = ""
 	junitDir                = "junit"
 )
 
@@ -82,6 +86,7 @@ var _ = BeforeSuite(func() {
 	testNamespace = *namespace
 	operatorNamespace = *olmNamespace
 	communityOperatorsImage = *communityOperators
+	globalCatalogNamespace = *catalogNamespace
 	testdataDir = *testdataPath
 	deprovision = ctx.MustProvision(ctx.Ctx())
 	ctx.MustInstall(ctx.Ctx())


### PR DESCRIPTION
Update the staging OLM testing suite, and override the E2E_CATALOG_NS and configure the global catalog namespace to the openshift-marketplace namespace. This should fix the permafailing global catalog exclusion tests as they were previously pointing to the wrong downstream namespace.