### PR TITLE
Psa downstream

### DIFF
--- a/manifests/0000_50_olm_00-namespace.yaml
+++ b/manifests/0000_50_olm_00-namespace.yaml
@@ -2,23 +2,25 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-operator-lifecycle-manager
+  labels:
+    openshift.io/scc: "anyuid"
+    openshift.io/cluster-monitoring: "true"
   annotations:
     openshift.io/node-selector: ""
     workload.openshift.io/allowed: "management"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-  labels:
-    openshift.io/scc: "anyuid"
-    openshift.io/cluster-monitoring: "true"
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-operators
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: "v1.24"
+    openshift.io/scc: "anyuid"
   annotations:
     openshift.io/node-selector: ""
     workload.openshift.io/allowed: "management"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-  labels:
-    openshift.io/scc: "anyuid"

--- a/manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
+++ b/manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
@@ -23,7 +23,6 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65534
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: olm-operator-serviceaccount

--- a/manifests/0000_50_olm_06-psm-operator.deployment.yaml
+++ b/manifests/0000_50_olm_06-psm-operator.deployment.yaml
@@ -23,7 +23,6 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65534
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: olm-operator-serviceaccount

--- a/manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
+++ b/manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
@@ -21,6 +21,10 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: olm-operator-serviceaccount
       volumes:
         - name: srv-cert
@@ -31,6 +35,10 @@ spec:
             secretName: pprof-cert
       containers:
         - name: olm-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - name: srv-cert
               mountPath: "/srv-cert"
@@ -82,10 +90,6 @@ spec:
             requests:
               cpu: 10m
               memory: 160Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
@@ -101,8 +105,3 @@ spec:
           operator: Exists
           tolerationSeconds: 120
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
-        seccompProfile:
-          type: RuntimeDefault

--- a/manifests/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/manifests/0000_50_olm_07-olm-operator.deployment.yaml
@@ -21,6 +21,10 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: olm-operator-serviceaccount
       volumes:
         - name: srv-cert
@@ -31,6 +35,10 @@ spec:
             secretName: pprof-cert
       containers:
         - name: olm-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - name: srv-cert
               mountPath: "/srv-cert"
@@ -82,10 +90,6 @@ spec:
             requests:
               cpu: 10m
               memory: 160Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
       nodeSelector:
         kubernetes.io/os: linux
         node-role.kubernetes.io/master: ""
@@ -102,8 +106,3 @@ spec:
           operator: Exists
           tolerationSeconds: 120
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
-        seccompProfile:
-          type: RuntimeDefault

--- a/manifests/0000_50_olm_08-catalog-operator.deployment.ibm-cloud-managed.yaml
+++ b/manifests/0000_50_olm_08-catalog-operator.deployment.ibm-cloud-managed.yaml
@@ -21,6 +21,10 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: olm-operator-serviceaccount
       volumes:
         - name: srv-cert
@@ -31,6 +35,10 @@ spec:
             secretName: pprof-cert
       containers:
         - name: catalog-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - name: srv-cert
               mountPath: "/srv-cert"
@@ -55,6 +63,7 @@ spec:
             - /srv-cert/tls.key
             - --client-ca
             - /profile-collector-cert/tls.crt
+            - --set-workload-user-id=false
           image: quay.io/operator-framework/olm@sha256:de396b540b82219812061d0d753440d5655250c621c753ed1dc67d6154741607
           imagePullPolicy: IfNotPresent
           ports:
@@ -78,10 +87,6 @@ spec:
           env:
             - name: RELEASE_VERSION
               value: "0.0.1-snapshot"
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
@@ -97,8 +102,3 @@ spec:
           operator: Exists
           tolerationSeconds: 120
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
-        seccompProfile:
-          type: RuntimeDefault

--- a/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -21,6 +21,10 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: olm-operator-serviceaccount
       volumes:
         - name: srv-cert
@@ -31,6 +35,10 @@ spec:
             secretName: pprof-cert
       containers:
         - name: catalog-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - name: srv-cert
               mountPath: "/srv-cert"
@@ -55,6 +63,7 @@ spec:
             - /srv-cert/tls.key
             - --client-ca
             - /profile-collector-cert/tls.crt
+            - --set-workload-user-id=false
           image: quay.io/operator-framework/olm@sha256:de396b540b82219812061d0d753440d5655250c621c753ed1dc67d6154741607
           imagePullPolicy: IfNotPresent
           ports:
@@ -78,10 +87,6 @@ spec:
           env:
             - name: RELEASE_VERSION
               value: "0.0.1-snapshot"
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
       nodeSelector:
         kubernetes.io/os: linux
         node-role.kubernetes.io/master: ""
@@ -98,8 +103,3 @@ spec:
           operator: Exists
           tolerationSeconds: 120
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
-        seccompProfile:
-          type: RuntimeDefault

--- a/pkg/manifests/csv.yaml
+++ b/pkg/manifests/csv.yaml
@@ -88,6 +88,10 @@ spec:
                   target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
                 creationTimestamp: null
               spec:
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
                 serviceAccountName: olm-operator-serviceaccount
                 nodeSelector:
                   kubernetes.io/os: linux
@@ -106,6 +110,10 @@ spec:
                     tolerationSeconds: 120
                 containers:
                   - name: packageserver
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop: ["ALL"]
                     command:
                       - /bin/package-server
                       - -v=4
@@ -136,10 +144,6 @@ spec:
                     volumeMounts:
                       - name: tmpfs
                         mountPath: /tmp
-                    securityContext:
-                      allowPrivilegeEscalation: false
-                      capabilities:
-                        drop: ["ALL"]
                 volumes:
                   - name: tmpfs
                     emptyDir: {}
@@ -154,11 +158,6 @@ spec:
                               values:
                                 - packageserver
                         topologyKey: "kubernetes.io/hostname"
-                securityContext:
-                  runAsNonRoot: true
-                  runAsUser: 65534
-                  seccompProfile:
-                    type: RuntimeDefault
   maturity: alpha
   version: 0.19.0
   apiservicedefinitions:

