### PR TITLE
[release-4.10] OCPBUGS-1323: Add autoscaling eviction annotation to catalog pods to enable proper draining of nodes

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
@@ -27,6 +27,8 @@ const (
 	CatalogPriorityClassKey string = "operatorframework.io/priorityclass"
 	// PodHashLabelKey is the key of a label for podspec hash information
 	PodHashLabelKey = "olm.pod-spec-hash"
+	//ClusterAutoscalingAnnotation is the annotation that enables the cluster autoscaler to evict catalog pods
+	ClusterAutoscalingAnnotationKey string = "cluster-autoscaler.kubernetes.io/safe-to-evict"
 )
 
 // RegistryEnsurer describes methods for ensuring a registry exists.
@@ -216,6 +218,15 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, saName strin
 	}
 	labels[PodHashLabelKey] = hashPodSpec(pod.Spec)
 	pod.SetLabels(labels)
+
+	// add eviction annotation to enable the cluster autoscaler to evict the pod in order to drain the node
+	// since catalog pods are not backed by a controller, they cannot be evicted by default
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[ClusterAutoscalingAnnotationKey] = "true"
+	pod.SetAnnotations(annotations)
+
 	return pod
 }
 

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
@@ -27,6 +27,8 @@ const (
 	CatalogPriorityClassKey string = "operatorframework.io/priorityclass"
 	// PodHashLabelKey is the key of a label for podspec hash information
 	PodHashLabelKey = "olm.pod-spec-hash"
+	//ClusterAutoscalingAnnotation is the annotation that enables the cluster autoscaler to evict catalog pods
+	ClusterAutoscalingAnnotationKey string = "cluster-autoscaler.kubernetes.io/safe-to-evict"
 )
 
 // RegistryEnsurer describes methods for ensuring a registry exists.
@@ -216,6 +218,15 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, saName strin
 	}
 	labels[PodHashLabelKey] = hashPodSpec(pod.Spec)
 	pod.SetLabels(labels)
+
+	// add eviction annotation to enable the cluster autoscaler to evict the pod in order to drain the node
+	// since catalog pods are not backed by a controller, they cannot be evicted by default
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[ClusterAutoscalingAnnotationKey] = "true"
+	pod.SetAnnotations(annotations)
+
 	return pod
 }
 


### PR DESCRIPTION
Signed-off-by: Daniel Sover <dsover@redhat.com>
Upstream-repository: operator-lifecycle-manager
Upstream-commit: dbd5b6f0d1dbc6981363c1345fa217629de97709