### PR TITLE
(psa) restrict olm namespace + remove labels from openshift-operators ns

### DIFF
--- a/manifests/0000_50_olm_00-namespace.yaml
+++ b/manifests/0000_50_olm_00-namespace.yaml
@@ -3,6 +3,8 @@ kind: Namespace
 metadata:
   name: openshift-operator-lifecycle-manager
   labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: "v1.24"
     openshift.io/scc: "anyuid"
     openshift.io/cluster-monitoring: "true"
   annotations:
@@ -16,7 +18,7 @@ kind: Namespace
 metadata:
   name: openshift-operators
   labels:
-    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/enforce-version: "v1.24"
     openshift.io/scc: "anyuid"
   annotations:

--- a/scripts/generate_crds_manifests.sh
+++ b/scripts/generate_crds_manifests.sh
@@ -402,4 +402,5 @@ add_ibm_managed_cloud_annotations "${ROOT_DIR}/manifests"
 find "${ROOT_DIR}/manifests" -type f -exec $SED -i "/^#/d" {} \;
 find "${ROOT_DIR}/manifests" -type f -exec $SED -i "1{/---/d}" {} \;
 
-${YQ} delete --inplace -d'0' manifests/0000_50_olm_00-namespace.yaml 'metadata.labels."pod-security.kubernetes.io/enforce*"'
+# (anik120): uncomment this once https://issues.redhat.com/browse/OLM-2695 is Done. 
+#${YQ} delete --inplace -d'1' manifests/0000_50_olm_00-namespace.yaml 'metadata.labels."pod-security.kubernetes.io/enforce*"'

--- a/values.yaml
+++ b/values.yaml
@@ -1,10 +1,13 @@
 installType: ocp
 rbacApiVersion: rbac.authorization.k8s.io
 namespace: openshift-operator-lifecycle-manager
+namespace_psa: 
+  enforceLevel: restricted
+  enforceVersion: '"v1.24"'
 catalog_namespace: openshift-marketplace
 operator_namespace: openshift-operators
 operator_namespace_psa: 
-  enforceLevel: baseline
+  enforceLevel: privileged
   enforceVersion: '"v1.24"'
 imagestream: true
 writeStatusName: operator-lifecycle-manager


### PR DESCRIPTION
This PR:

1. Adds the enforce:restricted Pod Security Admission labels to the
openshift-operator-lifecycle-manager namespace

2. Adds the enforce:privileged  PSA labels to the openshift-operator 
namespace, that will be removed in a future commit, when another entity 
is present to modify the namespace to set the security of the namespace 
according to the workloads present in the namespace.