--- a/scripts/catalog-deployment.patch.yaml
+++ b/scripts/catalog-deployment.patch.yaml
@@ -19,6 +19,5 @@
   path: spec.template.spec.securityContext
   value:
     runAsNonRoot: true
-    runAsUser: 65534
     seccompProfile:
       type: RuntimeDefault

--- a/scripts/generate_crds_manifests.sh
+++ b/scripts/generate_crds_manifests.sh
@@ -133,7 +133,6 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65534
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: olm-operator-serviceaccount
@@ -367,3 +366,5 @@ add_ibm_managed_cloud_annotations "${ROOT_DIR}/manifests"
 
 find "${ROOT_DIR}/manifests" -type f -exec $SED -i "/^#/d" {} \;
 find "${ROOT_DIR}/manifests" -type f -exec $SED -i "1{/---/d}" {} \;
+
+${YQ} delete --inplace -d'0' manifests/0000_50_olm_00-namespace.yaml 'metadata.labels."pod-security.kubernetes.io/enforce*"'

--- a/scripts/olm-deployment.patch.yaml
+++ b/scripts/olm-deployment.patch.yaml
@@ -19,6 +19,5 @@
   path: spec.template.spec.securityContext
   value:
     runAsNonRoot: true
-    runAsUser: 65534
     seccompProfile:
       type: RuntimeDefault

--- a/scripts/packageserver-deployment.patch.yaml
+++ b/scripts/packageserver-deployment.patch.yaml
@@ -43,6 +43,5 @@
   path: spec.install.spec.deployments[0].spec.template.spec.securityContext
   value:
     runAsNonRoot: true
-    runAsUser: 65534
     seccompProfile:
       type: RuntimeDefault

--- a/staging/operator-lifecycle-manager/Dockerfile
+++ b/staging/operator-lifecycle-manager/Dockerfile
@@ -33,6 +33,7 @@ COPY --from=builder /build/bin/olm /bin/olm
 COPY --from=builder /build/bin/catalog /bin/catalog
 COPY --from=builder /build/bin/package-server /bin/package-server
 COPY --from=builder /build/bin/cpb /bin/cpb
+USER 1001
 EXPOSE 8080
 EXPOSE 5443
 CMD ["/bin/olm"]

--- a/staging/operator-lifecycle-manager/Dockerfile.goreleaser
+++ b/staging/operator-lifecycle-manager/Dockerfile.goreleaser
@@ -10,4 +10,5 @@ COPY package-server /bin/package-server
 COPY cpb /bin/cpb
 EXPOSE 8080
 EXPOSE 5443
+USER 1001
 ENTRYPOINT ["/bin/olm"]

--- a/staging/operator-lifecycle-manager/cmd/catalog/main.go
+++ b/staging/operator-lifecycle-manager/cmd/catalog/main.go
@@ -30,6 +30,7 @@ const (
 	defaultOPMImage             = "quay.io/operator-framework/upstream-opm-builder:latest"
 	defaultUtilImage            = "quay.io/operator-framework/olm:latest"
 	defaultOperatorName         = ""
+	defaultWorkLoadUserID       = int64(1001)
 )
 
 // config flags defined globally so that they appear on the test binary as well
@@ -83,6 +84,10 @@ func (o *options) run(ctx context.Context, logger *logrus.Logger) error {
 		return fmt.Errorf("error configuring client: %s", err.Error())
 	}
 
+	workloadUserID := int64(-1)
+	if o.setWorkloadUserID {
+		workloadUserID = defaultWorkLoadUserID
+	}
 	// TODO(tflannag): Use options pattern for catalog operator
 	// Create a new instance of the operator.
 	op, err := catalog.NewOperator(
@@ -98,6 +103,7 @@ func (o *options) run(ctx context.Context, logger *logrus.Logger) error {
 		k8sscheme.Scheme,
 		o.installPlanTimeout,
 		o.bundleUnpackTimeout,
+		workloadUserID,
 	)
 	if err != nil {
 		return fmt.Errorf("error configuring catalog operator: %s", err.Error())

--- a/staging/operator-lifecycle-manager/cmd/catalog/start.go
+++ b/staging/operator-lifecycle-manager/cmd/catalog/start.go
@@ -25,6 +25,7 @@ type options struct {
 	tlsKeyPath           string
 	tlsCertPath          string
 	clientCAPath         string
+	setWorkloadUserID    bool
 
 	installPlanTimeout  time.Duration
 	bundleUnpackTimeout time.Duration
@@ -66,6 +67,7 @@ func newRootCmd() *cobra.Command {
 	cmd.Flags().StringVar(&o.opmImage, "opmImage", defaultOPMImage, "the image to use for unpacking bundle content with opm")
 	cmd.Flags().StringVar(&o.utilImage, "util-image", defaultUtilImage, "an image containing custom olm utilities")
 	cmd.Flags().StringVar(&o.writeStatusName, "writeStatusName", defaultOperatorName, "ClusterOperator name in which to write status, set to \"\" to disable.")
+	cmd.Flags().BoolVar(&o.setWorkloadUserID, "set-workload-user-id", false, "set user ID for all workloads (registry pods/bundle unpack jobs to default 1001")
 
 	cmd.Flags().BoolVar(&o.debug, "debug", false, "use debug log level")
 	cmd.Flags().BoolVar(&o.version, "version", false, "displays the olm version")

--- a/staging/operator-lifecycle-manager/deploy/chart/templates/0000_50_olm_00-namespace.yaml
+++ b/staging/operator-lifecycle-manager/deploy/chart/templates/0000_50_olm_00-namespace.yaml
@@ -3,8 +3,10 @@ kind: Namespace
 metadata:
   name: {{ .Values.namespace }}
   labels: 
-    pod-security.kubernetes.io/enforce: restricted
-    pod-security.kubernetes.io/enforce-version: latest
+    {{- if .Values.namespace_psa }}
+    pod-security.kubernetes.io/enforce: {{ .Values.namespace_psa.enforceLevel }}
+    pod-security.kubernetes.io/enforce-version: {{ .Values.namespace_psa.enforceVersion }}
+    {{- end }}
 
 ---
 apiVersion: v1
@@ -12,5 +14,7 @@ kind: Namespace
 metadata:
   name: {{ .Values.operator_namespace }}
   labels:
-    pod-security.kubernetes.io/enforce: baseline
-    pod-security.kubernetes.io/enforce-version: latest
+    {{- if .Values.operator_namespace_psa }}
+    pod-security.kubernetes.io/enforce: {{ .Values.operator_namespace_psa.enforceLevel }}
+    pod-security.kubernetes.io/enforce-version: {{ .Values.operator_namespace_psa.enforceVersion }}
+    {{- end }}

--- a/staging/operator-lifecycle-manager/deploy/chart/templates/0000_50_olm_00-namespace.yaml
+++ b/staging/operator-lifecycle-manager/deploy/chart/templates/0000_50_olm_00-namespace.yaml
@@ -2,9 +2,15 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.namespace }}
+  labels: 
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
 
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.operator_namespace }}
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: latest

