### PR TITLE
OCPBUGS-1684: Set cpu limit on collect-profiles job

### DIFF
--- a/manifests/0000_50_olm_07-collect-profiles.cronjob.yaml
+++ b/manifests/0000_50_olm_07-collect-profiles.cronjob.yaml
@@ -47,6 +47,8 @@ spec:
                 requests:
                   cpu: 10m
                   memory: 80Mi
+                limits:
+                  cpu: 100m
           volumes:
             - name: config-volume
               configMap:

--- a/scripts/generate_crds_manifests.sh
+++ b/scripts/generate_crds_manifests.sh
@@ -321,6 +321,8 @@ spec:
               requests:
                 cpu: 10m
                 memory: 80Mi
+              limits:
+                cpu: 100m
           volumes:
           - name: config-volume
             configMap:


### PR DESCRIPTION
Problem:
There have been reports of high cpu utilization by the collect profiles pod on customer cluster.

Solution:
Set a cpu limit to prevent extreme cpu utilization.

Signed-off-by: Alexander Greene <greene.al1991@gmail.com>