### PR TITLE
noqe: script fixes

### DIFF
--- a/scripts/sync_pop_candidate.sh
+++ b/scripts/sync_pop_candidate.sh
@@ -22,7 +22,7 @@ done
 set -u
 
 remote="${1:-api}"
-subtree_dir="staging/${remote}"
+subtree_dir="staging/${2:-${remote}}"
 cherrypick_set="${remote}.cherrypick"
 remaining=$(wc -l < "${cherrypick_set}")
 


### PR DESCRIPTION
This PR:
 - updates scripts/sync_pop_candidate.sh to take an optional second parameter for the subtree upon which to apply the cherry-picks (this makes it easier to cherry-pick from your fork so you can start to build up the downstream while waiting on the upstream)
 - updates scripts/crc_deploy.sh to push the olm images directly to the crc registry without having to use kubectl port-forward