--- a/staging/operator-lifecycle-manager/deploy/chart/templates/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/staging/operator-lifecycle-manager/deploy/chart/templates/0000_50_olm_07-olm-operator.deployment.yaml
@@ -17,6 +17,10 @@ spec:
       labels:
         app: olm-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: olm-operator-serviceaccount
       {{- if or .Values.olm.tlsSecret .Values.olm.clientCASecret }}
       volumes: 
@@ -33,6 +37,10 @@ spec:
       {{- end }}
       containers:
         - name: olm-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ "ALL" ]
           {{- if or .Values.olm.tlsSecret .Values.olm.clientCASecret }}
           volumeMounts:
           {{- end }}

--- a/staging/operator-lifecycle-manager/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/staging/operator-lifecycle-manager/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -84,8 +84,11 @@ spec:
           - --client-ca
           - /profile-collector-cert/tls.crt
           {{- end }}
-          - --set-workload-user-id
-          - "true"
+          {{- if eq .Values.catalog.setWorkloadUserID true }}
+          - --set-workload-user-id=true
+          {{- else }}
+          - --set-workload-user-id=false
+          {{ end }}
           image: {{ .Values.catalog.image.ref }}
           imagePullPolicy: {{ .Values.catalog.image.pullPolicy }}
           ports:

--- a/staging/operator-lifecycle-manager/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/staging/operator-lifecycle-manager/deploy/chart/templates/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -17,6 +17,10 @@ spec:
       labels:
         app: catalog-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: olm-operator-serviceaccount
       {{- if or .Values.catalog.tlsSecret .Values.catalog.clientCASecret }}
       volumes:
@@ -33,6 +37,10 @@ spec:
       {{- end }}
       containers:
         - name: catalog-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ "ALL" ]
           {{- if or .Values.catalog.tlsSecret .Values.catalog.clientCASecret }}
           volumeMounts:
           {{- end }}
@@ -76,6 +84,8 @@ spec:
           - --client-ca
           - /profile-collector-cert/tls.crt
           {{- end }}
+          - --set-workload-user-id
+          - "true"
           image: {{ .Values.catalog.image.ref }}
           imagePullPolicy: {{ .Values.catalog.image.pullPolicy }}
           ports:

--- a/staging/operator-lifecycle-manager/deploy/chart/templates/_packageserver.deployment-spec.yaml
+++ b/staging/operator-lifecycle-manager/deploy/chart/templates/_packageserver.deployment-spec.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
         app: packageserver
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: olm-operator-serviceaccount
       {{- if .Values.package.nodeSelector }}
       nodeSelector:
@@ -25,6 +29,10 @@ spec:
       {{- end }}
       containers:
       - name: packageserver
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ "ALL" ]
         command:
         - /bin/package-server
         - -v=4
@@ -60,10 +68,6 @@ spec:
         {{- if .Values.package.resources }}
         resources:
 {{ toYaml .Values.package.resources | indent 10 }}
-        {{- end }}
-        {{- if .Values.package.securityContext }}
-        securityContext:
-          runAsUser: {{ .Values.package.securityContext.runAsUser }}
         {{- end }}
         volumeMounts:
         - name: tmpfs

--- a/staging/operator-lifecycle-manager/deploy/chart/values.yaml
+++ b/staging/operator-lifecycle-manager/deploy/chart/values.yaml
@@ -1,7 +1,15 @@
 rbacApiVersion: rbac.authorization.k8s.io
 namespace: operator-lifecycle-manager
+# see https://kubernetes.io/docs/concepts/security/pod-security-admission/ for more details
+namespace_psa: 
+  enforceLevel: restricted
+  enforceVersion: latest
 catalog_namespace: operator-lifecycle-manager
 operator_namespace: operators
+# see https://kubernetes.io/docs/concepts/security/pod-security-admission/ for more details
+operator_namespace_psa: 
+  enforceLevel: baseline
+  enforceVersion: latest
 minKubeVersion: 1.11.0
 writeStatusName: '""'
 imagestream: false
@@ -25,6 +33,7 @@ olm:
      memory: 160Mi
 
 catalog:
+  setWorkloadUserID: true
   replicaCount: 1
   commandArgs: --configmapServerImage=quay.io/operator-framework/configmap-operator-registry:latest
   image:

--- a/staging/operator-lifecycle-manager/deploy/upstream/values.yaml
+++ b/staging/operator-lifecycle-manager/deploy/upstream/values.yaml
@@ -1,8 +1,16 @@
 installType: upstream
 rbacApiVersion: rbac.authorization.k8s.io
 namespace: olm
+# see https://kubernetes.io/docs/concepts/security/pod-security-admission/ for more details
+namespace_psa: 
+  enforceLevel: restricted
+  enforceVersion: latest
 catalog_namespace: olm
 operator_namespace: operators
+# see https://kubernetes.io/docs/concepts/security/pod-security-admission/ for more details
+operator_namespace_psa: 
+  enforceLevel: baseline
+  enforceVersion: latest
 imagestream: false
 writeStatusName: '""'
 writePackageServerStatusName: ""
@@ -14,6 +22,7 @@ olm:
   service:
     internalPort: 8080
 catalog:
