### PR TITLE
OCPBUGS-1088: Run collect-profile pod on management nodes

### DIFF
--- a/manifests/0000_50_olm_07-collect-profiles.cronjob.yaml
+++ b/manifests/0000_50_olm_07-collect-profiles.cronjob.yaml
@@ -12,6 +12,9 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
+            target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
         spec:
           securityContext:
             runAsNonRoot: true

--- a/scripts/generate_crds_manifests.sh
+++ b/scripts/generate_crds_manifests.sh
@@ -286,6 +286,9 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
+            target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
         spec:
           securityContext:
             runAsNonRoot: true


### PR DESCRIPTION
Problem:
The collect-profiles pod spec is missing the
"target.workload.openshift.io/management:" annotation. As a result when the workload partitioning feature is enabled on SNO, this pod resources will not get mutated and pinned to the reserved cpuset.

Solution:
Add the target.workload.openshift.io/management:" annotation to the collect-profiles pod.

Signed-off-by: Alexander Greene <greene.al1991@gmail.com>