### PR TITLE
OPRUN-2892: Update service-monitor tls config

### DIFF
--- a/manifests/0000_90_olm_00-service-monitor.yaml
+++ b/manifests/0000_90_olm_00-service-monitor.yaml
@@ -59,6 +59,8 @@ spec:
       tlsConfig:
         caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
         serverName: olm-operator-metrics.openshift-operator-lifecycle-manager.svc
+        keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
+        certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
   jobLabel: component
   namespaceSelector:
     matchNames:
@@ -92,6 +94,8 @@ spec:
       tlsConfig:
         caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
         serverName: catalog-operator-metrics.openshift-operator-lifecycle-manager.svc
+        keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
+        certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
   jobLabel: component
   namespaceSelector:
     matchNames:

--- a/scripts/generate_crds_manifests.sh
+++ b/scripts/generate_crds_manifests.sh
@@ -90,6 +90,8 @@ ${YQ} write --inplace -s scripts/olm-deployment.patch.yaml manifests/0000_50_olm
 ${YQ} write --inplace -s scripts/catalog-deployment.patch.yaml manifests/0000_50_olm_08-catalog-operator.deployment.yaml
 ${YQ} write --inplace -s scripts/packageserver-deployment.patch.yaml manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
 ${YQ} merge --inplace manifests/0000_50_olm_02-olmconfig.yaml scripts/cluster-olmconfig.patch.yaml
+${YQ} write --inplace -d'2' -s scripts/service-monitor.patch.yaml manifests/0000_90_olm_00-service-monitor.yaml
+${YQ} write --inplace -d'3' -s scripts/service-monitor.patch.yaml manifests/0000_90_olm_00-service-monitor.yaml
 mv manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml pkg/manifests/csv.yaml
 cp scripts/packageserver-pdb.yaml manifests/0000_50_olm_00-packageserver.pdb.yaml
 

--- a/scripts/service-monitor.patch.yaml
+++ b/scripts/service-monitor.patch.yaml
@@ -1,0 +1,6 @@
+- command: update
+  path: spec.endpoints[*].tlsConfig.keyFile
+  value: /etc/prometheus/secrets/metrics-client-certs/tls.key
+- command: update
+  path: spec.endpoints[*].tlsConfig.certFile
+  value: /etc/prometheus/secrets/metrics-client-certs/tls.crt


### PR DESCRIPTION
The client cert/key pair is a way of authenticating that will function even without live kube-apiserver connections so we can collect metrics if the kube-apiserver is unavailable.

Signed-off-by: perdasilva <perdasilva@redhat.com>