+  setWorkloadUserID: true
   replicaCount: 1
   image:
     ref: quay.io/operator-framework/olm@sha256:e74b2ac57963c7f3ba19122a8c31c9f2a0deb3c0c5cac9e5323ccffd0ca198ed

--- a/staging/operator-lifecycle-manager/e2e.Dockerfile
+++ b/staging/operator-lifecycle-manager/e2e.Dockerfile
@@ -3,4 +3,5 @@ FROM busybox
 COPY olm catalog package-server wait cpb /bin/
 EXPOSE 8080
 EXPOSE 5443
+USER 1001
 CMD ["/bin/olm"]

--- a/staging/operator-lifecycle-manager/pkg/controller/bundle/bundle_unpacker_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/bundle/bundle_unpacker_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/pointer"
 
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	crfake "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
@@ -32,6 +33,7 @@ const (
 	opmImage    = "opm-image"
 	utilImage   = "util-image"
 	bundlePath  = "bundle-path"
+	runAsUser   = 1001
 )
 
 func TestConfigMapUnpacker(t *testing.T) {
@@ -220,6 +222,13 @@ func TestConfigMapUnpacker(t *testing.T) {
 								Spec: corev1.PodSpec{
 									RestartPolicy:    corev1.RestartPolicyNever,
 									ImagePullSecrets: []corev1.LocalObjectReference{{Name: "my-secret"}},
+									SecurityContext: &corev1.PodSecurityContext{
+										RunAsNonRoot: pointer.Bool(true),
+										RunAsUser:    pointer.Int64(runAsUser),
+										SeccompProfile: &corev1.SeccompProfile{
+											Type: corev1.SeccompProfileTypeRuntimeDefault,
+										},
+									},
 									Containers: []corev1.Container{
 										{
 											Name:    "extract",
@@ -243,6 +252,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
+												},
+											},
 										},
 									},
 									InitContainers: []corev1.Container{
@@ -260,6 +275,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 												Requests: corev1.ResourceList{
 													corev1.ResourceCPU:    resource.MustParse("10m"),
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
+												},
+											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
 												},
 											},
 										},
@@ -282,6 +303,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 												Requests: corev1.ResourceList{
 													corev1.ResourceCPU:    resource.MustParse("10m"),
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
+												},
+											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
 												},
 											},
 										},
@@ -397,6 +424,13 @@ func TestConfigMapUnpacker(t *testing.T) {
 								},
 								Spec: corev1.PodSpec{
 									RestartPolicy: corev1.RestartPolicyNever,
+									SecurityContext: &corev1.PodSecurityContext{
+										RunAsNonRoot: pointer.Bool(true),
+										RunAsUser:    pointer.Int64(runAsUser),
+										SeccompProfile: &corev1.SeccompProfile{
+											Type: corev1.SeccompProfileTypeRuntimeDefault,
+										},
+									},
 									Containers: []corev1.Container{
 										{
 											Name:    "extract",
@@ -420,6 +454,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
+												},
+											},
 										},
 									},
 									InitContainers: []corev1.Container{
@@ -437,6 +477,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 												Requests: corev1.ResourceList{
 													corev1.ResourceCPU:    resource.MustParse("10m"),
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
+												},
+											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
 												},
 											},
 										},
@@ -459,6 +505,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 												Requests: corev1.ResourceList{
 													corev1.ResourceCPU:    resource.MustParse("10m"),
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
+												},
+											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
 												},
 											},
 										},
@@ -615,6 +667,13 @@ func TestConfigMapUnpacker(t *testing.T) {
 								},
 								Spec: corev1.PodSpec{
 									RestartPolicy: corev1.RestartPolicyNever,
+									SecurityContext: &corev1.PodSecurityContext{
+										RunAsNonRoot: pointer.Bool(true),
+										RunAsUser:    pointer.Int64(runAsUser),
+										SeccompProfile: &corev1.SeccompProfile{
+											Type: corev1.SeccompProfileTypeRuntimeDefault,
+										},
+									},
 									Containers: []corev1.Container{
 										{
 											Name:    "extract",
@@ -638,6 +697,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
+												},
+											},
 										},
 									},
 									InitContainers: []corev1.Container{
@@ -655,6 +720,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 												Requests: corev1.ResourceList{
 													corev1.ResourceCPU:    resource.MustParse("10m"),
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
+												},
+											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
 												},
 											},
 										},
@@ -677,6 +748,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 												Requests: corev1.ResourceList{
 													corev1.ResourceCPU:    resource.MustParse("10m"),
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
+												},
+											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
 												},
 											},
 										},
@@ -827,6 +904,13 @@ func TestConfigMapUnpacker(t *testing.T) {
 								},
 								Spec: corev1.PodSpec{
 									RestartPolicy: corev1.RestartPolicyNever,
+									SecurityContext: &corev1.PodSecurityContext{
+										RunAsNonRoot: pointer.Bool(true),
+										RunAsUser:    pointer.Int64(runAsUser),
+										SeccompProfile: &corev1.SeccompProfile{
+											Type: corev1.SeccompProfileTypeRuntimeDefault,
+										},
+									},
 									Containers: []corev1.Container{
 										{
 											Name:    "extract",
@@ -850,6 +934,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
+												},
+											},
 										},
 									},
 									InitContainers: []corev1.Container{
@@ -867,6 +957,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 												Requests: corev1.ResourceList{
 													corev1.ResourceCPU:    resource.MustParse("10m"),
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
+												},
+											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
 												},
 											},
 										},
@@ -889,6 +985,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 												Requests: corev1.ResourceList{
 													corev1.ResourceCPU:    resource.MustParse("10m"),
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
+												},
+											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
 												},
 											},
 										},
