### PR TITLE
OCPBUGS-858: Package Server Manager should enforce expected csv values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/openshift/operator-framework-olm
 go 1.18
 
 require (
+	github.com/blang/semver/v4 v4.0.0
 	github.com/go-bindata/go-bindata/v3 v3.1.3
 	github.com/go-logr/logr v1.2.2
 	github.com/golang/mock v1.6.0
@@ -72,7 +73,6 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5 // indirect
 	github.com/containerd/cgroups v1.0.3 // indirect

--- a/pkg/package-server-manager/config.go
+++ b/pkg/package-server-manager/config.go
@@ -11,6 +11,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
+
+	"github.com/openshift/operator-framework-olm/pkg/manifests"
 )
 
 func getReplicas(ha bool) int32 {
@@ -61,8 +63,61 @@ func getTopologyModeFromInfra(infra *configv1.Infrastructure) bool {
 }
 
 // ensureCSV is responsible for ensuring the state of the @csv ClusterServiceVersion custom
+// resource matches that of the codified defaults and high availability configurations, where
+// codified defaults are defined by the csv returned by the manifests.NewPackageServerCSV
+// function.
+func ensureCSV(log logr.Logger, image string, csv *olmv1alpha1.ClusterServiceVersion, highlyAvailableMode bool) (bool, error) {
+	expectedCSV, err := manifests.NewPackageServerCSV(
+		manifests.WithName(csv.Name),
+		manifests.WithNamespace(csv.Namespace),
+		manifests.WithImage(image),
+	)
+	if err != nil {
+		return false, err
+	}
+
+	ensureCSVHighAvailability(image, expectedCSV, highlyAvailableMode)
+
+	var modified bool
+
+	for k, v := range expectedCSV.GetLabels() {
+		if csv.GetLabels() == nil {
+			csv.SetLabels(make(map[string]string))
+		}
+		if vv, ok := csv.GetLabels()[k]; !ok || vv != v {
+			log.Info("setting expected label", "key", k, "value", v)
+			csv.ObjectMeta.Labels[k] = v
+			modified = true
+		}
+	}
+
+	for k, v := range expectedCSV.GetAnnotations() {
+		if csv.GetAnnotations() == nil {
+			csv.SetAnnotations(make(map[string]string))
+		}
+		if vv, ok := csv.GetAnnotations()[k]; !ok || vv != v {
+			log.Info("setting expected annotation", "key", k, "value", v)
+			csv.ObjectMeta.Annotations[k] = v
+			modified = true
+		}
+	}
+
+	if !reflect.DeepEqual(expectedCSV.Spec, csv.Spec) {
+		log.Info("updating csv spec")
+		csv.Spec = expectedCSV.Spec
+		modified = true
+	}
+
+	if modified {
+		log.V(3).Info("csv has been modified")
+	}
+
+	return modified, err
+}
+
+// ensureCSVHighAvailability is responsible for ensuring the state of the @csv ClusterServiceVersion custom
 // resource matches the expected state based on any high availability expectations being exposed.
-func ensureCSV(log logr.Logger, image string, csv *olmv1alpha1.ClusterServiceVersion, highlyAvailableMode bool) bool {
+func ensureCSVHighAvailability(image string, csv *olmv1alpha1.ClusterServiceVersion, highlyAvailableMode bool) {
 	var modified bool
 
 	deploymentSpecs := csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs
@@ -70,52 +125,29 @@ func ensureCSV(log logr.Logger, image string, csv *olmv1alpha1.ClusterServiceVer
 
 	currentImage := deployment.Template.Spec.Containers[0].Image
 	if currentImage != image {
-		log.Info("updating the image", "old", currentImage, "new", image)
 		deployment.Template.Spec.Containers[0].Image = image
 		modified = true
 	}
 
 	expectedReplicas := getReplicas(highlyAvailableMode)
 	if *deployment.Replicas != expectedReplicas {
-		log.Info("updating the replica count", "old", deployment.Replicas, "new", expectedReplicas)
 		deployment.Replicas = pointer.Int32Ptr(expectedReplicas)
 		modified = true
 	}
 
 	expectedRolloutConfiguration := getRolloutStrategy(highlyAvailableMode)
 	if !reflect.DeepEqual(deployment.Strategy.RollingUpdate, expectedRolloutConfiguration) {
-		log.Info("updating the rollout strategy")
 		deployment.Strategy.RollingUpdate = expectedRolloutConfiguration
 		modified = true
 	}
 
 	expectedAffinityConfiguration := getAntiAffinityConfig(highlyAvailableMode)
 	if !reflect.DeepEqual(deployment.Template.Spec.Affinity, expectedAffinityConfiguration) {
-		log.Info("updating the pod anti-affinity configuration")
 		deployment.Template.Spec.Affinity = expectedAffinityConfiguration
 		modified = true
 	}
 
 	if modified {
-		log.V(3).Info("csv has been modified")
 		csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[0].Spec = *deployment
 	}
-
-	return modified
-}
-
-func validateCSV(log logr.Logger, csv *olmv1alpha1.ClusterServiceVersion) bool {
-	deploymentSpecs := csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs
-	if len(deploymentSpecs) != 1 {
-		log.Info("csv contains more than one or zero nested deployment specs")
-		return false
-	}
-
-	deployment := &deploymentSpecs[0].Spec
-	if len(deployment.Template.Spec.Containers) != 1 {
-		log.Info("csv contains more than one container")
-		return false
-	}
-
-	return true
 }


### PR DESCRIPTION
**Problem:**
The package-server-manifest (PSM) is a downstream specific component responsible for reconciling the package-server csv, which is defined [here](https://github.com/openshift/operator-framework-olm/blob/fceaf8aba28fb5c9c8f636c49b0fe3119d7d348d/pkg/manifests/csv.yaml) as a yaml file. When the PSM reconciles the package-server csv, it:
- Attempts to generate the base of the expected CSV [here](https://github.com/openshift/operator-framework-olm/blob/fceaf8aba28fb5c9c8f636c49b0fe3119d7d348d/pkg/package-server-manager/controller.go#L76-L84)
- Passes the [reconcile function](https://github.com/openshift/operator-framework-olm/blob/fceaf8aba28fb5c9c8f636c49b0fe3119d7d348d/pkg/package-server-manager/controller.go#L97-L118) as the `mutateFn` parameter and the expectedCSV  as the `obj` parameter into into controller-runtime's [createOrUpdate function](https://github.com/openshift/operator-framework-olm/blob/fceaf8aba28fb5c9c8f636c49b0fe3119d7d348d/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllerutil/controllerutil.go#L195-L223). Controller runtime's `createOrUpdate function` will apply the `mutateFn` function against:
- The `obj` you passed in if it does not already exist.
OR
- The existing on cluster object.

In the case where the `mutateFn` is applied to the applied to the existing object, changes made to the [package-server csv yaml](https://github.com/openshift/operator-framework-olm/blob/fceaf8aba28fb5c9c8f636c49b0fe3119d7d348d/pkg/manifests/csv.yaml) are ignored because the `mutateFn` (ie the `reconcileCSV` function) doesn't consider changes to the manifest.

**Solution:**
Update the `reconcileCSV` function to:
- Ensure that expected annotations and labels are present on the csv.
- Ensure that the expected spec is present on the csv.


