### PR TITLE
OCPBUGS-459: fix(grpc): Add startupProbe to check for grpc health readiness (#2791)

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
@@ -149,6 +149,15 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, saName strin
 						InitialDelaySeconds: livenessDelay,
 						TimeoutSeconds:      5,
 					},
+					StartupProbe: &v1.Probe{
+						Handler: v1.Handler{
+							Exec: &v1.ExecAction{
+								Command: []string{"grpc_health_probe", "-addr=:50051"},
+							},
+						},
+						FailureThreshold: 15,
+						PeriodSeconds:    10,
+					},
 					Resources: v1.ResourceRequirements{
 						Requests: v1.ResourceList{
 							v1.ResourceCPU:    resource.MustParse("10m"),

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
@@ -149,6 +149,15 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, saName strin
 						InitialDelaySeconds: livenessDelay,
 						TimeoutSeconds:      5,
 					},
+					StartupProbe: &v1.Probe{
+						Handler: v1.Handler{
+							Exec: &v1.ExecAction{
+								Command: []string{"grpc_health_probe", "-addr=:50051"},
+							},
+						},
+						FailureThreshold: 15,
+						PeriodSeconds:    10,
+					},
 					Resources: v1.ResourceRequirements{
 						Requests: v1.ResourceList{
 							v1.ResourceCPU:    resource.MustParse("10m"),


### PR DESCRIPTION
Currently, liveness and readiness probes may fail due to grpc is not
ready. Adding a startupProbe will ensure grpc is ready before
liveness and readiness probes are triggered.

Upstream-repository: operator-lifecycle-manager
Upstream-commit: 8987522f97ea3726b42ce6fe23ce5aa75efa83ba

Signed-off-by: Vu Dinh <vudinh@outlook.com>