@@ -1009,6 +1111,13 @@ func TestConfigMapUnpacker(t *testing.T) {
 								},
 								Spec: corev1.PodSpec{
 									RestartPolicy: corev1.RestartPolicyNever,
+									SecurityContext: &corev1.PodSecurityContext{
+										RunAsNonRoot: pointer.Bool(true),
+										RunAsUser:    pointer.Int64(runAsUser),
+										SeccompProfile: &corev1.SeccompProfile{
+											Type: corev1.SeccompProfileTypeRuntimeDefault,
+										},
+									},
 									Containers: []corev1.Container{
 										{
 											Name:    "extract",
@@ -1032,6 +1141,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
+												},
+											},
 										},
 									},
 									InitContainers: []corev1.Container{
@@ -1049,6 +1164,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 												Requests: corev1.ResourceList{
 													corev1.ResourceCPU:    resource.MustParse("10m"),
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
+												},
+											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
 												},
 											},
 										},
@@ -1071,6 +1192,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 												Requests: corev1.ResourceList{
 													corev1.ResourceCPU:    resource.MustParse("10m"),
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
+												},
+											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
 												},
 											},
 										},
@@ -1202,6 +1329,13 @@ func TestConfigMapUnpacker(t *testing.T) {
 								},
 								Spec: corev1.PodSpec{
 									RestartPolicy: corev1.RestartPolicyNever,
+									SecurityContext: &corev1.PodSecurityContext{
+										RunAsNonRoot: pointer.Bool(true),
+										RunAsUser:    pointer.Int64(runAsUser),
+										SeccompProfile: &corev1.SeccompProfile{
+											Type: corev1.SeccompProfileTypeRuntimeDefault,
+										},
+									},
 									Containers: []corev1.Container{
 										{
 											Name:    "extract",
@@ -1225,6 +1359,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
 												},
 											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
+												},
+											},
 										},
 									},
 									InitContainers: []corev1.Container{
@@ -1242,6 +1382,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 												Requests: corev1.ResourceList{
 													corev1.ResourceCPU:    resource.MustParse("10m"),
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
+												},
+											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
 												},
 											},
 										},
@@ -1264,6 +1410,12 @@ func TestConfigMapUnpacker(t *testing.T) {
 												Requests: corev1.ResourceList{
 													corev1.ResourceCPU:    resource.MustParse("10m"),
 													corev1.ResourceMemory: resource.MustParse("50Mi"),
+												},
+											},
+											SecurityContext: &corev1.SecurityContext{
+												AllowPrivilegeEscalation: pointer.Bool(false),
+												Capabilities: &corev1.Capabilities{
+													Drop: []corev1.Capability{"ALL"},
 												},
 											},
 										},
@@ -1341,6 +1493,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 				WithUtilImage(utilImage),
 				WithNow(now),
 				WithUnpackTimeout(defaultUnpackDuration),
+				WithUserID(int64(runAsUser)),
 			)
 			require.NoError(t, err)
 

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator_test.go
@@ -1606,7 +1606,7 @@ func NewFakeOperator(ctx context.Context, namespace string, namespaces []string,
 		}
 		applier := controllerclient.NewFakeApplier(s, "testowner")
 
-		op.reconciler = reconciler.NewRegistryReconcilerFactory(lister, op.opClient, "test:pod", op.now, applier)
+		op.reconciler = reconciler.NewRegistryReconcilerFactory(lister, op.opClient, "test:pod", op.now, applier, 1001)
 	}
 
 	op.RunInformers(ctx)
@@ -1758,7 +1758,7 @@ func toManifest(t *testing.T, obj runtime.Object) string {
 }
 
 func pod(s v1alpha1.CatalogSource) *corev1.Pod {
-	pod := reconciler.Pod(&s, "registry-server", s.Spec.Image, s.GetName(), s.GetLabels(), s.GetAnnotations(), 5, 10)
+	pod := reconciler.Pod(&s, "registry-server", s.Spec.Image, s.GetName(), s.GetLabels(), s.GetAnnotations(), 5, 10, 1001)
 	ownerutil.AddOwner(pod, &s, false, false)
 	return pod
 }

