### PR TITLE
OLM-2726, OCPBUGS-643: downstreaming `opm serve` changes from operator-registry

### DIFF
--- a/staging/operator-registry/alpha/action/generate_dockerfile.go
+++ b/staging/operator-registry/alpha/action/generate_dockerfile.go
@@ -45,10 +45,11 @@ FROM {{.BaseImage}}
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]
-CMD ["serve", "/configs"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
 
-# Copy declarative config root into image at /configs
+# Copy declarative config root into image at /configs and pre-populate serve cache
 ADD {{.IndexDir}} /configs
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
 
 # Set DC-specific label for the location of the DC root directory
 # in the image

--- a/staging/operator-registry/alpha/action/generate_dockerfile_test.go
+++ b/staging/operator-registry/alpha/action/generate_dockerfile_test.go
@@ -50,10 +50,11 @@ FROM foo
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]
-CMD ["serve", "/configs"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
 
-# Copy declarative config root into image at /configs
+# Copy declarative config root into image at /configs and pre-populate serve cache
 ADD bar /configs
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
 
 # Set DC-specific label for the location of the DC root directory
 # in the image
@@ -76,10 +77,11 @@ FROM foo
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]
-CMD ["serve", "/configs"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
 
-# Copy declarative config root into image at /configs
+# Copy declarative config root into image at /configs and pre-populate serve cache
 ADD bar /configs
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
 
 # Set DC-specific label for the location of the DC root directory
 # in the image

--- a/staging/operator-registry/cmd/opm/registry/serve.go
+++ b/staging/operator-registry/cmd/opm/registry/serve.go
@@ -115,7 +115,7 @@ func serveFunc(cmd *cobra.Command, _ []string) error {
 
 	lis, err := net.Listen("tcp", ":"+port)
 	if err != nil {
-		logger.Fatalf("failed to listen: %s", err)
+		return fmt.Errorf("failed to listen: %s", err)
 	}
 
 	timeout, err := cmd.Flags().GetString("timeout-seconds")

--- a/staging/operator-registry/cmd/opm/serve/serve.go
+++ b/staging/operator-registry/cmd/opm/serve/serve.go
@@ -80,7 +80,9 @@ will not be reflected in the served content.
 
 func (s *serve) run(ctx context.Context) error {
 	p := newProfilerInterface(s.pprofAddr, s.logger)
-	p.startEndpoint()
+	if err := p.startEndpoint(); err != nil {
+		return fmt.Errorf("could not start pprof endpoint: %v", err)
+	}
 	if err := p.startCpuProfileCache(); err != nil {
 		return fmt.Errorf("could not start CPU profile: %v", err)
 	}
@@ -115,7 +117,7 @@ func (s *serve) run(ctx context.Context) error {
 
 	lis, err := net.Listen("tcp", ":"+s.port)
 	if err != nil {
-		s.logger.Fatalf("failed to listen: %s", err)
+		return fmt.Errorf("failed to listen: %s", err)
 	}
 
 	grpcServer := grpc.NewServer()
@@ -129,7 +131,9 @@ func (s *serve) run(ctx context.Context) error {
 		return grpcServer.Serve(lis)
 	}, func() {
 		grpcServer.GracefulStop()
-		p.stopEndpoint(p.logger.Context)
+		if err := p.stopEndpoint(ctx); err != nil {
+			s.logger.Warnf("error shutting down pprof server: %v", err)
+		}
 	})
 
 }
@@ -147,7 +151,8 @@ type profilerInterface struct {
 	cacheReady bool
 	cacheLock  sync.RWMutex
 
-	logger *logrus.Entry
+	logger   *logrus.Entry
+	closeErr chan error
 }
 
 func newProfilerInterface(a string, log *logrus.Entry) *profilerInterface {
@@ -162,10 +167,10 @@ func (p *profilerInterface) isEnabled() bool {
 	return p.addr != ""
 }
 
-func (p *profilerInterface) startEndpoint() {
+func (p *profilerInterface) startEndpoint() error {
 	// short-circuit if not enabled
 	if !p.isEnabled() {
-		return
+		return nil
 	}
 
 	mux := http.NewServeMux()
@@ -181,14 +186,22 @@ func (p *profilerInterface) startEndpoint() {
 		Handler: mux,
 	}
 
-	// goroutine exits with main
-	go func() {
+	lis, err := net.Listen("tcp", p.addr)
+	if err != nil {
+		return err
+	}
 
-		p.logger.Info("starting pprof endpoint")
-		if err := p.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			p.logger.Fatal(err)
-		}
+	p.closeErr = make(chan error)
+	go func() {
+		p.closeErr <- func() error {
+			p.logger.Info("starting pprof endpoint")
+			if err := p.server.Serve(lis); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				return err
+			}
+			return nil
+		}()
 	}()
+	return nil
 }
 
 func (p *profilerInterface) startCpuProfileCache() error {
@@ -222,10 +235,14 @@ func (p *profilerInterface) httpHandler(w http.ResponseWriter, r *http.Request) 
 	w.Write(p.cache.Bytes())
 }
 
-func (p *profilerInterface) stopEndpoint(ctx context.Context) {
-	if err := p.server.Shutdown(ctx); err != nil {
-		p.logger.Fatal(err)
+func (p *profilerInterface) stopEndpoint(ctx context.Context) error {
+	if !p.isEnabled() {
+		return nil
 	}
+	if err := p.server.Shutdown(ctx); err != nil {
+		return err
+	}
+	return <-p.closeErr
 }
 
 func (p *profilerInterface) isCacheReady() bool {

--- a/staging/operator-registry/cmd/opm/serve/serve.go
+++ b/staging/operator-registry/cmd/opm/serve/serve.go
@@ -6,19 +6,17 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"os"
-	"sync"
-
 	"net/http"
 	endpoint "net/http/pprof"
+	"os"
 	"runtime/pprof"
+	"sync"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 
-	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/pkg/api"
 	health "github.com/operator-framework/operator-registry/pkg/api/grpc_health_v1"
 	"github.com/operator-framework/operator-registry/pkg/lib/dns"
@@ -30,6 +28,8 @@ import (
 
 type serve struct {
 	configDir string
+	cacheDir  string
+	cacheOnly bool
 
 	port           string
 	terminationLog string
@@ -75,6 +75,8 @@ will not be reflected in the served content.
 	cmd.Flags().StringVarP(&s.terminationLog, "termination-log", "t", "/dev/termination-log", "path to a container termination log file")
 	cmd.Flags().StringVarP(&s.port, "port", "p", "50051", "port number to serve on")
 	cmd.Flags().StringVar(&s.pprofAddr, "pprof-addr", "", "address of startup profiling endpoint (addr:port format)")
+	cmd.Flags().StringVar(&s.cacheDir, "cache-dir", "", "if set, sync and persist server cache directory")
+	cmd.Flags().BoolVar(&s.cacheOnly, "cache-only", false, "sync the serve cache and exit without serving")
 	return cmd
 }
 
@@ -100,19 +102,13 @@ func (s *serve) run(ctx context.Context) error {
 
 	s.logger = s.logger.WithFields(logrus.Fields{"configs": s.configDir, "port": s.port})
 
-	cfg, err := declcfg.LoadFS(os.DirFS(s.configDir))
-	if err != nil {
-		return fmt.Errorf("load declarative config directory: %v", err)
-	}
-
-	m, err := declcfg.ConvertToModel(*cfg)
-	if err != nil {
-		return fmt.Errorf("could not build index model from declarative config: %v", err)
-	}
-	store, err := registry.NewQuerier(m)
+	store, err := registry.NewQuerierFromFS(os.DirFS(s.configDir), s.cacheDir)
 	defer store.Close()
 	if err != nil {
 		return err
+	}
+	if s.cacheOnly {
+		return nil
 	}
 
 	lis, err := net.Listen("tcp", ":"+s.port)

--- a/staging/operator-registry/go.mod
+++ b/staging/operator-registry/go.mod
@@ -35,6 +35,7 @@ require (
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3
 	golang.org/x/net v0.0.0-20220407224826-aac1ed45d8e3
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad
 	google.golang.org/grpc v1.45.0
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v0.0.0-20200709232328-d8193ee9cc3e
 	google.golang.org/protobuf v1.28.0
@@ -148,7 +149,6 @@ require (
 	go.opentelemetry.io/proto/otlp v0.7.0 // indirect
 	golang.org/x/crypto v0.0.0-20220408190544-5352b0902921 // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
-	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect

--- a/staging/operator-registry/pkg/registry/query.go
+++ b/staging/operator-registry/pkg/registry/query.go
@@ -17,6 +17,11 @@ import (
 	"github.com/operator-framework/operator-registry/pkg/api"
 )
 
+const (
+	cachePermissionDir  = 0750
+	cachePermissionFile = 0640
+)
+
 type Querier struct {
 	*cache
 }
@@ -423,7 +428,7 @@ func newEphemeralCache() (*cache, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(filepath.Join(baseDir, "cache"), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Join(baseDir, "cache"), cachePermissionDir); err != nil {
 		return nil, err
 	}
 	return &cache{
@@ -434,7 +439,7 @@ func newEphemeralCache() (*cache, error) {
 }
 
 func newPersistentCache(baseDir string) (*cache, error) {
-	if err := os.MkdirAll(baseDir, 0700); err != nil {
+	if err := os.MkdirAll(baseDir, cachePermissionDir); err != nil {
 		return nil, err
 	}
 	qc := &cache{baseDir: baseDir, persist: true}
@@ -481,6 +486,10 @@ func (qc *cache) loadFromCache() error {
 }
 
 func (qc *cache) repopulateCache(model digestableModel) error {
+	// ensure that generated cache is available to all future users
+	oldUmask := umask(000)
+	defer umask(oldUmask)
+
 	m, err := model.GetModel()
 	if err != nil {
 		return err
@@ -494,7 +503,7 @@ func (qc *cache) repopulateCache(model digestableModel) error {
 			return err
 		}
 	}
-	if err := os.MkdirAll(filepath.Join(qc.baseDir, "cache"), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Join(qc.baseDir, "cache"), cachePermissionDir); err != nil {
 		return err
 	}
 
@@ -507,7 +516,7 @@ func (qc *cache) repopulateCache(model digestableModel) error {
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(qc.baseDir, "cache", "packages.json"), packageJson, 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(qc.baseDir, "cache", "packages.json"), packageJson, cachePermissionFile); err != nil {
 		return err
 	}
 
@@ -524,7 +533,7 @@ func (qc *cache) repopulateCache(model digestableModel) error {
 					return err
 				}
 				filename := filepath.Join(qc.baseDir, "cache", fmt.Sprintf("%s_%s_%s.json", p.Name, ch.Name, b.Name))
-				if err := os.WriteFile(filename, jsonBundle, 0666); err != nil {
+				if err := os.WriteFile(filename, jsonBundle, cachePermissionFile); err != nil {
 					return err
 				}
 				qc.apiBundles[apiBundleKey{p.Name, ch.Name, b.Name}] = filename
@@ -533,7 +542,7 @@ func (qc *cache) repopulateCache(model digestableModel) error {
 	}
 	computedHash, err := model.GetDigest()
 	if err == nil {
-		if err := os.WriteFile(filepath.Join(qc.baseDir, "digest"), []byte(computedHash), 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(qc.baseDir, "digest"), []byte(computedHash), cachePermissionFile); err != nil {
 			return err
 		}
 	} else if !errors.Is(err, errNonDigestable) {

--- a/staging/operator-registry/pkg/registry/syscall_unix.go
+++ b/staging/operator-registry/pkg/registry/syscall_unix.go
@@ -1,0 +1,8 @@
+//go:build !windows
+// +build !windows
+
+package registry
+
+import "golang.org/x/sys/unix"
+
+var umask = unix.Umask

--- a/staging/operator-registry/pkg/registry/syscall_windows.go
+++ b/staging/operator-registry/pkg/registry/syscall_windows.go
@@ -1,0 +1,6 @@
+//go:build windows
+// +build windows
+
+package registry
+
+var umask = func(i int) int { return 0 }

--- a/staging/operator-registry/pkg/registry/tar.go
+++ b/staging/operator-registry/pkg/registry/tar.go
@@ -1,0 +1,66 @@
+package registry
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"time"
+)
+
+// fsToTar writes the filesystem represented by fsys to w as a tar archive.
+// This function unsets user and group information in the tar archive so that readers
+// of archives produced by this function do not need to account for differences in
+// permissions between source and destination filesystems.
+func fsToTar(w io.Writer, fsys fs.FS) error {
+	tw := tar.NewWriter(w)
+	if err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return fmt.Errorf("get file info for %q: %v", path, err)
+		}
+
+		h, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return fmt.Errorf("build tar file info header for %q: %v", path, err)
+		}
+		h.Uid = 0
+		h.Gid = 0
+		h.Uname = ""
+		h.Gname = ""
+		h.AccessTime = time.Time{}
+		h.ChangeTime = time.Time{}
+		h.ModTime = time.Time{}
+		h.Name = path
+
+		if err := tw.WriteHeader(h); err != nil {
+			return fmt.Errorf("write tar header for %q: %v", path, err)
+		}
+		if d.IsDir() {
+			return nil
+		}
+		f, err := fsys.Open(path)
+		if err != nil {
+			return fmt.Errorf("open file %q: %v", path, err)
+		}
+		defer f.Close()
+		if _, err := io.Copy(tw, f); err != nil {
+			return fmt.Errorf("write tar data for %q: %v", path, err)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("write tar: %w", err)
+	}
+	if err := tw.Close(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/vendor/github.com/operator-framework/operator-registry/alpha/action/generate_dockerfile.go
+++ b/vendor/github.com/operator-framework/operator-registry/alpha/action/generate_dockerfile.go
@@ -45,10 +45,11 @@ FROM {{.BaseImage}}
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]
-CMD ["serve", "/configs"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
 
-# Copy declarative config root into image at /configs
+# Copy declarative config root into image at /configs and pre-populate serve cache
 ADD {{.IndexDir}} /configs
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
 
 # Set DC-specific label for the location of the DC root directory
 # in the image

--- a/vendor/github.com/operator-framework/operator-registry/cmd/opm/registry/serve.go
+++ b/vendor/github.com/operator-framework/operator-registry/cmd/opm/registry/serve.go
@@ -115,7 +115,7 @@ func serveFunc(cmd *cobra.Command, _ []string) error {
 
 	lis, err := net.Listen("tcp", ":"+port)
 	if err != nil {
-		logger.Fatalf("failed to listen: %s", err)
+		return fmt.Errorf("failed to listen: %s", err)
 	}
 
 	timeout, err := cmd.Flags().GetString("timeout-seconds")

--- a/vendor/github.com/operator-framework/operator-registry/cmd/opm/serve/serve.go
+++ b/vendor/github.com/operator-framework/operator-registry/cmd/opm/serve/serve.go
@@ -80,7 +80,9 @@ will not be reflected in the served content.
 
 func (s *serve) run(ctx context.Context) error {
 	p := newProfilerInterface(s.pprofAddr, s.logger)
-	p.startEndpoint()
+	if err := p.startEndpoint(); err != nil {
+		return fmt.Errorf("could not start pprof endpoint: %v", err)
+	}
 	if err := p.startCpuProfileCache(); err != nil {
 		return fmt.Errorf("could not start CPU profile: %v", err)
 	}
@@ -115,7 +117,7 @@ func (s *serve) run(ctx context.Context) error {
 
 	lis, err := net.Listen("tcp", ":"+s.port)
 	if err != nil {
-		s.logger.Fatalf("failed to listen: %s", err)
+		return fmt.Errorf("failed to listen: %s", err)
 	}
 
 	grpcServer := grpc.NewServer()
@@ -129,7 +131,9 @@ func (s *serve) run(ctx context.Context) error {
 		return grpcServer.Serve(lis)
 	}, func() {
 		grpcServer.GracefulStop()
-		p.stopEndpoint(p.logger.Context)
+		if err := p.stopEndpoint(ctx); err != nil {
+			s.logger.Warnf("error shutting down pprof server: %v", err)
+		}
 	})
 
 }
@@ -147,7 +151,8 @@ type profilerInterface struct {
 	cacheReady bool
 	cacheLock  sync.RWMutex
 
-	logger *logrus.Entry
+	logger   *logrus.Entry
+	closeErr chan error
 }
 
 func newProfilerInterface(a string, log *logrus.Entry) *profilerInterface {
@@ -162,10 +167,10 @@ func (p *profilerInterface) isEnabled() bool {
 	return p.addr != ""
 }
 
-func (p *profilerInterface) startEndpoint() {
+func (p *profilerInterface) startEndpoint() error {
 	// short-circuit if not enabled
 	if !p.isEnabled() {
-		return
+		return nil
 	}
 
 	mux := http.NewServeMux()
@@ -181,14 +186,22 @@ func (p *profilerInterface) startEndpoint() {
 		Handler: mux,
 	}
 
-	// goroutine exits with main
-	go func() {
+	lis, err := net.Listen("tcp", p.addr)
+	if err != nil {
+		return err
+	}
 
-		p.logger.Info("starting pprof endpoint")
-		if err := p.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			p.logger.Fatal(err)
-		}
+	p.closeErr = make(chan error)
+	go func() {
+		p.closeErr <- func() error {
+			p.logger.Info("starting pprof endpoint")
+			if err := p.server.Serve(lis); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				return err
+			}
+			return nil
+		}()
 	}()
+	return nil
 }
 
 func (p *profilerInterface) startCpuProfileCache() error {
@@ -222,10 +235,14 @@ func (p *profilerInterface) httpHandler(w http.ResponseWriter, r *http.Request) 
 	w.Write(p.cache.Bytes())
 }
 
-func (p *profilerInterface) stopEndpoint(ctx context.Context) {
-	if err := p.server.Shutdown(ctx); err != nil {
-		p.logger.Fatal(err)
+func (p *profilerInterface) stopEndpoint(ctx context.Context) error {
+	if !p.isEnabled() {
+		return nil
 	}
+	if err := p.server.Shutdown(ctx); err != nil {
+		return err
+	}
+	return <-p.closeErr
 }
 
 func (p *profilerInterface) isCacheReady() bool {

--- a/vendor/github.com/operator-framework/operator-registry/cmd/opm/serve/serve.go
+++ b/vendor/github.com/operator-framework/operator-registry/cmd/opm/serve/serve.go
@@ -6,19 +6,17 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"os"
-	"sync"
-
 	"net/http"
 	endpoint "net/http/pprof"
+	"os"
 	"runtime/pprof"
+	"sync"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 
-	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/pkg/api"
 	health "github.com/operator-framework/operator-registry/pkg/api/grpc_health_v1"
 	"github.com/operator-framework/operator-registry/pkg/lib/dns"
@@ -30,6 +28,8 @@ import (
 
 type serve struct {
 	configDir string
+	cacheDir  string
+	cacheOnly bool
 
 	port           string
 	terminationLog string
@@ -75,6 +75,8 @@ will not be reflected in the served content.
 	cmd.Flags().StringVarP(&s.terminationLog, "termination-log", "t", "/dev/termination-log", "path to a container termination log file")
 	cmd.Flags().StringVarP(&s.port, "port", "p", "50051", "port number to serve on")
 	cmd.Flags().StringVar(&s.pprofAddr, "pprof-addr", "", "address of startup profiling endpoint (addr:port format)")
+	cmd.Flags().StringVar(&s.cacheDir, "cache-dir", "", "if set, sync and persist server cache directory")
+	cmd.Flags().BoolVar(&s.cacheOnly, "cache-only", false, "sync the serve cache and exit without serving")
 	return cmd
 }
 
@@ -100,19 +102,13 @@ func (s *serve) run(ctx context.Context) error {
 
 	s.logger = s.logger.WithFields(logrus.Fields{"configs": s.configDir, "port": s.port})
 
-	cfg, err := declcfg.LoadFS(os.DirFS(s.configDir))
-	if err != nil {
-		return fmt.Errorf("load declarative config directory: %v", err)
-	}
-
-	m, err := declcfg.ConvertToModel(*cfg)
-	if err != nil {
-		return fmt.Errorf("could not build index model from declarative config: %v", err)
-	}
-	store, err := registry.NewQuerier(m)
+	store, err := registry.NewQuerierFromFS(os.DirFS(s.configDir), s.cacheDir)
 	defer store.Close()
 	if err != nil {
 		return err
+	}
+	if s.cacheOnly {
+		return nil
 	}
 
 	lis, err := net.Listen("tcp", ":"+s.port)

--- a/vendor/github.com/operator-framework/operator-registry/pkg/registry/query.go
+++ b/vendor/github.com/operator-framework/operator-registry/pkg/registry/query.go
@@ -17,6 +17,11 @@ import (
 	"github.com/operator-framework/operator-registry/pkg/api"
 )
 
+const (
+	cachePermissionDir  = 0750
+	cachePermissionFile = 0640
+)
+
 type Querier struct {
 	*cache
 }
@@ -423,7 +428,7 @@ func newEphemeralCache() (*cache, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(filepath.Join(baseDir, "cache"), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Join(baseDir, "cache"), cachePermissionDir); err != nil {
 		return nil, err
 	}
 	return &cache{
@@ -434,7 +439,7 @@ func newEphemeralCache() (*cache, error) {
 }
 
 func newPersistentCache(baseDir string) (*cache, error) {
-	if err := os.MkdirAll(baseDir, 0700); err != nil {
+	if err := os.MkdirAll(baseDir, cachePermissionDir); err != nil {
 		return nil, err
 	}
 	qc := &cache{baseDir: baseDir, persist: true}
@@ -481,6 +486,10 @@ func (qc *cache) loadFromCache() error {
 }
 
 func (qc *cache) repopulateCache(model digestableModel) error {
+	// ensure that generated cache is available to all future users
+	oldUmask := umask(000)
+	defer umask(oldUmask)
+
 	m, err := model.GetModel()
 	if err != nil {
 		return err
@@ -494,7 +503,7 @@ func (qc *cache) repopulateCache(model digestableModel) error {
 			return err
 		}
 	}
-	if err := os.MkdirAll(filepath.Join(qc.baseDir, "cache"), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Join(qc.baseDir, "cache"), cachePermissionDir); err != nil {
 		return err
 	}
 
@@ -507,7 +516,7 @@ func (qc *cache) repopulateCache(model digestableModel) error {
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(qc.baseDir, "cache", "packages.json"), packageJson, 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(qc.baseDir, "cache", "packages.json"), packageJson, cachePermissionFile); err != nil {
 		return err
 	}
 
@@ -524,7 +533,7 @@ func (qc *cache) repopulateCache(model digestableModel) error {
 					return err
 				}
 				filename := filepath.Join(qc.baseDir, "cache", fmt.Sprintf("%s_%s_%s.json", p.Name, ch.Name, b.Name))
-				if err := os.WriteFile(filename, jsonBundle, 0666); err != nil {
+				if err := os.WriteFile(filename, jsonBundle, cachePermissionFile); err != nil {
 					return err
 				}
 				qc.apiBundles[apiBundleKey{p.Name, ch.Name, b.Name}] = filename
@@ -533,7 +542,7 @@ func (qc *cache) repopulateCache(model digestableModel) error {
 	}
 	computedHash, err := model.GetDigest()
 	if err == nil {
-		if err := os.WriteFile(filepath.Join(qc.baseDir, "digest"), []byte(computedHash), 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(qc.baseDir, "digest"), []byte(computedHash), cachePermissionFile); err != nil {
 			return err
 		}
 	} else if !errors.Is(err, errNonDigestable) {

--- a/vendor/github.com/operator-framework/operator-registry/pkg/registry/syscall_unix.go
+++ b/vendor/github.com/operator-framework/operator-registry/pkg/registry/syscall_unix.go
@@ -1,0 +1,8 @@
+//go:build !windows
+// +build !windows
+
+package registry
+
+import "golang.org/x/sys/unix"
+
+var umask = unix.Umask

--- a/vendor/github.com/operator-framework/operator-registry/pkg/registry/syscall_windows.go
+++ b/vendor/github.com/operator-framework/operator-registry/pkg/registry/syscall_windows.go
@@ -1,0 +1,6 @@
+//go:build windows
+// +build windows
+
+package registry
+
+var umask = func(i int) int { return 0 }

--- a/vendor/github.com/operator-framework/operator-registry/pkg/registry/tar.go
+++ b/vendor/github.com/operator-framework/operator-registry/pkg/registry/tar.go
@@ -1,0 +1,66 @@
+package registry
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"time"
+)
+
+// fsToTar writes the filesystem represented by fsys to w as a tar archive.
+// This function unsets user and group information in the tar archive so that readers
+// of archives produced by this function do not need to account for differences in
+// permissions between source and destination filesystems.
+func fsToTar(w io.Writer, fsys fs.FS) error {
+	tw := tar.NewWriter(w)
+	if err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return fmt.Errorf("get file info for %q: %v", path, err)
+		}
+
+		h, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return fmt.Errorf("build tar file info header for %q: %v", path, err)
+		}
+		h.Uid = 0
+		h.Gid = 0
+		h.Uname = ""
+		h.Gname = ""
+		h.AccessTime = time.Time{}
+		h.ChangeTime = time.Time{}
+		h.ModTime = time.Time{}
+		h.Name = path
+
+		if err := tw.WriteHeader(h); err != nil {
+			return fmt.Errorf("write tar header for %q: %v", path, err)
+		}
+		if d.IsDir() {
+			return nil
+		}
+		f, err := fsys.Open(path)
+		if err != nil {
+			return fmt.Errorf("open file %q: %v", path, err)
+		}
+		defer f.Close()
+		if _, err := io.Copy(tw, f); err != nil {
+			return fmt.Errorf("write tar data for %q: %v", path, err)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("write tar: %w", err)
+	}
+	if err := tw.Close(); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
including two commits which seem to be of equal priority to pipeline:

- 215f413e do not fatally exit from serve commands (#1016)
- 494b68e6 opm serve: use pre-existing cache, if set and up-to-date (#1005)