### PR TITLE
Attempt workaround for https://issues.redhat.com/browse/CLOUDBLD-11068

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -278,6 +278,8 @@ replace (
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.20.0
 	go.opentelemetry.io/otel => go.opentelemetry.io/otel v0.20.0
 	go.opentelemetry.io/otel/sdk => go.opentelemetry.io/otel/sdk v0.20.0
+	// this should be removeable once https://issues.redhat.com/browse/CLOUDBLD-11068 is resolved
+	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.25.0
 
 	// pinned because no tag supports 1.18 yet
 	sigs.k8s.io/structured-merge-diff => sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2190,4 +2190,5 @@ sigs.k8s.io/yaml
 # go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.20.0
 # go.opentelemetry.io/otel => go.opentelemetry.io/otel v0.20.0
 # go.opentelemetry.io/otel/sdk => go.opentelemetry.io/otel/sdk v0.20.0
+# k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.25.0
 # sigs.k8s.io/structured-merge-diff => sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06


### PR DESCRIPTION
this is based on the fact that:

1) cluster-policy-controller is able to dep pod security admission and build ok:
https://github.com/openshift/cluster-policy-controller/blob/6dba7561af11e0a949bbeaa57958b195b98b8d0a/go.mod#L140

2) olm doesn't actually need pod security admission, it needs one file from cluster-policy-controller.  That seems to drag the transitive dep in during the brew build, but go mod vendor does not pull it in.  Which makes me think brew is resolving the dep differently and not resolving to the right thing.  Hoping the explicit replaces helps that.

that said, cluster-policy, since it actually deps psa, also has this:

https://github.com/openshift/cluster-policy-controller/blob/6dba7561af11e0a949bbeaa57958b195b98b8d0a/go.sum#L952-L953

which olm of course doesn't, because it doesn't actually need the dep.