--- a/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/configmap.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/configmap.go
@@ -23,6 +23,7 @@ import (
 // configMapCatalogSourceDecorator wraps CatalogSource to add additional methods
 type configMapCatalogSourceDecorator struct {
 	*v1alpha1.CatalogSource
+	runAsUser int64
 }
 
 const (
@@ -101,7 +102,7 @@ func (s *configMapCatalogSourceDecorator) Service() *corev1.Service {
 }
 
 func (s *configMapCatalogSourceDecorator) Pod(image string) *corev1.Pod {
-	pod := Pod(s.CatalogSource, "configmap-registry-server", image, "", s.Labels(), s.Annotations(), 5, 5)
+	pod := Pod(s.CatalogSource, "configmap-registry-server", image, "", s.Labels(), s.Annotations(), 5, 5, s.runAsUser)
 	pod.Spec.ServiceAccountName = s.GetName() + ConfigMapServerPostfix
 	pod.Spec.Containers[0].Command = []string{"configmap-server", "-c", s.Spec.ConfigMap, "-n", s.GetNamespace()}
 	ownerutil.AddOwner(pod, s.CatalogSource, false, false)
@@ -162,10 +163,11 @@ func (s *configMapCatalogSourceDecorator) RoleBinding() *rbacv1.RoleBinding {
 }
 
 type ConfigMapRegistryReconciler struct {
-	now      nowFunc
-	Lister   operatorlister.OperatorLister
-	OpClient operatorclient.ClientInterface
-	Image    string
+	now             nowFunc
+	Lister          operatorlister.OperatorLister
+	OpClient        operatorclient.ClientInterface
+	Image           string
+	createPodAsUser int64
 }
 
 var _ RegistryEnsurer = &ConfigMapRegistryReconciler{}
@@ -240,7 +242,7 @@ func (c *ConfigMapRegistryReconciler) currentPodsWithCorrectResourceVersion(sour
 
 // EnsureRegistryServer ensures that all components of registry server are up to date.
 func (c *ConfigMapRegistryReconciler) EnsureRegistryServer(catalogSource *v1alpha1.CatalogSource) error {
-	source := configMapCatalogSourceDecorator{catalogSource}
+	source := configMapCatalogSourceDecorator{catalogSource, c.createPodAsUser}
 
 	image := c.Image
 	if source.Spec.SourceType == "grpc" {
@@ -389,7 +391,7 @@ func (c *ConfigMapRegistryReconciler) ensureService(source configMapCatalogSourc
 
 // CheckRegistryServer returns true if the given CatalogSource is considered healthy; false otherwise.
 func (c *ConfigMapRegistryReconciler) CheckRegistryServer(catalogSource *v1alpha1.CatalogSource) (healthy bool, err error) {
-	source := configMapCatalogSourceDecorator{catalogSource}
+	source := configMapCatalogSourceDecorator{catalogSource, c.createPodAsUser}
 
 	image := c.Image
 	if source.Spec.SourceType == "grpc" {

--- a/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/configmap_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/configmap_test.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	registryImageName = "test:image"
+	runAsUser         = 1001
 	testNamespace     = "testns"
 )
 
@@ -104,6 +105,7 @@ func fakeReconcilerFactory(t *testing.T, stopc <-chan struct{}, options ...fakeR
 		OpClient:             opClientFake,
 		Lister:               lister,
 		ConfigMapServerImage: config.configMapServerImage,
+		createPodAsUser:      runAsUser,
 	}
 
 	var hasSyncedCheckFns []cache.InformerSynced
@@ -186,7 +188,7 @@ func objectsForCatalogSource(catsrc *v1alpha1.CatalogSource) []runtime.Object {
 	var objs []runtime.Object
 	switch catsrc.Spec.SourceType {
 	case v1alpha1.SourceTypeInternal, v1alpha1.SourceTypeConfigmap:
-		decorated := configMapCatalogSourceDecorator{catsrc}
+		decorated := configMapCatalogSourceDecorator{catsrc, runAsUser}
 		objs = clientfake.AddSimpleGeneratedNames(
 			clientfake.AddSimpleGeneratedName(decorated.Pod(registryImageName)),
 			decorated.Service(),
@@ -196,7 +198,7 @@ func objectsForCatalogSource(catsrc *v1alpha1.CatalogSource) []runtime.Object {
 		)
 	case v1alpha1.SourceTypeGrpc:
 		if catsrc.Spec.Image != "" {
-			decorated := grpcCatalogSourceDecorator{catsrc}
+			decorated := grpcCatalogSourceDecorator{catsrc, runAsUser}
 			objs = clientfake.AddSimpleGeneratedNames(
 				decorated.Pod(catsrc.GetName()),
 				decorated.Service(),
@@ -451,7 +453,7 @@ func TestConfigMapRegistryReconciler(t *testing.T) {
 			}
 
 			// if no error, the reconciler should create the same set of kube objects every time
-			decorated := configMapCatalogSourceDecorator{tt.in.catsrc}
+			decorated := configMapCatalogSourceDecorator{tt.in.catsrc, runAsUser}
 
 			pod := decorated.Pod(registryImageName)
 			listOptions := metav1.ListOptions{LabelSelector: labels.SelectorFromSet(labels.Set{CatalogSourceLabelKey: tt.in.catsrc.GetName()}).String()}

--- a/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/grpc_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/grpc_test.go
@@ -331,7 +331,7 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 			}
 
 			// Check for resource existence
-			decorated := grpcCatalogSourceDecorator{tt.in.catsrc}
+			decorated := grpcCatalogSourceDecorator{tt.in.catsrc, runAsUser}
 			pod := decorated.Pod(tt.in.catsrc.GetName())
 			service := decorated.Service()
 			sa := decorated.ServiceAccount()
@@ -421,7 +421,7 @@ func TestRegistryPodPriorityClass(t *testing.T) {
 			require.NoError(t, err)
 
 			// Check for resource existence
-			decorated := grpcCatalogSourceDecorator{tt.in.catsrc}
+			decorated := grpcCatalogSourceDecorator{tt.in.catsrc, runAsUser}
 			pod := decorated.Pod(tt.in.catsrc.GetName())
 			listOptions := metav1.ListOptions{LabelSelector: labels.SelectorFromSet(labels.Set{CatalogSourceLabelKey: tt.in.catsrc.GetName()}).String()}
 			outPods, podErr := client.KubernetesInterface().CoreV1().Pods(pod.GetNamespace()).List(context.TODO(), listOptions)

--- a/staging/operator-lifecycle-manager/test/e2e/operator_groups_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/operator_groups_e2e_test.go
@@ -2021,16 +2021,10 @@ var _ = Describe("Operator Group", func() {
 			fetchedCSV.Annotations[v1.OperatorGroupNamespaceAnnotationKey] = fetchedCSV.GetNamespace()
 			_, updateErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Update(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
 			if updateErr != nil {
+				GinkgoT().Logf("Error updating copied CSV (in %v): %v", otherNamespaceName, updateErr.Error())
 				return false, updateErr
 			}
-			updatedCSV, updatedfetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(context.TODO(), csvName, metav1.GetOptions{})
-			if updatedfetchErr != nil {
-				return false, updatedfetchErr
-			}
-			if updatedCSV.Annotations[v1.OperatorGroupNamespaceAnnotationKey] == fetchedCSV.GetNamespace() {
-				return true, nil
-			}
-			return false, nil
+			return true, nil
 		})
 		require.NoError(GinkgoT(), err)
 		GinkgoT().Log("Done updating copied CSV with bad annotation OperatorGroup, waiting for CSV to be gc'd")

--- a/values.yaml
+++ b/values.yaml
@@ -3,6 +3,9 @@ rbacApiVersion: rbac.authorization.k8s.io
 namespace: openshift-operator-lifecycle-manager
 catalog_namespace: openshift-marketplace
 operator_namespace: openshift-operators
+operator_namespace_psa: 
+  enforceLevel: baseline
+  enforceVersion: '"v1.24"'
 imagestream: true
 writeStatusName: operator-lifecycle-manager
 writeStatusNameCatalog: operator-lifecycle-manager-catalog
@@ -37,6 +40,7 @@ olm:
       cpu: 10m
       memory: 160Mi
 catalog:
+  setWorkloadUserID: false
   replicaCount: 1
   opmImageArgs: --opmImage=quay.io/operator-framework/configmap-operator-registry:latest
   image:

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/cmd/catalog/main.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/cmd/catalog/main.go
@@ -30,6 +30,7 @@ const (
 	defaultOPMImage             = "quay.io/operator-framework/upstream-opm-builder:latest"
 	defaultUtilImage            = "quay.io/operator-framework/olm:latest"
 	defaultOperatorName         = ""
+	defaultWorkLoadUserID       = int64(1001)
 )
 
 // config flags defined globally so that they appear on the test binary as well
@@ -83,6 +84,10 @@ func (o *options) run(ctx context.Context, logger *logrus.Logger) error {
 		return fmt.Errorf("error configuring client: %s", err.Error())
 	}
 
+	workloadUserID := int64(-1)
+	if o.setWorkloadUserID {
+		workloadUserID = defaultWorkLoadUserID
+	}
 	// TODO(tflannag): Use options pattern for catalog operator
 	// Create a new instance of the operator.
 	op, err := catalog.NewOperator(
@@ -98,6 +103,7 @@ func (o *options) run(ctx context.Context, logger *logrus.Logger) error {
 		k8sscheme.Scheme,
 		o.installPlanTimeout,
 		o.bundleUnpackTimeout,
+		workloadUserID,
 	)
 	if err != nil {
 		return fmt.Errorf("error configuring catalog operator: %s", err.Error())

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/cmd/catalog/start.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/cmd/catalog/start.go
@@ -25,6 +25,7 @@ type options struct {
 	tlsKeyPath           string
 	tlsCertPath          string
 	clientCAPath         string
+	setWorkloadUserID    bool
 
 	installPlanTimeout  time.Duration
 	bundleUnpackTimeout time.Duration
@@ -66,6 +67,7 @@ func newRootCmd() *cobra.Command {
 	cmd.Flags().StringVar(&o.opmImage, "opmImage", defaultOPMImage, "the image to use for unpacking bundle content with opm")
 	cmd.Flags().StringVar(&o.utilImage, "util-image", defaultUtilImage, "an image containing custom olm utilities")
 	cmd.Flags().StringVar(&o.writeStatusName, "writeStatusName", defaultOperatorName, "ClusterOperator name in which to write status, set to \"\" to disable.")
+	cmd.Flags().BoolVar(&o.setWorkloadUserID, "set-workload-user-id", false, "set user ID for all workloads (registry pods/bundle unpack jobs to default 1001")
 
 	cmd.Flags().BoolVar(&o.debug, "debug", false, "use debug log level")
 	cmd.Flags().BoolVar(&o.version, "version", false, "displays the olm version")

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/configmap.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/configmap.go
@@ -23,6 +23,7 @@ import (
 // configMapCatalogSourceDecorator wraps CatalogSource to add additional methods
 type configMapCatalogSourceDecorator struct {
 	*v1alpha1.CatalogSource
+	runAsUser int64
 }
 
 const (
@@ -101,7 +102,7 @@ func (s *configMapCatalogSourceDecorator) Service() *corev1.Service {
 }
 
 func (s *configMapCatalogSourceDecorator) Pod(image string) *corev1.Pod {
-	pod := Pod(s.CatalogSource, "configmap-registry-server", image, "", s.Labels(), s.Annotations(), 5, 5)
+	pod := Pod(s.CatalogSource, "configmap-registry-server", image, "", s.Labels(), s.Annotations(), 5, 5, s.runAsUser)
 	pod.Spec.ServiceAccountName = s.GetName() + ConfigMapServerPostfix
 	pod.Spec.Containers[0].Command = []string{"configmap-server", "-c", s.Spec.ConfigMap, "-n", s.GetNamespace()}
 	ownerutil.AddOwner(pod, s.CatalogSource, false, false)
@@ -162,10 +163,11 @@ func (s *configMapCatalogSourceDecorator) RoleBinding() *rbacv1.RoleBinding {
 }
 
 type ConfigMapRegistryReconciler struct {
-	now      nowFunc
-	Lister   operatorlister.OperatorLister
-	OpClient operatorclient.ClientInterface
-	Image    string
+	now             nowFunc
+	Lister          operatorlister.OperatorLister
+	OpClient        operatorclient.ClientInterface
+	Image           string
+	createPodAsUser int64
 }
 
 var _ RegistryEnsurer = &ConfigMapRegistryReconciler{}
@@ -240,7 +242,7 @@ func (c *ConfigMapRegistryReconciler) currentPodsWithCorrectResourceVersion(sour
 
 // EnsureRegistryServer ensures that all components of registry server are up to date.
 func (c *ConfigMapRegistryReconciler) EnsureRegistryServer(catalogSource *v1alpha1.CatalogSource) error {
-	source := configMapCatalogSourceDecorator{catalogSource}
+	source := configMapCatalogSourceDecorator{catalogSource, c.createPodAsUser}
 
 	image := c.Image
 	if source.Spec.SourceType == "grpc" {
@@ -389,7 +391,7 @@ func (c *ConfigMapRegistryReconciler) ensureService(source configMapCatalogSourc
 
 // CheckRegistryServer returns true if the given CatalogSource is considered healthy; false otherwise.
 func (c *ConfigMapRegistryReconciler) CheckRegistryServer(catalogSource *v1alpha1.CatalogSource) (healthy bool, err error) {
-	source := configMapCatalogSourceDecorator{catalogSource}
+	source := configMapCatalogSourceDecorator{catalogSource, c.createPodAsUser}
 
 	image := c.Image
 	if source.Spec.SourceType == "grpc" {


### PR DESCRIPTION
Namespace currently look like: 
```
$ oc get ns openshift-operator-lifecycle-manager -o yaml  
apiVersion: v1
kind: Namespace
metadata:
  annotations:
    include.release.openshift.io/ibm-cloud-managed: "true"
    include.release.openshift.io/self-managed-high-availability: "true"
    openshift.io/node-selector: ""
    openshift.io/sa.scc.mcs: s0:c20,c0
    openshift.io/sa.scc.supplemental-groups: 1000380000/10000
    openshift.io/sa.scc.uid-range: 1000380000/10000
    workload.openshift.io/allowed: management
  creationTimestamp: "2022-08-08T20:43:32Z"
  labels:
    kubernetes.io/metadata.name: openshift-operator-lifecycle-manager
    olm.operatorgroup.uid/05abd798-6c32-444f-b464-8d6b055c1782: ""
    olm.operatorgroup.uid/0a8c1277-46e3-4fc8-a1cc-8aa53df77f87: ""
    openshift.io/cluster-monitoring: "true"
    openshift.io/scc: anyuid
  name: openshift-operator-lifecycle-manager
.
.

oc get ns openshift-operators -o yaml 
apiVersion: v1
kind: Namespace
metadata:
  annotations:
    include.release.openshift.io/ibm-cloud-managed: "true"
    include.release.openshift.io/self-managed-high-availability: "true"
    openshift.io/node-selector: ""
    openshift.io/sa.scc.mcs: s0:c20,c10
    openshift.io/sa.scc.supplemental-groups: 1000400000/10000
    openshift.io/sa.scc.uid-range: 1000400000/10000
    workload.openshift.io/allowed: management
  creationTimestamp: "2022-08-09T17:25:15Z"
  labels:
    kubernetes.io/metadata.name: openshift-operators
    openshift.io/scc: anyuid
    pod-security.kubernetes.io/enforce: baseline
    pod-security.kubernetes.io/enforce-version: v1.24
  name: openshift-operators
.
.
```
Notice the `baseline` profile enforced in `openshift-operators` namespace, to allow exsiting CSVs to install ☝🏽.
 
Workloads all working seamlessly with the right securityContext configs: 
```
$ oc get pod catalog-operator-569796f9fc-22zp2 -n openshift-operator-lifecycle-manager -o yaml | grep securityContext -A 6
    securityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop:
        - ALL
      runAsUser: 1000380000
    terminationMessagePath: /dev/termination-log
--
  securityContext:
    fsGroup: 1000380000
    runAsNonRoot: true
    seLinuxOptions:
      level: s0:c20,c0
    seccompProfile:
      type: RuntimeDefault

$ oc get pod olm-operator-59df754788-j4qm8 -n openshift-operator-lifecycle-manager -o yaml | grep securityContext -A 6
    securityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop:
        - ALL
      runAsUser: 1000380000
    terminationMessagePath: /dev/termination-log
--
  securityContext:
    fsGroup: 1000380000
    runAsNonRoot: true
    seLinuxOptions:
      level: s0:c20,c0
    seccompProfile:
      type: RuntimeDefault

$ oc get pod package-server-manager-69d7b66648-7kzsp -n openshift-operator-lifecycle-manager -o yaml | grep securityContext -A 6
    securityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop:
        - ALL
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: FallbackToLogsOnError
--
  securityContext:
    runAsNonRoot: true
    runAsUser: 1000380000
    seLinuxOptions:
      level: s0:c20,c0
    seccompProfile:
      type: RuntimeDefault

```

```
$ oc get pods -n openshift-marketplace 
NAME                                    READY   STATUS    RESTARTS   AGE
certified-operators-xbpbt               1/1     Running   0          23m
community-operators-vfwgb               1/1     Running   0          9m17s
marketplace-operator-5df96fcb9c-cx6pq   1/1     Running   0          29m
redhat-marketplace-zw7bd                1/1     Running   0          23m
redhat-operators-d8cbk                  1/1     Running   0          23m

$ oc get pod community-operators-vfwgb -n openshift-marketplace -o yaml | grep securityContext -A 6
    securityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop:
        - ALL
      readOnlyRootFilesystem: false
      runAsNonRoot: true
--
  securityContext:
    fsGroup: 1000280000
    seLinuxOptions:
      level: s0:c17,c4
    seccompProfile:
      type: RuntimeDefault
  serviceAccount: community-operators

```

Test to make sure installing operator in the `openshift-operator` namespace works as expected: 

1) installed the aerospike-kubernetes-operator from the OperatorHub console (that installs the operator in the `openshift-operators` namespace) 
```
$ oc get sub -n openshift-operators                   
NAME                            PACKAGE                         SOURCE                CHANNEL
aerospike-kubernetes-operator   aerospike-kubernetes-operator   community-operators   alpha

$ oc get pods -n openshift-marketplace 
NAME                                                              READY   STATUS      RESTARTS   AGE
5ce4a54e377765068d69d5a13713476ef8bfa345dd551448534d5f80abxhlcr   0/1     Completed   0          3m14s
certified-operators-gmcm7                                         1/1     Running     0          41m
community-operators-dmfdf                                         1/1     Running     0          41m
marketplace-operator-6ff65457ff-2hgvl                             1/1     Running     0          47m
redhat-marketplace-zn9bw                                          1/1     Running     0          41m
redhat-operators-q6m65                                            1/1     Running     0          41m

# check that the job has the right security context configs: 
$ oc get pod 5ce4a54e377765068d69d5a13713476ef8bfa345dd551448534d5f80abxhlcr -n openshift-marketplace -o yaml | grep securityContext -A 6
    securityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop:
        - ALL
      runAsNonRoot: true
      runAsUser: 1000270000
--
    securityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop:
        - ALL
      runAsNonRoot: true
      runAsUser: 1000270000
--
    securityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop:
        - ALL
      runAsNonRoot: true
      runAsUser: 1000270000
--
  securityContext:
    fsGroup: 1000270000
    seLinuxOptions:
      level: s0:c16,c15
    seccompProfile:
      type: RuntimeDefault

$ oc get csv -n openshift-operators 
NAME                                   DISPLAY                         VERSION   REPLACES   PHASE
aerospike-kubernetes-operator.v2.1.0   Aerospike Kubernetes Operator   2.1.0                Succeeded

$ oc get pods -n openshift-operators 
NAME                                                     READY   STATUS    RESTARTS   AGE
aerospike-operator-controller-manager-587678b6fc-67j7v   2/2     Running   0          32s
aerospike-operator-controller-manager-587678b6fc-xhswq   2/2     Running   0          32s
```