### PR TITLE
[release-4.10] OCPBUGS-1525: Package Server Manager should enforce expected csv values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/openshift/operator-framework-olm
 go 1.17
 
 require (
+	github.com/blang/semver/v4 v4.0.0
 	github.com/go-bindata/go-bindata/v3 v3.1.3
 	github.com/go-logr/logr v0.4.0
 	github.com/golang/mock v1.6.0
@@ -57,8 +58,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
-	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/containerd/cgroups v1.0.3 // indirect
 	github.com/containerd/containerd v1.5.13 // indirect
 	github.com/containerd/continuity v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -205,8 +205,9 @@ github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
-github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
+github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5/go.mod h1:/iP1qXHoty45bqomnu2LM+VVyAEdWN+vtSHGlQgyxbw=
 github.com/checkpoint-restore/go-criu/v4 v4.1.0/go.mod h1:xUQBLp4RLc5zJtWY++yjOoMoB5lihDt7fai+75m+rGw=
 github.com/checkpoint-restore/go-criu/v5 v5.0.0/go.mod h1:cfwC0EG7HMUenopBsUf9d89JlCLQIfgVcNsNN0t6T2M=

--- a/pkg/package-server-manager/config.go
+++ b/pkg/package-server-manager/config.go
@@ -11,6 +11,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
+
+	"github.com/openshift/operator-framework-olm/pkg/manifests"
 )
 
 func getReplicas(ha bool) int32 {
@@ -61,8 +63,61 @@ func getTopologyModeFromInfra(infra *configv1.Infrastructure) bool {
 }
 
 // ensureCSV is responsible for ensuring the state of the @csv ClusterServiceVersion custom
+// resource matches that of the codified defaults and high availability configurations, where
+// codified defaults are defined by the csv returned by the manifests.NewPackageServerCSV
+// function.
+func ensureCSV(log logr.Logger, image string, csv *olmv1alpha1.ClusterServiceVersion, highlyAvailableMode bool) (bool, error) {
+	expectedCSV, err := manifests.NewPackageServerCSV(
+		manifests.WithName(csv.Name),
+		manifests.WithNamespace(csv.Namespace),
+		manifests.WithImage(image),
+	)
+	if err != nil {
+		return false, err
+	}
+
+	ensureCSVHighAvailability(image, expectedCSV, highlyAvailableMode)
+
+	var modified bool
+
+	for k, v := range expectedCSV.GetLabels() {
+		if csv.GetLabels() == nil {
+			csv.SetLabels(make(map[string]string))
+		}
+		if vv, ok := csv.GetLabels()[k]; !ok || vv != v {
+			log.Info("setting expected label", "key", k, "value", v)
+			csv.ObjectMeta.Labels[k] = v
+			modified = true
+		}
+	}
+
+	for k, v := range expectedCSV.GetAnnotations() {
+		if csv.GetAnnotations() == nil {
+			csv.SetAnnotations(make(map[string]string))
+		}
+		if vv, ok := csv.GetAnnotations()[k]; !ok || vv != v {
+			log.Info("setting expected annotation", "key", k, "value", v)
+			csv.ObjectMeta.Annotations[k] = v
+			modified = true
+		}
+	}
+
+	if !reflect.DeepEqual(expectedCSV.Spec, csv.Spec) {
+		log.Info("updating csv spec")
+		csv.Spec = expectedCSV.Spec
+		modified = true
+	}
+
+	if modified {
+		log.V(3).Info("csv has been modified")
+	}
+
+	return modified, err
+}
+
+// ensureCSVHighAvailability is responsible for ensuring the state of the @csv ClusterServiceVersion custom
 // resource matches the expected state based on any high availability expectations being exposed.
-func ensureCSV(log logr.Logger, image string, csv *olmv1alpha1.ClusterServiceVersion, highlyAvailableMode bool) bool {
+func ensureCSVHighAvailability(image string, csv *olmv1alpha1.ClusterServiceVersion, highlyAvailableMode bool) {
 	var modified bool
 
 	deploymentSpecs := csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs
@@ -70,52 +125,29 @@ func ensureCSV(log logr.Logger, image string, csv *olmv1alpha1.ClusterServiceVer
 
 	currentImage := deployment.Template.Spec.Containers[0].Image
 	if currentImage != image {
-		log.Info("updating the image", "old", currentImage, "new", image)
 		deployment.Template.Spec.Containers[0].Image = image
 		modified = true
 	}
 
 	expectedReplicas := getReplicas(highlyAvailableMode)
 	if *deployment.Replicas != expectedReplicas {
-		log.Info("updating the replica count", "old", deployment.Replicas, "new", expectedReplicas)
 		deployment.Replicas = pointer.Int32Ptr(expectedReplicas)
 		modified = true
 	}
 
 	expectedRolloutConfiguration := getRolloutStrategy(highlyAvailableMode)
 	if !reflect.DeepEqual(deployment.Strategy.RollingUpdate, expectedRolloutConfiguration) {
-		log.Info("updating the rollout strategy")
 		deployment.Strategy.RollingUpdate = expectedRolloutConfiguration
 		modified = true
 	}
 
 	expectedAffinityConfiguration := getAntiAffinityConfig(highlyAvailableMode)
 	if !reflect.DeepEqual(deployment.Template.Spec.Affinity, expectedAffinityConfiguration) {
-		log.Info("updating the pod anti-affinity configuration")
 		deployment.Template.Spec.Affinity = expectedAffinityConfiguration
 		modified = true
 	}
 
 	if modified {
-		log.V(3).Info("csv has been modified")
 		csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[0].Spec = *deployment
 	}
-
-	return modified
-}
-
-func validateCSV(log logr.Logger, csv *olmv1alpha1.ClusterServiceVersion) bool {
-	deploymentSpecs := csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs
-	if len(deploymentSpecs) != 1 {
-		log.Info("csv contains more than one or zero nested deployment specs")
-		return false
-	}
-
-	deployment := &deploymentSpecs[0].Spec
-	if len(deployment.Template.Spec.Containers) != 1 {
-		log.Info("csv contains more than one container")
-		return false
-	}
-
-	return true
 }

--- a/vendor/github.com/cespare/xxhash/v2/.travis.yml
+++ b/vendor/github.com/cespare/xxhash/v2/.travis.yml
@@ -1,8 +1,0 @@
-language: go
-go:
-  - "1.x"
-  - master
-env:
-  - TAGS=""
-  - TAGS="-tags purego"
-script: go test $TAGS -v ./...

--- a/vendor/github.com/cespare/xxhash/v2/README.md
+++ b/vendor/github.com/cespare/xxhash/v2/README.md
@@ -1,7 +1,7 @@
 # xxhash
 
-[![GoDoc](https://godoc.org/github.com/cespare/xxhash?status.svg)](https://godoc.org/github.com/cespare/xxhash)
-[![Build Status](https://travis-ci.org/cespare/xxhash.svg?branch=master)](https://travis-ci.org/cespare/xxhash)
+[![Go Reference](https://pkg.go.dev/badge/github.com/cespare/xxhash/v2.svg)](https://pkg.go.dev/github.com/cespare/xxhash/v2)
+[![Test](https://github.com/cespare/xxhash/actions/workflows/test.yml/badge.svg)](https://github.com/cespare/xxhash/actions/workflows/test.yml)
 
 xxhash is a Go implementation of the 64-bit
 [xxHash](http://cyan4973.github.io/xxHash/) algorithm, XXH64. This is a
@@ -64,4 +64,6 @@ $ go test -benchtime 10s -bench '/xxhash,direct,bytes'
 
 - [InfluxDB](https://github.com/influxdata/influxdb)
 - [Prometheus](https://github.com/prometheus/prometheus)
+- [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics)
 - [FreeCache](https://github.com/coocood/freecache)
+- [FastCache](https://github.com/VictoriaMetrics/fastcache)

--- a/vendor/github.com/cespare/xxhash/v2/xxhash.go
+++ b/vendor/github.com/cespare/xxhash/v2/xxhash.go
@@ -193,7 +193,6 @@ func (d *Digest) UnmarshalBinary(b []byte) error {
 	b, d.v4 = consumeUint64(b)
 	b, d.total = consumeUint64(b)
 	copy(d.mem[:], b)
-	b = b[len(d.mem):]
 	d.n = int(d.total % uint64(len(d.mem)))
 	return nil
 }

--- a/vendor/github.com/cespare/xxhash/v2/xxhash_unsafe.go
+++ b/vendor/github.com/cespare/xxhash/v2/xxhash_unsafe.go
@@ -6,41 +6,52 @@
 package xxhash
 
 import (
-	"reflect"
 	"unsafe"
 )
 
-// Notes:
-//
-// See https://groups.google.com/d/msg/golang-nuts/dcjzJy-bSpw/tcZYBzQqAQAJ
-// for some discussion about these unsafe conversions.
-//
 // In the future it's possible that compiler optimizations will make these
-// unsafe operations unnecessary: https://golang.org/issue/2205.
+// XxxString functions unnecessary by realizing that calls such as
+// Sum64([]byte(s)) don't need to copy s. See https://golang.org/issue/2205.
+// If that happens, even if we keep these functions they can be replaced with
+// the trivial safe code.
+
+// NOTE: The usual way of doing an unsafe string-to-[]byte conversion is:
 //
-// Both of these wrapper functions still incur function call overhead since they
-// will not be inlined. We could write Go/asm copies of Sum64 and Digest.Write
-// for strings to squeeze out a bit more speed. Mid-stack inlining should
-// eventually fix this.
+//   var b []byte
+//   bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+//   bh.Data = (*reflect.StringHeader)(unsafe.Pointer(&s)).Data
+//   bh.Len = len(s)
+//   bh.Cap = len(s)
+//
+// Unfortunately, as of Go 1.15.3 the inliner's cost model assigns a high enough
+// weight to this sequence of expressions that any function that uses it will
+// not be inlined. Instead, the functions below use a different unsafe
+// conversion designed to minimize the inliner weight and allow both to be
+// inlined. There is also a test (TestInlining) which verifies that these are
+// inlined.
+//
+// See https://github.com/golang/go/issues/42739 for discussion.
 
 // Sum64String computes the 64-bit xxHash digest of s.
 // It may be faster than Sum64([]byte(s)) by avoiding a copy.
 func Sum64String(s string) uint64 {
-	var b []byte
-	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	bh.Data = (*reflect.StringHeader)(unsafe.Pointer(&s)).Data
-	bh.Len = len(s)
-	bh.Cap = len(s)
+	b := *(*[]byte)(unsafe.Pointer(&sliceHeader{s, len(s)}))
 	return Sum64(b)
 }
 
 // WriteString adds more data to d. It always returns len(s), nil.
 // It may be faster than Write([]byte(s)) by avoiding a copy.
 func (d *Digest) WriteString(s string) (n int, err error) {
-	var b []byte
-	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	bh.Data = (*reflect.StringHeader)(unsafe.Pointer(&s)).Data
-	bh.Len = len(s)
-	bh.Cap = len(s)
-	return d.Write(b)
+	d.Write(*(*[]byte)(unsafe.Pointer(&sliceHeader{s, len(s)})))
+	// d.Write always returns len(s), nil.
+	// Ignoring the return output and returning these fixed values buys a
+	// savings of 6 in the inliner's cost model.
+	return len(s), nil
+}
+
+// sliceHeader is similar to reflect.SliceHeader, but it assumes that the layout
+// of the first two words is the same as the layout of a string.
+type sliceHeader struct {
+	s   string
+	cap int
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -99,7 +99,7 @@ github.com/blang/semver
 # github.com/blang/semver/v4 v4.0.0
 ## explicit; go 1.14
 github.com/blang/semver/v4
-# github.com/cespare/xxhash/v2 v2.1.1
+# github.com/cespare/xxhash/v2 v2.1.2
 ## explicit; go 1.11
 github.com/cespare/xxhash/v2
 # github.com/containerd/cgroups v1.0.3


### PR DESCRIPTION
**Problem:**
The package-server-manifest (PSM) is a downstream specific component responsible for reconciling the package-server csv, which is defined in code as a yaml file. When the PSM reconciles the package-server csv, it:
- Attempts to generate the base of the expected CSV from the yaml mentioned above.
- Passes the reconcileCSV function as the mutateFn parameter and the expectedCSV  as the `obj` parameter into into controller-runtime's createOrUpdate function.

Controller runtime's createOrUpdate function will apply the mutateFn function against:
- The `obj` you passed in if it does not already exist. OR
- The existing on cluster object.

In the case where the mutateFn is applied to the applied to the existing object, changes made to the package-server csv yaml are ignored because the mutateFn (ie the reconcileCSV function) doesn't consider changes to the manifest.

**Solution:**
Update the reconcileCSV function to:
- Ensure that expected annotations and labels are present on the csv.
- Ensure that the expected spec is present on the csv.