### PR TITLE
OLM-2695: Adds downstream only CSV Namespace Labeler Plug-In

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.4.1
 	github.com/mikefarah/yq/v3 v3.0.0-20201202084205-8846255d1c37
 	github.com/onsi/ginkgo/v2 v2.1.3
-	github.com/openshift/api v0.0.0-20200331152225-585af27e34fd
+	github.com/openshift/api v0.0.0-20220525145417-ee5b62754c68
 	github.com/operator-framework/api v0.16.0
 	github.com/operator-framework/operator-lifecycle-manager v0.0.0-00010101000000-000000000000
 	github.com/operator-framework/operator-registry v1.17.5
@@ -176,7 +176,7 @@ require (
 	github.com/onsi/gomega v1.18.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799 // indirect
-	github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0 // indirect
+	github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a // indirect
 	github.com/otiai10/copy v1.2.0 // indirect
 	github.com/pbnjay/strptime v0.0.0-20140226051138-5c05b0d668c9 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
@@ -223,7 +223,7 @@ require (
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
 	golang.org/x/net v0.0.0-20220407224826-aac1ed45d8e3 // indirect
-	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
+	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect

--- a/go.mod
+++ b/go.mod
@@ -177,6 +177,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799 // indirect
 	github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a // indirect
+	github.com/openshift/cluster-policy-controller v0.0.0-20220825134653-523e4104074f // indirect
 	github.com/otiai10/copy v1.2.0 // indirect
 	github.com/pbnjay/strptime v0.0.0-20140226051138-5c05b0d668c9 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -989,6 +989,8 @@ github.com/openshift/api v0.0.0-20210517065120-b325f58df679/go.mod h1:dZ4kytOo3s
 github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0 h1:kMiuiZXH1GdfbiMwsuAQOqGaMxlo9NCUk0wT4XAdfNM=
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0/go.mod h1:uUQ4LClRO+fg5MF/P6QxjMCb1C9f7Oh4RKepftDnEJE=
+github.com/openshift/cluster-policy-controller v0.0.0-20220825134653-523e4104074f h1:ll0eE7rgGHsFlrI6ksr6nXL2ur8GYBe8Jj0GwNQ/1+o=
+github.com/openshift/cluster-policy-controller v0.0.0-20220825134653-523e4104074f/go.mod h1:r9ZZT5wjwoS2heBfYR26uJhhkGYwgmFqomu9ww0y9Qw=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=

--- a/go.sum
+++ b/go.sum
@@ -1435,8 +1435,9 @@ golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210805134026-6f1e6394065a/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 h1:RerP+noqYHUQ8CMRcPlC2nvTa4dcBIjegkuWdcUDuqg=
 golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 h1:OSnWWcOd/CtWQC2cYSBgbTSJv3ciqd8r54ySIW2y3RE=
+golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/staging/operator-lifecycle-manager/go.mod
+++ b/staging/operator-lifecycle-manager/go.mod
@@ -258,3 +258,6 @@ replace (
 	go.opentelemetry.io/otel => go.opentelemetry.io/otel v0.20.0
 	go.opentelemetry.io/otel/sdk => go.opentelemetry.io/otel/sdk v0.20.0
 )
+
+// downstream only
+require github.com/openshift/cluster-policy-controller v0.0.0-20220825134653-523e4104074f

--- a/staging/operator-lifecycle-manager/go.mod
+++ b/staging/operator-lifecycle-manager/go.mod
@@ -22,8 +22,8 @@ require (
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.18.1
-	github.com/openshift/api v0.0.0-20200331152225-585af27e34fd
-	github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0
+	github.com/openshift/api v0.0.0-20220525145417-ee5b62754c68
+	github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a
 	github.com/operator-framework/api v0.16.0
 	github.com/operator-framework/operator-registry v1.17.5
 	github.com/otiai10/copy v1.2.0
@@ -221,7 +221,7 @@ require (
 	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
-	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
+	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect

--- a/staging/operator-lifecycle-manager/go.sum
+++ b/staging/operator-lifecycle-manager/go.sum
@@ -1550,8 +1550,9 @@ golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210805134026-6f1e6394065a/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 h1:RerP+noqYHUQ8CMRcPlC2nvTa4dcBIjegkuWdcUDuqg=
 golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 h1:OSnWWcOd/CtWQC2cYSBgbTSJv3ciqd8r54ySIW2y3RE=
+golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/staging/operator-lifecycle-manager/go.sum
+++ b/staging/operator-lifecycle-manager/go.sum
@@ -1075,6 +1075,8 @@ github.com/openshift/api v0.0.0-20211014063134-be2a7fb8aa44/go.mod h1:RsQCVJu4qh
 github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0 h1:kMiuiZXH1GdfbiMwsuAQOqGaMxlo9NCUk0wT4XAdfNM=
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0/go.mod h1:uUQ4LClRO+fg5MF/P6QxjMCb1C9f7Oh4RKepftDnEJE=
+github.com/openshift/cluster-policy-controller v0.0.0-20220825134653-523e4104074f h1:ll0eE7rgGHsFlrI6ksr6nXL2ur8GYBe8Jj0GwNQ/1+o=
+github.com/openshift/cluster-policy-controller v0.0.0-20220825134653-523e4104074f/go.mod h1:r9ZZT5wjwoS2heBfYR26uJhhkGYwgmFqomu9ww0y9Qw=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/operator-framework/api v0.7.1/go.mod h1:L7IvLd/ckxJEJg/t4oTTlnHKAJIP/p51AvEslW3wYdY=

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/config.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/config.go
@@ -37,6 +37,26 @@ type operatorConfig struct {
 	configClient                 configv1client.Interface
 }
 
+func (o *operatorConfig) OperatorClient() operatorclient.ClientInterface {
+	return o.operatorClient
+}
+
+func (o *operatorConfig) ExternalClient() versioned.Interface {
+	return o.externalClient
+}
+
+func (o *operatorConfig) ResyncPeriod() func() time.Duration {
+	return o.resyncPeriod
+}
+
+func (o *operatorConfig) WatchedNamespaces() []string {
+	return o.watchedNamespaces
+}
+
+func (o *operatorConfig) Logger() *logrus.Logger {
+	return o.logger
+}
+
 func (o *operatorConfig) apply(options []OperatorOption) {
 	for _, option := range options {
 		option(o)

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/downstream_plugins.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/downstream_plugins.go
@@ -1,0 +1,13 @@
+package olm
+
+import (
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/plugins"
+)
+
+func init() {
+	operatorPlugInFactoryFuncs = []plugins.OperatorPlugInFactoryFunc{
+		// labels unlabeled non-payload openshift-* csv namespaces with
+		// security.openshift.io/scc.podSecurityLabelSync: true
+		plugins.NewCsvNamespaceLabelerPluginFunc,
+	}
+}

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/plugins/downstream_csv_namespace_labeler_plugin.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/plugins/downstream_csv_namespace_labeler_plugin.go
@@ -1,0 +1,368 @@
+package plugins
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/openshift/cluster-policy-controller/pkg/psalabelsyncer/nsexemptions"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	listerv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubestate"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	listerv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+const NamespaceLabelSyncerLabelKey = "security.openshift.io/scc.podSecurityLabelSync"
+const openshiftPrefix = "openshift-"
+
+const noCopiedCsvSelector = "!" + v1alpha1.CopiedLabelKey
+
+// csvNamespaceLabelerPlugin is responsible for labeling non-payload openshift-* namespaces
+// with the label "security.openshift.io/scc.podSecurityLabelSync=true" so that the  PSA Label Syncer
+// see https://github.com/openshift/cluster-policy-controller/blob/master/pkg/psalabelsyncer/podsecurity_label_sync_controller.go
+// can help ensure that the operator payloads in the namespace continue to work even if they don't yet respect the
+// upstream Pod Security Admission controller, which will become active in k8s 1.25.
+// see https://kubernetes.io/docs/concepts/security/pod-security-admission/
+// If a CSV is created or modified, this controller will look at the csv's namespace. If it is a non-payload namespace,
+// if the namespace name is prefixed with 'openshift-', and if the namespace does not contain the label (whatever
+// value it may be set to), it will add the "security.openshift.io/scc.podSecurityLabelSync=true" to the namespace.
+type csvNamespaceLabelerPlugin struct {
+	namespaceLister       listerv1.NamespaceLister
+	nonCopiedCsvListerMap map[string]listerv1alpha1.ClusterServiceVersionLister
+	kubeClient            operatorclient.ClientInterface
+	externalClient        versioned.Interface
+	logger                *logrus.Logger
+}
+
+func NewCsvNamespaceLabelerPluginFunc(ctx context.Context, config OperatorConfig, hostOperator HostOperator) (OperatorPlugin, error) {
+
+	if hostOperator == nil {
+		return nil, fmt.Errorf("cannot initialize plugin: operator undefined")
+	}
+
+	plugin := &csvNamespaceLabelerPlugin{
+		kubeClient:            config.OperatorClient(),
+		externalClient:        config.ExternalClient(),
+		logger:                config.Logger(),
+		namespaceLister:       nil,
+		nonCopiedCsvListerMap: map[string]listerv1alpha1.ClusterServiceVersionLister{},
+	}
+
+	plugin.log("setting up csv namespace plug-in for namespaces: %s", config.WatchedNamespaces())
+
+	namespaceInformer := newNamespaceInformer(config.OperatorClient(), config.ResyncPeriod()())
+
+	plugin.log("registering namespace informer")
+
+	plugin.namespaceLister = listerv1.NewNamespaceLister(namespaceInformer.GetIndexer())
+
+	namespaceQueue := workqueue.NewNamedRateLimitingQueue(
+		workqueue.DefaultControllerRateLimiter(),
+		"csv-ns-labeler-plugin-ns-queue",
+	)
+	namespaceQueueInformer, err := queueinformer.NewQueueInformer(
+		ctx,
+		queueinformer.WithInformer(namespaceInformer),
+		queueinformer.WithLogger(config.Logger()),
+		queueinformer.WithQueue(namespaceQueue),
+		queueinformer.WithIndexer(namespaceInformer.GetIndexer()),
+		queueinformer.WithSyncer(plugin),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := hostOperator.RegisterQueueInformer(namespaceQueueInformer); err != nil {
+		return nil, err
+	}
+
+	for _, namespace := range config.WatchedNamespaces() {
+		plugin.log("setting up namespace: %s", namespace)
+		// ignore namespaces that are *NOT* prefixed with openshift- but accept metav1.NamespaceAll
+		if !(hasOpenshiftPrefix(namespace)) && namespace != metav1.NamespaceAll {
+			continue
+		}
+
+		nonCopiedCsvInformer := newNonCopiedCsvInformerForNamespace(namespace, config.ExternalClient(), config.ResyncPeriod()())
+
+		nonCopiedCsvQueue := workqueue.NewNamedRateLimitingQueue(
+			workqueue.DefaultControllerRateLimiter(),
+			fmt.Sprintf("%s/csv-ns-labeler-plugin-csv-queue", namespace),
+		)
+		nonCopiedCsvQueueInformer, err := queueinformer.NewQueueInformer(
+			ctx,
+			queueinformer.WithInformer(nonCopiedCsvInformer),
+			queueinformer.WithLogger(config.Logger()),
+			queueinformer.WithQueue(nonCopiedCsvQueue),
+			queueinformer.WithIndexer(nonCopiedCsvInformer.GetIndexer()),
+			queueinformer.WithSyncer(plugin),
+		)
+		if err != nil {
+			return nil, err
+		}
+		if err := hostOperator.RegisterQueueInformer(nonCopiedCsvQueueInformer); err != nil {
+			return nil, err
+		}
+		plugin.nonCopiedCsvListerMap[namespace] = listerv1alpha1.NewClusterServiceVersionLister(nonCopiedCsvInformer.GetIndexer())
+		plugin.log("registered csv queue informer for: %s", namespace)
+	}
+	plugin.log("finished setting up csv namespace labeler plugin")
+
+	return plugin, nil
+}
+
+func (p *csvNamespaceLabelerPlugin) Shutdown() error {
+	return nil
+}
+
+func (p *csvNamespaceLabelerPlugin) Sync(ctx context.Context, event kubestate.ResourceEvent) error {
+	// only act on csv added and updated events
+	if event.Type() != kubestate.ResourceAdded && event.Type() != kubestate.ResourceUpdated {
+		return nil
+	}
+
+	var namespace *v1.Namespace
+	var err error
+
+	// get namespace from the event resource
+	switch eventResource := event.Resource().(type) {
+
+	// handle csv events
+	case *v1alpha1.ClusterServiceVersion:
+		// ignore copied csvs and namespaces that should be ignored
+		if eventResource.IsCopied() || ignoreNamespace(eventResource.GetNamespace()) {
+			return nil
+		}
+
+		namespace, err = p.getNamespace(eventResource.GetNamespace())
+		if err != nil {
+			return fmt.Errorf("error getting csv namespace (%s) for label sync'er labeling", eventResource.GetNamespace())
+		}
+
+	// handle namespace events
+	case *v1.Namespace:
+		// ignore namespaces that should be ignored and ones that are already labeled
+		if ignoreNamespace(eventResource.GetName()) || hasLabelSyncerLabel(eventResource) {
+			return nil
+		}
+
+		// get csv count for namespace
+		csvCount, err := p.countClusterServiceVersions(eventResource.GetName())
+		if err != nil {
+			return fmt.Errorf("error counting csvs in namespace=%s: %s", eventResource.GetName(), err)
+		}
+
+		// ignore namespaces with no csvs
+		if csvCount <= 0 {
+			return nil
+		}
+
+		namespace = eventResource
+	default:
+		return fmt.Errorf("event resource is neither a ClusterServiceVersion or a Namespace")
+	}
+
+	// add label sync'er label if it does not exist
+	if !(hasLabelSyncerLabel(namespace)) {
+		if err := applyLabelSyncerLabel(ctx, p.kubeClient, namespace); err != nil {
+			return fmt.Errorf("error updating csv namespace (%s) with label sync'er label", namespace.GetNamespace())
+		}
+		p.log("applied %s=true label to namespace %s", NamespaceLabelSyncerLabelKey, namespace.GetNamespace())
+	}
+
+	return nil
+}
+
+func (p *csvNamespaceLabelerPlugin) getNamespace(namespace string) (*v1.Namespace, error) {
+	ns, err := p.namespaceLister.Get(namespace)
+	if err != nil {
+		return nil, err
+	}
+	return ns, nil
+}
+
+func (p *csvNamespaceLabelerPlugin) countClusterServiceVersions(namespace string) (int, error) {
+	lister, ok := p.nonCopiedCsvListerMap[namespace]
+	if !ok {
+		lister, ok = p.nonCopiedCsvListerMap[metav1.NamespaceAll]
+		if !ok {
+			return 0, fmt.Errorf("no csv indexer found for namespace: %s", namespace)
+		}
+	}
+	labelSelector, err := labels.Parse(noCopiedCsvSelector)
+	if err != nil {
+		return 0, err
+	}
+
+	csvList, err := lister.ClusterServiceVersions(namespace).List(labelSelector)
+	if err != nil {
+		return 0, err
+	}
+	return len(csvList), nil
+}
+
+func (p *csvNamespaceLabelerPlugin) log(format string, args ...interface{}) {
+	if p.logger != nil {
+		p.logger.Infof("[CSV NS Plug-in] "+format, args...)
+	}
+}
+
+// newNamespaceInformer creates a namespace informer that filters namespaces the plug-in is not interested in:
+// payload namespaces (except openshift-operators) and non openshift- prefixed namespaces
+// the informer also prunes the namespace objects to only keep basic type and object metadata and annotations
+func newNamespaceInformer(k8sClient operatorclient.ClientInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	// create a namespace informer
+	pruneNamespace := func(namespace *v1.Namespace) {
+		namespace = &v1.Namespace{
+			TypeMeta: namespace.TypeMeta,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        namespace.GetName(),
+				Namespace:   namespace.GetNamespace(),
+				Annotations: namespace.GetAnnotations(),
+			},
+		}
+	}
+
+	return cache.NewSharedIndexInformer(
+		&cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				list, err := k8sClient.KubernetesInterface().CoreV1().Namespaces().List(context.Background(), options)
+				if err != nil {
+					return list, err
+				}
+
+				// filter and prune namespaces
+				var filteredList []v1.Namespace
+				for i := range list.Items {
+					ns := list.Items[i]
+					if !(ignoreNamespace(ns.GetName())) {
+						pruneNamespace(&ns)
+						filteredList = append(filteredList, ns)
+					}
+				}
+				return &v1.NamespaceList{
+					Items: filteredList,
+				}, nil
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				nsWatch, err := k8sClient.KubernetesInterface().CoreV1().Namespaces().Watch(context.Background(), options)
+				if err != nil {
+					return nsWatch, err
+				}
+				return watch.Filter(nsWatch, func(e watch.Event) (watch.Event, bool) {
+					if ns, ok := e.Object.(*v1.Namespace); ok {
+						if !(ignoreNamespace(ns.GetName())) {
+							pruneNamespace(ns)
+							return e, true
+						}
+					}
+					return e, false
+				}), nil
+			},
+		},
+		&v1.Namespace{},
+		resyncPeriod,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+	)
+}
+
+// newNonCopiedCsvInformerForNamespace creates a csv-based informer that filters out copied csvs and csv events coming
+// from namespaces the plug-in is not interested in: payload namespaces (except openshift-operators) and
+// non openshift- prefixed namespaces
+// the informer also prunes the csvs to only keep basic type and object metadata and annotations
+func newNonCopiedCsvInformerForNamespace(namespace string, externalClient versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	// create a new csv informer and prune status to reduce memory footprint
+	pruneCSV := func(csv *v1alpha1.ClusterServiceVersion) {
+		csv = &v1alpha1.ClusterServiceVersion{
+			TypeMeta: csv.TypeMeta,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        csv.GetName(),
+				Namespace:   csv.GetNamespace(),
+				Annotations: csv.GetAnnotations(),
+			},
+		}
+	}
+
+	return cache.NewSharedIndexInformer(
+		&cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				options.LabelSelector = noCopiedCsvSelector
+				list, err := externalClient.OperatorsV1alpha1().ClusterServiceVersions(namespace).List(context.Background(), options)
+				if err != nil {
+					return list, err
+				}
+
+				// filter and prune csvs
+				var filteredList []v1alpha1.ClusterServiceVersion
+				for i := range list.Items {
+					csv := list.Items[i]
+					if !(ignoreNamespace(csv.GetNamespace())) {
+						pruneCSV(&csv)
+						filteredList = append(filteredList, csv)
+					}
+				}
+				return &v1alpha1.ClusterServiceVersionList{
+					Items: filteredList,
+				}, nil
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				options.LabelSelector = noCopiedCsvSelector
+				csvWatch, err := externalClient.OperatorsV1alpha1().ClusterServiceVersions(namespace).Watch(context.Background(), options)
+				if err != nil {
+					return csvWatch, err
+				}
+				return watch.Filter(csvWatch, func(e watch.Event) (watch.Event, bool) {
+					if csv, ok := e.Object.(*v1alpha1.ClusterServiceVersion); ok {
+						if !(ignoreNamespace(csv.GetNamespace())) && !csv.IsCopied() {
+							pruneCSV(csv)
+							return e, true
+						}
+					}
+					return e, false
+				}), nil
+			},
+		},
+		&v1alpha1.ClusterServiceVersion{},
+		resyncPeriod,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+	)
+}
+
+func hasOpenshiftPrefix(namespaceName string) bool {
+	return strings.HasPrefix(namespaceName, openshiftPrefix)
+}
+
+func ignoreNamespace(namespace string) bool {
+	// ignore non-openshift-* and payload openshift-* namespaces
+	return !hasOpenshiftPrefix(namespace) || nsexemptions.IsNamespacePSALabelSyncExemptedInVendoredOCPVersion(namespace)
+}
+
+func applyLabelSyncerLabel(ctx context.Context, kubeClient operatorclient.ClientInterface, namespace *v1.Namespace) error {
+	if _, ok := namespace.GetLabels()[NamespaceLabelSyncerLabelKey]; !ok {
+		nsCopy := namespace.DeepCopy()
+		if nsCopy.GetLabels() == nil {
+			nsCopy.SetLabels(map[string]string{})
+		}
+		nsCopy.GetLabels()[NamespaceLabelSyncerLabelKey] = "true"
+		if _, err := kubeClient.KubernetesInterface().CoreV1().Namespaces().Update(ctx, nsCopy, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func hasLabelSyncerLabel(namespace *v1.Namespace) bool {
+	_, ok := namespace.GetLabels()[NamespaceLabelSyncerLabelKey]
+	return ok
+}

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/plugins/downstream_csv_namespace_labeler_plugin_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/plugins/downstream_csv_namespace_labeler_plugin_test.go
@@ -1,0 +1,318 @@
+package plugins
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
+	listerv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubestate"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	v1fake "k8s.io/client-go/kubernetes/typed/core/v1/fake"
+	listerv1 "k8s.io/client-go/listers/core/v1"
+	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+	apiregistrationfake "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake"
+)
+
+type fakeClientOptions struct {
+	k8sResources      []runtime.Object
+	extendedResources []runtime.Object
+}
+
+type fakeClientOption func(options *fakeClientOptions)
+
+func withK8sResources(resource ...runtime.Object) fakeClientOption {
+	return func(options *fakeClientOptions) {
+		options.k8sResources = append(options.k8sResources, resource...)
+	}
+}
+
+func withExtendedResources(resource ...runtime.Object) fakeClientOption {
+	return func(options *fakeClientOptions) {
+		options.extendedResources = append(options.extendedResources, resource...)
+	}
+}
+
+func NewFakeCSVNamespaceLabelerPlugin(t *testing.T, options ...fakeClientOption) (*csvNamespaceLabelerPlugin, context.CancelFunc) {
+
+	resyncPeriod := 5 * time.Minute
+	clientOptions := &fakeClientOptions{}
+	for _, applyOption := range options {
+		applyOption(clientOptions)
+	}
+
+	// create fake clients
+	k8sClientFake := operatorclient.NewClient(k8sfake.NewSimpleClientset(clientOptions.k8sResources...), apiextensionsfake.NewSimpleClientset(), apiregistrationfake.NewSimpleClientset())
+	extendedClient := fake.NewReactionForwardingClientsetDecorator(clientOptions.extendedResources)
+
+	// create informers
+	namespaceInformer := newNamespaceInformer(k8sClientFake, resyncPeriod)
+	nonCopiedCsvInformer := newNonCopiedCsvInformerForNamespace(metav1.NamespaceAll, extendedClient, resyncPeriod)
+
+	// sync caches
+	ctx, cancel := context.WithCancel(context.TODO())
+	go namespaceInformer.Run(ctx.Done())
+	go nonCopiedCsvInformer.Run(ctx.Done())
+
+	if ok := cache.WaitForCacheSync(ctx.Done(), namespaceInformer.HasSynced, nonCopiedCsvInformer.HasSynced); !ok {
+		t.Fatalf("failed to wait for caches to sync")
+	}
+
+	return &csvNamespaceLabelerPlugin{
+		kubeClient:      k8sClientFake,
+		externalClient:  extendedClient,
+		logger:          nil,
+		namespaceLister: listerv1.NewNamespaceLister(namespaceInformer.GetIndexer()),
+		nonCopiedCsvListerMap: map[string]listerv1alpha1.ClusterServiceVersionLister{
+			metav1.NamespaceAll: listerv1alpha1.NewClusterServiceVersionLister(nonCopiedCsvInformer.GetIndexer()),
+		},
+	}, cancel
+}
+
+func NewCsvInNamespace(namespace string) *v1alpha1.ClusterServiceVersion {
+	return &v1alpha1.ClusterServiceVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-csv",
+			Namespace: namespace,
+		},
+	}
+}
+
+func NewCopiedCsvInNamespace(namespace string) *v1alpha1.ClusterServiceVersion {
+	csv := NewCsvInNamespace(namespace)
+	csv.SetLabels(map[string]string{
+		v1alpha1.CopiedLabelKey: "true",
+	})
+	return csv
+}
+
+func NewNamespace(name string) *v1.Namespace {
+	return &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}
+
+func NewLabeledNamespace(name string, labelValue string) *v1.Namespace {
+	ns := NewNamespace(name)
+	ns.SetLabels(map[string]string{
+		NamespaceLabelSyncerLabelKey: labelValue,
+	})
+	return ns
+}
+
+func Test_SyncIgnoresDeletionEvent(t *testing.T) {
+	// Sync ignores deletion events
+	namespace := "test-namespace"
+	plugin, shutdown := NewFakeCSVNamespaceLabelerPlugin(t, withK8sResources(NewNamespace(namespace)))
+	defer shutdown()
+
+	event := kubestate.NewResourceEvent(kubestate.ResourceDeleted, NewCsvInNamespace(namespace))
+	assert.Nil(t, plugin.Sync(context.Background(), event))
+
+	ns, err := plugin.kubeClient.KubernetesInterface().CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.NotContains(t, ns.GetLabels(), NamespaceLabelSyncerLabelKey)
+}
+
+func Test_SyncIgnoresCopiedCsvs(t *testing.T) {
+	// Sync ignores copied csvs
+	namespace := "openshift-test"
+	plugin, shutdown := NewFakeCSVNamespaceLabelerPlugin(t, withK8sResources(NewNamespace(namespace)))
+	defer shutdown()
+
+	event := kubestate.NewResourceEvent(kubestate.ResourceAdded, NewCopiedCsvInNamespace(namespace))
+	assert.Nil(t, plugin.Sync(context.Background(), event))
+
+	ns, err := plugin.kubeClient.KubernetesInterface().CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.NotContains(t, ns.GetLabels(), NamespaceLabelSyncerLabelKey)
+}
+
+func Test_SyncIgnoresNonOpenshiftNamespaces(t *testing.T) {
+	// Sync ignores non-openshift namespaces
+	namespace := "test-namespace"
+	plugin, shutdown := NewFakeCSVNamespaceLabelerPlugin(t, withK8sResources(NewNamespace(namespace)))
+	defer shutdown()
+
+	event := kubestate.NewResourceEvent(kubestate.ResourceAdded, NewCopiedCsvInNamespace(namespace))
+	assert.Nil(t, plugin.Sync(context.Background(), event))
+
+	ns, err := plugin.kubeClient.KubernetesInterface().CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.NotContains(t, ns.GetLabels(), NamespaceLabelSyncerLabelKey)
+}
+
+func Test_SyncIgnoresPayloadOpenshiftNamespacesExceptOperators(t *testing.T) {
+	// Sync ignores payload openshift namespaces, except openshift-operators
+	// openshift-monitoring sync -> no label
+	plugin, shutdown := NewFakeCSVNamespaceLabelerPlugin(t, withK8sResources(NewNamespace("openshift-monitoring"), NewNamespace("openshift-operators")))
+	defer shutdown()
+
+	event := kubestate.NewResourceEvent(kubestate.ResourceAdded, NewCsvInNamespace("openshift-monitoring"))
+	assert.Nil(t, plugin.Sync(context.Background(), event))
+
+	ns, err := plugin.kubeClient.KubernetesInterface().CoreV1().Namespaces().Get(context.Background(), "openshift-monitoring", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.NotContains(t, ns.GetLabels(), NamespaceLabelSyncerLabelKey)
+
+	// openshift-operators sync -> label added
+	event = kubestate.NewResourceEvent(kubestate.ResourceAdded, NewCsvInNamespace("openshift-operators"))
+	assert.Nil(t, plugin.Sync(context.Background(), event))
+	ns, err = plugin.kubeClient.KubernetesInterface().CoreV1().Namespaces().Get(context.Background(), "openshift-operators", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, "true", ns.GetLabels()[NamespaceLabelSyncerLabelKey])
+}
+
+func Test_SyncIgnoresAlreadyLabeledNonPayloadOpenshiftNamespaces(t *testing.T) {
+	// Sync ignores non-payload openshift namespaces that are already labeled
+	labelValues := []string{"true", "false", " ", "", "gibberish"}
+	namespace := "openshift-test"
+
+	for _, labelValue := range labelValues {
+		func() {
+			plugin, shutdown := NewFakeCSVNamespaceLabelerPlugin(t, withK8sResources(NewLabeledNamespace(namespace, labelValue)))
+			defer shutdown()
+
+			event := kubestate.NewResourceEvent(kubestate.ResourceUpdated, NewCsvInNamespace(namespace))
+			assert.Nil(t, plugin.Sync(context.Background(), event))
+
+			ns, err := plugin.kubeClient.KubernetesInterface().CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
+			assert.NoError(t, err)
+			assert.Equal(t, labelValue, ns.GetLabels()[NamespaceLabelSyncerLabelKey])
+		}()
+	}
+}
+
+func Test_SyncLabelsNonPayloadUnlabeledOpenshiftNamespaces(t *testing.T) {
+	// Sync will label non-labeled non-payload openshift- namespaces independent of event type (except deletion, tested separately)
+	eventTypes := []kubestate.ResourceEventType{kubestate.ResourceUpdated, kubestate.ResourceAdded}
+	namespace := "openshift-test"
+
+	for _, eventType := range eventTypes {
+		func() {
+			plugin, shutdown := NewFakeCSVNamespaceLabelerPlugin(t, withK8sResources(NewNamespace(namespace)))
+			defer shutdown()
+
+			event := kubestate.NewResourceEvent(eventType, NewCsvInNamespace(namespace))
+			assert.Nil(t, plugin.Sync(context.Background(), event))
+
+			ns, err := plugin.kubeClient.KubernetesInterface().CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
+			assert.NoError(t, err)
+			assert.Contains(t, ns.GetLabels(), NamespaceLabelSyncerLabelKey)
+		}()
+	}
+}
+
+func Test_SyncFailsIfEventResourceIsNotCSV(t *testing.T) {
+	// Sync fails if resource is not a csv\
+	plugin, shutdown := NewFakeCSVNamespaceLabelerPlugin(t)
+	defer shutdown()
+
+	event := kubestate.NewResourceEvent(kubestate.ResourceAdded, v1.ConfigMap{})
+	assert.Error(t, plugin.Sync(context.Background(), event))
+}
+
+func Test_SyncFailsIfNamespaceNotFound(t *testing.T) {
+	// Sync fails if the namespace is not found
+	plugin, shutdown := NewFakeCSVNamespaceLabelerPlugin(t)
+	defer shutdown()
+
+	event := kubestate.NewResourceEvent(kubestate.ResourceAdded, NewCsvInNamespace("openshift-test"))
+	assert.Error(t, plugin.Sync(context.Background(), event))
+}
+
+func Test_SyncFailsIfCSVCannotBeUpdated(t *testing.T) {
+	// Sync fails if the namespace cannot be updated
+	namespace := "openshift-test"
+	plugin, shutdown := NewFakeCSVNamespaceLabelerPlugin(t, withK8sResources(NewNamespace(namespace)))
+	defer shutdown()
+
+	event := kubestate.NewResourceEvent(kubestate.ResourceAdded, NewCsvInNamespace(namespace))
+	updateNsError := func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, &v1.Namespace{}, errors.New("error updating namespace")
+	}
+	plugin.kubeClient.KubernetesInterface().CoreV1().(*v1fake.FakeCoreV1).PrependReactor("update", "namespaces", updateNsError)
+	assert.Error(t, plugin.Sync(context.Background(), event))
+}
+
+func Test_SyncLabelsNamespaceWithCSV(t *testing.T) {
+	// Given a namespace event for an unlabelled and non-payload openshift-* namespace
+	// that contains at least one non-copied csv
+	// Sync should apply the label syncer label to the namespace
+	namespace := NewNamespace("openshift-test")
+	csv := NewCsvInNamespace(namespace.GetName())
+	plugin, shutdown := NewFakeCSVNamespaceLabelerPlugin(t, withK8sResources(namespace), withExtendedResources(csv))
+	defer shutdown()
+
+	event := kubestate.NewResourceEvent(kubestate.ResourceUpdated, namespace)
+	assert.NoError(t, plugin.Sync(context.Background(), event))
+
+	ns, err := plugin.kubeClient.KubernetesInterface().CoreV1().Namespaces().Get(context.Background(), namespace.GetName(), metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Contains(t, ns.GetLabels(), NamespaceLabelSyncerLabelKey)
+}
+
+func Test_SyncDoesNotLabelNamespaceWithoutCSVs(t *testing.T) {
+	// Given a namespace event for an unlabelled and non-payload openshift-* namespace
+	// that contains zero non-copied csvs
+	// Sync should *NOT* apply the label syncer label to the namespace
+	namespace := NewNamespace("openshift-test")
+	plugin, shutdown := NewFakeCSVNamespaceLabelerPlugin(t, withK8sResources(namespace))
+	defer shutdown()
+
+	event := kubestate.NewResourceEvent(kubestate.ResourceUpdated, namespace)
+	assert.NoError(t, plugin.Sync(context.Background(), event))
+
+	ns, err := plugin.kubeClient.KubernetesInterface().CoreV1().Namespaces().Get(context.Background(), namespace.GetName(), metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.NotContains(t, ns.GetLabels(), NamespaceLabelSyncerLabelKey)
+}
+
+func Test_SyncDoesNotLabelNamespacesWithCopiedCSVs(t *testing.T) {
+	// Given a namespace event for an unlabelled and non-payload openshift-* namespace
+	// that only contains copied csvs
+	// Sync should *NOT* apply the label syncer label to the namespace
+	namespace := NewNamespace("openshift-test")
+	csv := NewCopiedCsvInNamespace(namespace.GetName())
+	plugin, shutdown := NewFakeCSVNamespaceLabelerPlugin(t, withK8sResources(namespace), withExtendedResources(csv))
+	defer shutdown()
+
+	event := kubestate.NewResourceEvent(kubestate.ResourceUpdated, namespace)
+	assert.NoError(t, plugin.Sync(context.Background(), event))
+
+	ns, err := plugin.kubeClient.KubernetesInterface().CoreV1().Namespaces().Get(context.Background(), namespace.GetName(), metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.NotContains(t, ns.GetLabels(), NamespaceLabelSyncerLabelKey)
+}
+
+func Test_OCPVersion(t *testing.T) {
+	// This test is a maintenance alert that means the next OCP version is now in active development.
+	// This plugin relies on a list of payload namespaces that comes from the cluster-policy-controller project
+	// https://github.com/openshift/cluster-policy-controller/tree/master/pkg/psalabelsyncer
+	// This list is dependent on the OCP version. Please update the dependency version to correspond to the one
+	// vendored for the new OCP version (or contact the responsible team if it hasn't been updated yet).
+	// Then, bump the OCP version in the `nextOCPUncutBranchName` constant below
+	const nextOCPUncutBranchName = "release-4.14"
+	const errorMessage = "[maintenance alert] new ocp version branch has been cut: please check comments in test for instructions"
+
+	// Get branches
+	branches, err := exec.Command("git", "branch", "-a").Output()
+	assert.NoError(t, err)
+
+	// check if the next uncut branch has been cut and fail if so
+	assert.False(t, strings.Contains(string(branches), nextOCPUncutBranchName), errorMessage)
+}

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/plugins/operator_plugin.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/plugins/operator_plugin.go
@@ -1,0 +1,37 @@
+package plugins
+
+import (
+	"context"
+	"time"
+
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
+	"github.com/sirupsen/logrus"
+)
+
+// HostOperator is an extensible and observable operator that hosts the plug-in, i.e. which the plug-in is extending
+type HostOperator interface {
+	queueinformer.ObservableOperator
+	queueinformer.ExtensibleOperator
+}
+
+// OperatorConfig gives access to required configuration from the host operator
+type OperatorConfig interface {
+	OperatorClient() operatorclient.ClientInterface
+	ExternalClient() versioned.Interface
+	ResyncPeriod() func() time.Duration
+	WatchedNamespaces() []string
+	Logger() *logrus.Logger
+}
+
+// OperatorPlugin provides a simple interface
+// that can be used to extend the olm operator's functionality
+type OperatorPlugin interface {
+	// Shutdown is called once the host operator is done
+	// to give the plug-in a change to clean up resources if necessary
+	Shutdown() error
+}
+
+// OperatorPlugInFactoryFunc factory function that returns a new instance of a plug-in
+type OperatorPlugInFactoryFunc func(ctx context.Context, config OperatorConfig, hostOperator HostOperator) (OperatorPlugin, error)

--- a/staging/operator-lifecycle-manager/pkg/lib/queueinformer/queueinformer_operator.go
+++ b/staging/operator-lifecycle-manager/pkg/lib/queueinformer/queueinformer_operator.go
@@ -13,8 +13,19 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-// Operator describes a Reconciler that manages a set of QueueInformers.
-type Operator interface {
+// ExtensibleOperator describes a Reconciler that can be extended with additional informers and queue informers
+type ExtensibleOperator interface {
+	// RegisterQueueInformer registers the given QueueInformer with the Operator.
+	// This method returns an error if the Operator has already been started.
+	RegisterQueueInformer(queueInformer *QueueInformer) error
+
+	// RegisterInformer registers an informer with the Operator.
+	// This method returns an error if the Operator has already been started.
+	RegisterInformer(cache.SharedIndexInformer) error
+}
+
+// ObservableOperator describes a Reconciler whose state can be queried
+type ObservableOperator interface {
 	// Ready returns a channel that is closed when the Operator is ready to run.
 	Ready() <-chan struct{}
 
@@ -29,15 +40,12 @@ type Operator interface {
 
 	// HasSynced returns true if the Operator's Informers have synced, false otherwise.
 	HasSynced() bool
+}
 
-	// RegisterQueueInformer registers the given QueueInformer with the Operator.
-	// This method returns an error if the Operator has already been started.
-	RegisterQueueInformer(queueInformer *QueueInformer) error
-
-	// RegisterInformer registers an informer with the Operator.
-	// This method returns an error if the Operator has already been started.
-	RegisterInformer(cache.SharedIndexInformer) error
-
+// Operator describes a Reconciler that manages a set of QueueInformers.
+type Operator interface {
+	ObservableOperator
+	ExtensibleOperator
 	// RunInformers starts the Operator's underlying Informers.
 	RunInformers(ctx context.Context)
 

--- a/staging/operator-lifecycle-manager/test/e2e/downstream_csv_namespace_labeler_plugin_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/downstream_csv_namespace_labeler_plugin_test.go
@@ -1,0 +1,97 @@
+package e2e
+
+import (
+	"context"
+
+	"github.com/blang/semver/v4"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/plugins"
+	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/ctx"
+	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/util"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	k8scontrollerclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// See pkg/controller/operators/olm/downstream_csv_namespace_labeler_plugin.go for more details
+var _ = Describe("CSV Namespace Labeler Plugin", func() {
+	var (
+		testNamespace       v1.Namespace
+		determinedE2eClient *util.DeterminedE2EClient
+	)
+
+	BeforeEach(func() {
+		determinedE2eClient = util.NewDeterminedClient(ctx.Ctx().E2EClient())
+	})
+
+	AfterEach(func() {
+		TeardownNamespace(testNamespace.GetName())
+	})
+
+	It("should not label non openshift- namespaces", func() {
+		// create namespace with operator group
+		testNamespace = SetupGeneratedTestNamespace(genName("csv-ns-labeler-"))
+
+		// create csv in namespace
+		Expect(determinedE2eClient.Create(context.Background(), newCsv(testNamespace.GetName()))).To(Succeed())
+
+		// namespace should not be labeled
+		Consistently(func() (map[string]string, error) {
+			ns := &v1.Namespace{}
+			err := determinedE2eClient.Get(context.Background(), k8scontrollerclient.ObjectKeyFromObject(&testNamespace), ns)
+			return ns.GetLabels(), err
+		}).Should(Not(HaveKey(plugins.NamespaceLabelSyncerLabelKey)))
+	})
+
+	It("should label a non-payload openshift- namespace", func() {
+		// create namespace with operator group
+		testNamespace = SetupGeneratedTestNamespace(genName("openshift-csv-ns-labeler-"))
+
+		// create csv in namespace
+		Expect(determinedE2eClient.Create(context.Background(), newCsv(testNamespace.GetName()))).To(Succeed())
+
+		// namespace should be labeled
+		Eventually(func() (map[string]string, error) {
+			ns := &v1.Namespace{}
+			err := determinedE2eClient.Get(context.Background(), k8scontrollerclient.ObjectKeyFromObject(&testNamespace), ns)
+			return ns.GetLabels(), err
+		}).Should(HaveKeyWithValue(plugins.NamespaceLabelSyncerLabelKey, "true"))
+	})
+
+	It("should relabel a non-payload openshift- namespace containing csvs if the label is deleted", func() {
+		// create namespace with operator group
+		testNamespace = SetupGeneratedTestNamespace(genName("openshift-csv-ns-labeler-"))
+
+		// create csv in namespace
+		Expect(determinedE2eClient.Create(context.Background(), newCsv(testNamespace.GetName()))).To(Succeed())
+
+		// namespace should be labeled
+		Eventually(func() (map[string]string, error) {
+			ns := &v1.Namespace{}
+			err := determinedE2eClient.Get(context.Background(), k8scontrollerclient.ObjectKeyFromObject(&testNamespace), ns)
+			return ns.GetLabels(), err
+		}).Should(HaveKeyWithValue(plugins.NamespaceLabelSyncerLabelKey, "true"))
+
+		// delete label
+		ns := &v1.Namespace{}
+		Expect(determinedE2eClient.Get(context.Background(), k8scontrollerclient.ObjectKeyFromObject(&testNamespace), ns)).To(Succeed())
+		nsCopy := ns.DeepCopy()
+		delete(nsCopy.Annotations, plugins.NamespaceLabelSyncerLabelKey)
+		Expect(determinedE2eClient.Update(context.Background(), nsCopy)).To(Succeed())
+
+		// namespace should be labeled
+		Eventually(func() (map[string]string, error) {
+			ns := &v1.Namespace{}
+			err := determinedE2eClient.Get(context.Background(), k8scontrollerclient.ObjectKeyFromObject(&testNamespace), ns)
+			return ns.GetLabels(), err
+		}).Should(HaveKeyWithValue(plugins.NamespaceLabelSyncerLabelKey, "true"))
+	})
+})
+
+func newCsv(namespace string) *v1alpha1.ClusterServiceVersion {
+	crd := newCRD(genName("ins-"))
+	csv := newCSV(genName("package-"), namespace, "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd}, nil, nil)
+	return &csv
+}

--- a/vendor/github.com/openshift/cluster-policy-controller/LICENSE
+++ b/vendor/github.com/openshift/cluster-policy-controller/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/openshift/cluster-policy-controller/pkg/psalabelsyncer/nsexemptions/nsexemptions.go
+++ b/vendor/github.com/openshift/cluster-policy-controller/pkg/psalabelsyncer/nsexemptions/nsexemptions.go
@@ -1,0 +1,85 @@
+package nsexemptions
+
+import "k8s.io/apimachinery/pkg/util/sets"
+
+// systemNSSyncExemptions is the list of namespaces deployed by an OpenShift install
+// payload, as retrieved by listing the namespaces after a successful installation
+// IMPORTANT: The Namespace openshift-operators must be an exception to this rule
+// since it is used by OCP/OLM users to install their Operator bundle solutions.
+var systemNSSyncExemptions = sets.NewString(
+	// kube-specific system namespaces
+	"default",
+	"kube-node-lease",
+	"kube-public",
+	"kube-system",
+
+	// openshift payload namespaces
+	"openshift",
+	"openshift-apiserver",
+	"openshift-apiserver-operator",
+	"openshift-authentication",
+	"openshift-authentication-operator",
+	"openshift-cloud-controller-manager",
+	"openshift-cloud-controller-manager-operator",
+	"openshift-cloud-credential-operator",
+	"openshift-cloud-network-config-controller",
+	"openshift-cluster-csi-drivers",
+	"openshift-cluster-machine-approver",
+	"openshift-cluster-node-tuning-operator",
+	"openshift-cluster-samples-operator",
+	"openshift-cluster-storage-operator",
+	"openshift-cluster-version",
+	"openshift-config",
+	"openshift-config-managed",
+	"openshift-config-operator",
+	"openshift-console",
+	"openshift-console-operator",
+	"openshift-console-user-settings",
+	"openshift-controller-manager",
+	"openshift-controller-manager-operator",
+	"openshift-dns",
+	"openshift-dns-operator",
+	"openshift-etcd",
+	"openshift-etcd-operator",
+	"openshift-host-network",
+	"openshift-image-registry",
+	"openshift-infra",
+	"openshift-ingress",
+	"openshift-ingress-canary",
+	"openshift-ingress-operator",
+	"openshift-insights",
+	"openshift-kni-infra",
+	"openshift-kube-apiserver",
+	"openshift-kube-apiserver-operator",
+	"openshift-kube-controller-manager",
+	"openshift-kube-controller-manager-operator",
+	"openshift-kube-scheduler",
+	"openshift-kube-scheduler-operator",
+	"openshift-kube-storage-version-migrator",
+	"openshift-kube-storage-version-migrator-operator",
+	"openshift-machine-api",
+	"openshift-machine-config-operator",
+	"openshift-marketplace",
+	"openshift-monitoring",
+	"openshift-multus",
+	"openshift-network-diagnostics",
+	"openshift-network-operator",
+	"openshift-node",
+	"openshift-nutanix-infra",
+	"openshift-oauth-apiserver",
+	"openshift-openstack-infra",
+	"openshift-operator-lifecycle-manager",
+	"openshift-ovirt-infra",
+	"openshift-sdn",
+	"openshift-service-ca",
+	"openshift-service-ca-operator",
+	"openshift-user-workload-monitoring",
+	"openshift-vsphere-infra",
+)
+
+// IsNamespacePSALabelSyncExemptedInVendoredOCPVersion returns true if the given namespace should be exempted from
+// PSA label sync'ing. NOTE: the exemption list is OCP version dependent. Ensure that your vendored
+// version of 'cluster-policy-controller' is for the same OCP version as your project.
+func IsNamespacePSALabelSyncExemptedInVendoredOCPVersion(namespace string) bool {
+	return systemNSSyncExemptions.Has(namespace)
+}

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/config.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/config.go
@@ -37,6 +37,26 @@ type operatorConfig struct {
 	configClient                 configv1client.Interface
 }
 
+func (o *operatorConfig) OperatorClient() operatorclient.ClientInterface {
+	return o.operatorClient
+}
+
+func (o *operatorConfig) ExternalClient() versioned.Interface {
+	return o.externalClient
+}
+
+func (o *operatorConfig) ResyncPeriod() func() time.Duration {
+	return o.resyncPeriod
+}
+
+func (o *operatorConfig) WatchedNamespaces() []string {
+	return o.watchedNamespaces
+}
+
+func (o *operatorConfig) Logger() *logrus.Logger {
+	return o.logger
+}
+
 func (o *operatorConfig) apply(options []OperatorOption) {
 	for _, option := range options {
 		option(o)

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/downstream_plugins.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/downstream_plugins.go
@@ -1,0 +1,13 @@
+package olm
+
+import (
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/plugins"
+)
+
+func init() {
+	operatorPlugInFactoryFuncs = []plugins.OperatorPlugInFactoryFunc{
+		// labels unlabeled non-payload openshift-* csv namespaces with
+		// security.openshift.io/scc.podSecurityLabelSync: true
+		plugins.NewCsvNamespaceLabelerPluginFunc,
+	}
+}

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/plugins/downstream_csv_namespace_labeler_plugin.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/plugins/downstream_csv_namespace_labeler_plugin.go
@@ -1,0 +1,368 @@
+package plugins
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/openshift/cluster-policy-controller/pkg/psalabelsyncer/nsexemptions"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	listerv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubestate"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	listerv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+const NamespaceLabelSyncerLabelKey = "security.openshift.io/scc.podSecurityLabelSync"
+const openshiftPrefix = "openshift-"
+
+const noCopiedCsvSelector = "!" + v1alpha1.CopiedLabelKey
+
+// csvNamespaceLabelerPlugin is responsible for labeling non-payload openshift-* namespaces
+// with the label "security.openshift.io/scc.podSecurityLabelSync=true" so that the  PSA Label Syncer
+// see https://github.com/openshift/cluster-policy-controller/blob/master/pkg/psalabelsyncer/podsecurity_label_sync_controller.go
+// can help ensure that the operator payloads in the namespace continue to work even if they don't yet respect the
+// upstream Pod Security Admission controller, which will become active in k8s 1.25.
+// see https://kubernetes.io/docs/concepts/security/pod-security-admission/
+// If a CSV is created or modified, this controller will look at the csv's namespace. If it is a non-payload namespace,
+// if the namespace name is prefixed with 'openshift-', and if the namespace does not contain the label (whatever
+// value it may be set to), it will add the "security.openshift.io/scc.podSecurityLabelSync=true" to the namespace.
+type csvNamespaceLabelerPlugin struct {
+	namespaceLister       listerv1.NamespaceLister
+	nonCopiedCsvListerMap map[string]listerv1alpha1.ClusterServiceVersionLister
+	kubeClient            operatorclient.ClientInterface
+	externalClient        versioned.Interface
+	logger                *logrus.Logger
+}
+
+func NewCsvNamespaceLabelerPluginFunc(ctx context.Context, config OperatorConfig, hostOperator HostOperator) (OperatorPlugin, error) {
+
+	if hostOperator == nil {
+		return nil, fmt.Errorf("cannot initialize plugin: operator undefined")
+	}
+
+	plugin := &csvNamespaceLabelerPlugin{
+		kubeClient:            config.OperatorClient(),
+		externalClient:        config.ExternalClient(),
+		logger:                config.Logger(),
+		namespaceLister:       nil,
+		nonCopiedCsvListerMap: map[string]listerv1alpha1.ClusterServiceVersionLister{},
+	}
+
+	plugin.log("setting up csv namespace plug-in for namespaces: %s", config.WatchedNamespaces())
+
+	namespaceInformer := newNamespaceInformer(config.OperatorClient(), config.ResyncPeriod()())
+
+	plugin.log("registering namespace informer")
+
+	plugin.namespaceLister = listerv1.NewNamespaceLister(namespaceInformer.GetIndexer())
+
+	namespaceQueue := workqueue.NewNamedRateLimitingQueue(
+		workqueue.DefaultControllerRateLimiter(),
+		"csv-ns-labeler-plugin-ns-queue",
+	)
+	namespaceQueueInformer, err := queueinformer.NewQueueInformer(
+		ctx,
+		queueinformer.WithInformer(namespaceInformer),
+		queueinformer.WithLogger(config.Logger()),
+		queueinformer.WithQueue(namespaceQueue),
+		queueinformer.WithIndexer(namespaceInformer.GetIndexer()),
+		queueinformer.WithSyncer(plugin),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := hostOperator.RegisterQueueInformer(namespaceQueueInformer); err != nil {
+		return nil, err
+	}
+
+	for _, namespace := range config.WatchedNamespaces() {
+		plugin.log("setting up namespace: %s", namespace)
+		// ignore namespaces that are *NOT* prefixed with openshift- but accept metav1.NamespaceAll
+		if !(hasOpenshiftPrefix(namespace)) && namespace != metav1.NamespaceAll {
+			continue
+		}
+
+		nonCopiedCsvInformer := newNonCopiedCsvInformerForNamespace(namespace, config.ExternalClient(), config.ResyncPeriod()())
+
+		nonCopiedCsvQueue := workqueue.NewNamedRateLimitingQueue(
+			workqueue.DefaultControllerRateLimiter(),
+			fmt.Sprintf("%s/csv-ns-labeler-plugin-csv-queue", namespace),
+		)
+		nonCopiedCsvQueueInformer, err := queueinformer.NewQueueInformer(
+			ctx,
+			queueinformer.WithInformer(nonCopiedCsvInformer),
+			queueinformer.WithLogger(config.Logger()),
+			queueinformer.WithQueue(nonCopiedCsvQueue),
+			queueinformer.WithIndexer(nonCopiedCsvInformer.GetIndexer()),
+			queueinformer.WithSyncer(plugin),
+		)
+		if err != nil {
+			return nil, err
+		}
+		if err := hostOperator.RegisterQueueInformer(nonCopiedCsvQueueInformer); err != nil {
+			return nil, err
+		}
+		plugin.nonCopiedCsvListerMap[namespace] = listerv1alpha1.NewClusterServiceVersionLister(nonCopiedCsvInformer.GetIndexer())
+		plugin.log("registered csv queue informer for: %s", namespace)
+	}
+	plugin.log("finished setting up csv namespace labeler plugin")
+
+	return plugin, nil
+}
+
+func (p *csvNamespaceLabelerPlugin) Shutdown() error {
+	return nil
+}
+
+func (p *csvNamespaceLabelerPlugin) Sync(ctx context.Context, event kubestate.ResourceEvent) error {
+	// only act on csv added and updated events
+	if event.Type() != kubestate.ResourceAdded && event.Type() != kubestate.ResourceUpdated {
+		return nil
+	}
+
+	var namespace *v1.Namespace
+	var err error
+
+	// get namespace from the event resource
+	switch eventResource := event.Resource().(type) {
+
+	// handle csv events
+	case *v1alpha1.ClusterServiceVersion:
+		// ignore copied csvs and namespaces that should be ignored
+		if eventResource.IsCopied() || ignoreNamespace(eventResource.GetNamespace()) {
+			return nil
+		}
+
+		namespace, err = p.getNamespace(eventResource.GetNamespace())
+		if err != nil {
+			return fmt.Errorf("error getting csv namespace (%s) for label sync'er labeling", eventResource.GetNamespace())
+		}
+
+	// handle namespace events
+	case *v1.Namespace:
+		// ignore namespaces that should be ignored and ones that are already labeled
+		if ignoreNamespace(eventResource.GetName()) || hasLabelSyncerLabel(eventResource) {
+			return nil
+		}
+
+		// get csv count for namespace
+		csvCount, err := p.countClusterServiceVersions(eventResource.GetName())
+		if err != nil {
+			return fmt.Errorf("error counting csvs in namespace=%s: %s", eventResource.GetName(), err)
+		}
+
+		// ignore namespaces with no csvs
+		if csvCount <= 0 {
+			return nil
+		}
+
+		namespace = eventResource
+	default:
+		return fmt.Errorf("event resource is neither a ClusterServiceVersion or a Namespace")
+	}
+
+	// add label sync'er label if it does not exist
+	if !(hasLabelSyncerLabel(namespace)) {
+		if err := applyLabelSyncerLabel(ctx, p.kubeClient, namespace); err != nil {
+			return fmt.Errorf("error updating csv namespace (%s) with label sync'er label", namespace.GetNamespace())
+		}
+		p.log("applied %s=true label to namespace %s", NamespaceLabelSyncerLabelKey, namespace.GetNamespace())
+	}
+
+	return nil
+}
+
+func (p *csvNamespaceLabelerPlugin) getNamespace(namespace string) (*v1.Namespace, error) {
+	ns, err := p.namespaceLister.Get(namespace)
+	if err != nil {
+		return nil, err
+	}
+	return ns, nil
+}
+
+func (p *csvNamespaceLabelerPlugin) countClusterServiceVersions(namespace string) (int, error) {
+	lister, ok := p.nonCopiedCsvListerMap[namespace]
+	if !ok {
+		lister, ok = p.nonCopiedCsvListerMap[metav1.NamespaceAll]
+		if !ok {
+			return 0, fmt.Errorf("no csv indexer found for namespace: %s", namespace)
+		}
+	}
+	labelSelector, err := labels.Parse(noCopiedCsvSelector)
+	if err != nil {
+		return 0, err
+	}
+
+	csvList, err := lister.ClusterServiceVersions(namespace).List(labelSelector)
+	if err != nil {
+		return 0, err
+	}
+	return len(csvList), nil
+}
+
+func (p *csvNamespaceLabelerPlugin) log(format string, args ...interface{}) {
+	if p.logger != nil {
+		p.logger.Infof("[CSV NS Plug-in] "+format, args...)
+	}
+}
+
+// newNamespaceInformer creates a namespace informer that filters namespaces the plug-in is not interested in:
+// payload namespaces (except openshift-operators) and non openshift- prefixed namespaces
+// the informer also prunes the namespace objects to only keep basic type and object metadata and annotations
+func newNamespaceInformer(k8sClient operatorclient.ClientInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	// create a namespace informer
+	pruneNamespace := func(namespace *v1.Namespace) {
+		namespace = &v1.Namespace{
+			TypeMeta: namespace.TypeMeta,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        namespace.GetName(),
+				Namespace:   namespace.GetNamespace(),
+				Annotations: namespace.GetAnnotations(),
+			},
+		}
+	}
+
+	return cache.NewSharedIndexInformer(
+		&cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				list, err := k8sClient.KubernetesInterface().CoreV1().Namespaces().List(context.Background(), options)
+				if err != nil {
+					return list, err
+				}
+
+				// filter and prune namespaces
+				var filteredList []v1.Namespace
+				for i := range list.Items {
+					ns := list.Items[i]
+					if !(ignoreNamespace(ns.GetName())) {
+						pruneNamespace(&ns)
+						filteredList = append(filteredList, ns)
+					}
+				}
+				return &v1.NamespaceList{
+					Items: filteredList,
+				}, nil
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				nsWatch, err := k8sClient.KubernetesInterface().CoreV1().Namespaces().Watch(context.Background(), options)
+				if err != nil {
+					return nsWatch, err
+				}
+				return watch.Filter(nsWatch, func(e watch.Event) (watch.Event, bool) {
+					if ns, ok := e.Object.(*v1.Namespace); ok {
+						if !(ignoreNamespace(ns.GetName())) {
+							pruneNamespace(ns)
+							return e, true
+						}
+					}
+					return e, false
+				}), nil
+			},
+		},
+		&v1.Namespace{},
+		resyncPeriod,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+	)
+}
+
+// newNonCopiedCsvInformerForNamespace creates a csv-based informer that filters out copied csvs and csv events coming
+// from namespaces the plug-in is not interested in: payload namespaces (except openshift-operators) and
+// non openshift- prefixed namespaces
+// the informer also prunes the csvs to only keep basic type and object metadata and annotations
+func newNonCopiedCsvInformerForNamespace(namespace string, externalClient versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	// create a new csv informer and prune status to reduce memory footprint
+	pruneCSV := func(csv *v1alpha1.ClusterServiceVersion) {
+		csv = &v1alpha1.ClusterServiceVersion{
+			TypeMeta: csv.TypeMeta,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        csv.GetName(),
+				Namespace:   csv.GetNamespace(),
+				Annotations: csv.GetAnnotations(),
+			},
+		}
+	}
+
+	return cache.NewSharedIndexInformer(
+		&cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				options.LabelSelector = noCopiedCsvSelector
+				list, err := externalClient.OperatorsV1alpha1().ClusterServiceVersions(namespace).List(context.Background(), options)
+				if err != nil {
+					return list, err
+				}
+
+				// filter and prune csvs
+				var filteredList []v1alpha1.ClusterServiceVersion
+				for i := range list.Items {
+					csv := list.Items[i]
+					if !(ignoreNamespace(csv.GetNamespace())) {
+						pruneCSV(&csv)
+						filteredList = append(filteredList, csv)
+					}
+				}
+				return &v1alpha1.ClusterServiceVersionList{
+					Items: filteredList,
+				}, nil
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				options.LabelSelector = noCopiedCsvSelector
+				csvWatch, err := externalClient.OperatorsV1alpha1().ClusterServiceVersions(namespace).Watch(context.Background(), options)
+				if err != nil {
+					return csvWatch, err
+				}
+				return watch.Filter(csvWatch, func(e watch.Event) (watch.Event, bool) {
+					if csv, ok := e.Object.(*v1alpha1.ClusterServiceVersion); ok {
+						if !(ignoreNamespace(csv.GetNamespace())) && !csv.IsCopied() {
+							pruneCSV(csv)
+							return e, true
+						}
+					}
+					return e, false
+				}), nil
+			},
+		},
+		&v1alpha1.ClusterServiceVersion{},
+		resyncPeriod,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+	)
+}
+
+func hasOpenshiftPrefix(namespaceName string) bool {
+	return strings.HasPrefix(namespaceName, openshiftPrefix)
+}
+
+func ignoreNamespace(namespace string) bool {
+	// ignore non-openshift-* and payload openshift-* namespaces
+	return !hasOpenshiftPrefix(namespace) || nsexemptions.IsNamespacePSALabelSyncExemptedInVendoredOCPVersion(namespace)
+}
+
+func applyLabelSyncerLabel(ctx context.Context, kubeClient operatorclient.ClientInterface, namespace *v1.Namespace) error {
+	if _, ok := namespace.GetLabels()[NamespaceLabelSyncerLabelKey]; !ok {
+		nsCopy := namespace.DeepCopy()
+		if nsCopy.GetLabels() == nil {
+			nsCopy.SetLabels(map[string]string{})
+		}
+		nsCopy.GetLabels()[NamespaceLabelSyncerLabelKey] = "true"
+		if _, err := kubeClient.KubernetesInterface().CoreV1().Namespaces().Update(ctx, nsCopy, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func hasLabelSyncerLabel(namespace *v1.Namespace) bool {
+	_, ok := namespace.GetLabels()[NamespaceLabelSyncerLabelKey]
+	return ok
+}

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/plugins/operator_plugin.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/plugins/operator_plugin.go
@@ -1,0 +1,37 @@
+package plugins
+
+import (
+	"context"
+	"time"
+
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
+	"github.com/sirupsen/logrus"
+)
+
+// HostOperator is an extensible and observable operator that hosts the plug-in, i.e. which the plug-in is extending
+type HostOperator interface {
+	queueinformer.ObservableOperator
+	queueinformer.ExtensibleOperator
+}
+
+// OperatorConfig gives access to required configuration from the host operator
+type OperatorConfig interface {
+	OperatorClient() operatorclient.ClientInterface
+	ExternalClient() versioned.Interface
+	ResyncPeriod() func() time.Duration
+	WatchedNamespaces() []string
+	Logger() *logrus.Logger
+}
+
+// OperatorPlugin provides a simple interface
+// that can be used to extend the olm operator's functionality
+type OperatorPlugin interface {
+	// Shutdown is called once the host operator is done
+	// to give the plug-in a change to clean up resources if necessary
+	Shutdown() error
+}
+
+// OperatorPlugInFactoryFunc factory function that returns a new instance of a plug-in
+type OperatorPlugInFactoryFunc func(ctx context.Context, config OperatorConfig, hostOperator HostOperator) (OperatorPlugin, error)

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer/queueinformer_operator.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer/queueinformer_operator.go
@@ -13,8 +13,19 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-// Operator describes a Reconciler that manages a set of QueueInformers.
-type Operator interface {
+// ExtensibleOperator describes a Reconciler that can be extended with additional informers and queue informers
+type ExtensibleOperator interface {
+	// RegisterQueueInformer registers the given QueueInformer with the Operator.
+	// This method returns an error if the Operator has already been started.
+	RegisterQueueInformer(queueInformer *QueueInformer) error
+
+	// RegisterInformer registers an informer with the Operator.
+	// This method returns an error if the Operator has already been started.
+	RegisterInformer(cache.SharedIndexInformer) error
+}
+
+// ObservableOperator describes a Reconciler whose state can be queried
+type ObservableOperator interface {
 	// Ready returns a channel that is closed when the Operator is ready to run.
 	Ready() <-chan struct{}
 
@@ -29,15 +40,12 @@ type Operator interface {
 
 	// HasSynced returns true if the Operator's Informers have synced, false otherwise.
 	HasSynced() bool
+}
 
-	// RegisterQueueInformer registers the given QueueInformer with the Operator.
-	// This method returns an error if the Operator has already been started.
-	RegisterQueueInformer(queueInformer *QueueInformer) error
-
-	// RegisterInformer registers an informer with the Operator.
-	// This method returns an error if the Operator has already been started.
-	RegisterInformer(cache.SharedIndexInformer) error
-
+// Operator describes a Reconciler that manages a set of QueueInformers.
+type Operator interface {
+	ObservableOperator
+	ExtensibleOperator
 	// RunInformers starts the Operator's underlying Informers.
 	RunInformers(ctx context.Context)
 

--- a/vendor/golang.org/x/oauth2/google/default.go
+++ b/vendor/golang.org/x/oauth2/google/default.go
@@ -94,20 +94,20 @@ func DefaultTokenSource(ctx context.Context, scope ...string) (oauth2.TokenSourc
 // It looks for credentials in the following places,
 // preferring the first location found:
 //
-//   1. A JSON file whose path is specified by the
-//      GOOGLE_APPLICATION_CREDENTIALS environment variable.
-//      For workload identity federation, refer to
-//      https://cloud.google.com/iam/docs/how-to#using-workload-identity-federation on
-//      how to generate the JSON configuration file for on-prem/non-Google cloud
-//      platforms.
-//   2. A JSON file in a location known to the gcloud command-line tool.
-//      On Windows, this is %APPDATA%/gcloud/application_default_credentials.json.
-//      On other systems, $HOME/.config/gcloud/application_default_credentials.json.
-//   3. On Google App Engine standard first generation runtimes (<= Go 1.9) it uses
-//      the appengine.AccessToken function.
-//   4. On Google Compute Engine, Google App Engine standard second generation runtimes
-//      (>= Go 1.11), and Google App Engine flexible environment, it fetches
-//      credentials from the metadata server.
+//  1. A JSON file whose path is specified by the
+//     GOOGLE_APPLICATION_CREDENTIALS environment variable.
+//     For workload identity federation, refer to
+//     https://cloud.google.com/iam/docs/how-to#using-workload-identity-federation on
+//     how to generate the JSON configuration file for on-prem/non-Google cloud
+//     platforms.
+//  2. A JSON file in a location known to the gcloud command-line tool.
+//     On Windows, this is %APPDATA%/gcloud/application_default_credentials.json.
+//     On other systems, $HOME/.config/gcloud/application_default_credentials.json.
+//  3. On Google App Engine standard first generation runtimes (<= Go 1.9) it uses
+//     the appengine.AccessToken function.
+//  4. On Google Compute Engine, Google App Engine standard second generation runtimes
+//     (>= Go 1.11), and Google App Engine flexible environment, it fetches
+//     credentials from the metadata server.
 func FindDefaultCredentialsWithParams(ctx context.Context, params CredentialsParams) (*Credentials, error) {
 	// Make defensive copy of the slices in params.
 	params = params.deepCopy()

--- a/vendor/golang.org/x/oauth2/google/doc.go
+++ b/vendor/golang.org/x/oauth2/google/doc.go
@@ -15,14 +15,14 @@
 // For more information on using workload identity federation, refer to
 // https://cloud.google.com/iam/docs/how-to#using-workload-identity-federation.
 //
-// OAuth2 Configs
+// # OAuth2 Configs
 //
 // Two functions in this package return golang.org/x/oauth2.Config values from Google credential
 // data. Google supports two JSON formats for OAuth2 credentials: one is handled by ConfigFromJSON,
 // the other by JWTConfigFromJSON. The returned Config can be used to obtain a TokenSource or
 // create an http.Client.
 //
-// Workload Identity Federation
+// # Workload Identity Federation
 //
 // Using workload identity federation, your application can access Google Cloud
 // resources from Amazon Web Services (AWS), Microsoft Azure or any identity
@@ -36,9 +36,9 @@
 // Follow the detailed instructions on how to configure Workload Identity Federation
 // in various platforms:
 //
-//   Amazon Web Services (AWS): https://cloud.google.com/iam/docs/access-resources-aws
-//   Microsoft Azure: https://cloud.google.com/iam/docs/access-resources-azure
-//   OIDC identity provider: https://cloud.google.com/iam/docs/access-resources-oidc
+//	Amazon Web Services (AWS): https://cloud.google.com/iam/docs/access-resources-aws
+//	Microsoft Azure: https://cloud.google.com/iam/docs/access-resources-azure
+//	OIDC identity provider: https://cloud.google.com/iam/docs/access-resources-oidc
 //
 // For OIDC providers, the library can retrieve OIDC tokens either from a
 // local file location (file-sourced credentials) or from a local server
@@ -51,8 +51,7 @@
 // return the OIDC token. The response can be in plain text or JSON.
 // Additional required request headers can also be specified.
 //
-//
-// Credentials
+// # Credentials
 //
 // The Credentials type represents Google credentials, including Application Default
 // Credentials.

--- a/vendor/golang.org/x/oauth2/google/internal/externalaccount/aws.go
+++ b/vendor/golang.org/x/oauth2/google/internal/externalaccount/aws.go
@@ -52,6 +52,13 @@ const (
 	// The AWS authorization header name for the security session token if available.
 	awsSecurityTokenHeader = "x-amz-security-token"
 
+	// The name of the header containing the session token for metadata endpoint calls
+	awsIMDSv2SessionTokenHeader = "X-aws-ec2-metadata-token"
+
+	awsIMDSv2SessionTtlHeader = "X-aws-ec2-metadata-token-ttl-seconds"
+
+	awsIMDSv2SessionTtl = "300"
+
 	// The AWS authorization header name for the auto-generated date.
 	awsDateHeader = "x-amz-date"
 
@@ -241,6 +248,7 @@ type awsCredentialSource struct {
 	RegionURL                   string
 	RegionalCredVerificationURL string
 	CredVerificationURL         string
+	IMDSv2SessionTokenURL       string
 	TargetResource              string
 	requestSigner               *awsRequestSigner
 	region                      string
@@ -268,12 +276,22 @@ func (cs awsCredentialSource) doRequest(req *http.Request) (*http.Response, erro
 
 func (cs awsCredentialSource) subjectToken() (string, error) {
 	if cs.requestSigner == nil {
-		awsSecurityCredentials, err := cs.getSecurityCredentials()
+		awsSessionToken, err := cs.getAWSSessionToken()
 		if err != nil {
 			return "", err
 		}
 
-		if cs.region, err = cs.getRegion(); err != nil {
+		headers := make(map[string]string)
+		if awsSessionToken != "" {
+			headers[awsIMDSv2SessionTokenHeader] = awsSessionToken
+		}
+
+		awsSecurityCredentials, err := cs.getSecurityCredentials(headers)
+		if err != nil {
+			return "", err
+		}
+
+		if cs.region, err = cs.getRegion(headers); err != nil {
 			return "", err
 		}
 
@@ -340,7 +358,37 @@ func (cs awsCredentialSource) subjectToken() (string, error) {
 	return url.QueryEscape(string(result)), nil
 }
 
-func (cs *awsCredentialSource) getRegion() (string, error) {
+func (cs *awsCredentialSource) getAWSSessionToken() (string, error) {
+	if cs.IMDSv2SessionTokenURL == "" {
+		return "", nil
+	}
+
+	req, err := http.NewRequest("PUT", cs.IMDSv2SessionTokenURL, nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Add(awsIMDSv2SessionTtlHeader, awsIMDSv2SessionTtl)
+
+	resp, err := cs.doRequest(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("oauth2/google: unable to retrieve AWS session token - %s", string(respBody))
+	}
+
+	return string(respBody), nil
+}
+
+func (cs *awsCredentialSource) getRegion(headers map[string]string) (string, error) {
 	if envAwsRegion := getenv("AWS_REGION"); envAwsRegion != "" {
 		return envAwsRegion, nil
 	}
@@ -355,6 +403,10 @@ func (cs *awsCredentialSource) getRegion() (string, error) {
 	req, err := http.NewRequest("GET", cs.RegionURL, nil)
 	if err != nil {
 		return "", err
+	}
+
+	for name, value := range headers {
+		req.Header.Add(name, value)
 	}
 
 	resp, err := cs.doRequest(req)
@@ -381,7 +433,7 @@ func (cs *awsCredentialSource) getRegion() (string, error) {
 	return string(respBody[:respBodyEnd]), nil
 }
 
-func (cs *awsCredentialSource) getSecurityCredentials() (result awsSecurityCredentials, err error) {
+func (cs *awsCredentialSource) getSecurityCredentials(headers map[string]string) (result awsSecurityCredentials, err error) {
 	if accessKeyID := getenv("AWS_ACCESS_KEY_ID"); accessKeyID != "" {
 		if secretAccessKey := getenv("AWS_SECRET_ACCESS_KEY"); secretAccessKey != "" {
 			return awsSecurityCredentials{
@@ -392,12 +444,12 @@ func (cs *awsCredentialSource) getSecurityCredentials() (result awsSecurityCrede
 		}
 	}
 
-	roleName, err := cs.getMetadataRoleName()
+	roleName, err := cs.getMetadataRoleName(headers)
 	if err != nil {
 		return
 	}
 
-	credentials, err := cs.getMetadataSecurityCredentials(roleName)
+	credentials, err := cs.getMetadataSecurityCredentials(roleName, headers)
 	if err != nil {
 		return
 	}
@@ -413,7 +465,7 @@ func (cs *awsCredentialSource) getSecurityCredentials() (result awsSecurityCrede
 	return credentials, nil
 }
 
-func (cs *awsCredentialSource) getMetadataSecurityCredentials(roleName string) (awsSecurityCredentials, error) {
+func (cs *awsCredentialSource) getMetadataSecurityCredentials(roleName string, headers map[string]string) (awsSecurityCredentials, error) {
 	var result awsSecurityCredentials
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/%s", cs.CredVerificationURL, roleName), nil)
@@ -421,6 +473,10 @@ func (cs *awsCredentialSource) getMetadataSecurityCredentials(roleName string) (
 		return result, err
 	}
 	req.Header.Add("Content-Type", "application/json")
+
+	for name, value := range headers {
+		req.Header.Add(name, value)
+	}
 
 	resp, err := cs.doRequest(req)
 	if err != nil {
@@ -441,7 +497,7 @@ func (cs *awsCredentialSource) getMetadataSecurityCredentials(roleName string) (
 	return result, err
 }
 
-func (cs *awsCredentialSource) getMetadataRoleName() (string, error) {
+func (cs *awsCredentialSource) getMetadataRoleName(headers map[string]string) (string, error) {
 	if cs.CredVerificationURL == "" {
 		return "", errors.New("oauth2/google: unable to determine the AWS metadata server security credentials endpoint")
 	}
@@ -449,6 +505,10 @@ func (cs *awsCredentialSource) getMetadataRoleName() (string, error) {
 	req, err := http.NewRequest("GET", cs.CredVerificationURL, nil)
 	if err != nil {
 		return "", err
+	}
+
+	for name, value := range headers {
+		req.Header.Add(name, value)
 	}
 
 	resp, err := cs.doRequest(req)

--- a/vendor/golang.org/x/oauth2/google/internal/externalaccount/basecredentials.go
+++ b/vendor/golang.org/x/oauth2/google/internal/externalaccount/basecredentials.go
@@ -175,6 +175,7 @@ type CredentialSource struct {
 	RegionURL                   string `json:"region_url"`
 	RegionalCredVerificationURL string `json:"regional_cred_verification_url"`
 	CredVerificationURL         string `json:"cred_verification_url"`
+	IMDSv2SessionTokenURL       string `json:"imdsv2_session_token_url"`
 	Format                      format `json:"format"`
 }
 
@@ -185,14 +186,20 @@ func (c *Config) parse(ctx context.Context) (baseCredentialSource, error) {
 			if awsVersion != 1 {
 				return nil, fmt.Errorf("oauth2/google: aws version '%d' is not supported in the current build", awsVersion)
 			}
-			return awsCredentialSource{
+
+			awsCredSource := awsCredentialSource{
 				EnvironmentID:               c.CredentialSource.EnvironmentID,
 				RegionURL:                   c.CredentialSource.RegionURL,
 				RegionalCredVerificationURL: c.CredentialSource.RegionalCredVerificationURL,
 				CredVerificationURL:         c.CredentialSource.URL,
 				TargetResource:              c.Audience,
 				ctx:                         ctx,
-			}, nil
+			}
+			if c.CredentialSource.IMDSv2SessionTokenURL != "" {
+				awsCredSource.IMDSv2SessionTokenURL = c.CredentialSource.IMDSv2SessionTokenURL
+			}
+
+			return awsCredSource, nil
 		}
 	} else if c.CredentialSource.File != "" {
 		return fileCredentialSource{File: c.CredentialSource.File, Format: c.CredentialSource.Format}, nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -633,6 +633,9 @@ github.com/openshift/client-go/config/informers/externalversions/config
 github.com/openshift/client-go/config/informers/externalversions/config/v1
 github.com/openshift/client-go/config/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/config/listers/config/v1
+# github.com/openshift/cluster-policy-controller v0.0.0-20220825134653-523e4104074f
+## explicit; go 1.18
+github.com/openshift/cluster-policy-controller/pkg/psalabelsyncer/nsexemptions
 # github.com/operator-framework/api v0.16.0 => ./staging/api
 ## explicit; go 1.18
 github.com/operator-framework/api/crds

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -689,6 +689,7 @@ github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operator
 github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm
 github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/overrides
 github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/overrides/inject
+github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/plugins
 github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/openshift
 github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry
 github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/grpc

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -620,10 +620,10 @@ github.com/opencontainers/go-digest
 ## explicit
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
-# github.com/openshift/api v0.0.0-20200331152225-585af27e34fd => github.com/openshift/api v0.0.0-20210517065120-b325f58df679
+# github.com/openshift/api v0.0.0-20220525145417-ee5b62754c68 => github.com/openshift/api v0.0.0-20210517065120-b325f58df679
 ## explicit; go 1.15
 github.com/openshift/api/config/v1
-# github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0 => github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0
+# github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a => github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0
 ## explicit; go 1.13
 github.com/openshift/client-go/config/clientset/versioned
 github.com/openshift/client-go/config/clientset/versioned/scheme
@@ -1069,7 +1069,7 @@ golang.org/x/net/internal/timeseries
 golang.org/x/net/proxy
 golang.org/x/net/trace
 golang.org/x/net/websocket
-# golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
+# golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
 ## explicit; go 1.11
 golang.org/x/oauth2
 golang.org/x/oauth2/authhandler


### PR DESCRIPTION
#### Description
This PR adds the downstream only csv namespace labeler olm controller plug-in. This plug-in adds an additional csv queue informer with a sync method that when a csv is updated/created labels the csv namespace with `security.openshift.io/scc.podSecurityLabelSync=true` if:
 - the namespace is not part of the payload, unless it is `openshift-operators`
 - the namespace is not already labelled with the label above (whether true or false)
 - the namespace name is prefixed with `openshift-`

The csv informer ignores copied csvs and prunes out the body of the csv (save for the metadata section) to be frugal on memory.

**NOTE**: because this is a downstream only change, it makes changes to the staging directory. Because of this the `verify` job will fail - as it checks that there are no staging directory changes outside of what is brought in from the upstream.