### PR TITLE
provide the capability to filter mermaid output to a single package name / skipRange support (#1023)

### DIFF
--- a/staging/operator-registry/alpha/declcfg/write_test.go
+++ b/staging/operator-registry/alpha/declcfg/write_test.go
@@ -472,16 +472,19 @@ func removeJSONWhitespace(cfg *DeclarativeConfig) {
 
 func TestWriteMermaidChannels(t *testing.T) {
 	type spec struct {
-		name     string
-		cfg      DeclarativeConfig
-		expected string
+		name          string
+		cfg           DeclarativeConfig
+		startEdge     string
+		packageFilter string
+		expected      string
 	}
 	specs := []spec{
 		{
-			name: "Success",
-			cfg:  buildValidDeclarativeConfig(true),
-			expected: `<!-- PLEASE NOTE:  skipRange edges are not currently displayed -->
-graph LR
+			name:          "SuccessNoFilters",
+			cfg:           buildValidDeclarativeConfig(true),
+			startEdge:     "",
+			packageFilter: "",
+			expected: `graph LR
   %% package "anakin"
   subgraph "anakin"
     %% channel "dark"
@@ -509,15 +512,52 @@ graph LR
       boba-fett-mando-boba-fett.v2.0.0["boba-fett.v2.0.0"]-- replaces --> boba-fett-mando-boba-fett.v1.0.0["boba-fett.v1.0.0"]
     end
   end
-<!-- PLEASE NOTE:  skipRange edges are not currently displayed -->
+`,
+		},
+		{
+			name:          "SuccessMinEdgeFilter",
+			cfg:           buildValidDeclarativeConfig(true),
+			startEdge:     "anakin.v0.1.0",
+			packageFilter: "",
+			expected: `graph LR
+  %% package "anakin"
+  subgraph "anakin"
+    %% channel "dark"
+    subgraph anakin-dark["dark"]
+      anakin-dark-anakin.v0.1.0["anakin.v0.1.0"]
+      anakin-dark-anakin.v0.1.1["anakin.v0.1.1"]
+      anakin-dark-anakin.v0.1.1["anakin.v0.1.1"]-- skips --> anakin-dark-anakin.v0.1.0["anakin.v0.1.0"]
+    end
+    %% channel "light"
+    subgraph anakin-light["light"]
+      anakin-light-anakin.v0.1.0["anakin.v0.1.0"]
+    end
+  end
+`,
+		},
+		{
+			name:          "SuccessPackageNameFilter",
+			cfg:           buildValidDeclarativeConfig(true),
+			startEdge:     "",
+			packageFilter: "boba-fett",
+			expected: `graph LR
+  %% package "boba-fett"
+  subgraph "boba-fett"
+    %% channel "mando"
+    subgraph boba-fett-mando["mando"]
+      boba-fett-mando-boba-fett.v1.0.0["boba-fett.v1.0.0"]
+      boba-fett-mando-boba-fett.v2.0.0["boba-fett.v2.0.0"]
+      boba-fett-mando-boba-fett.v2.0.0["boba-fett.v2.0.0"]-- replaces --> boba-fett-mando-boba-fett.v1.0.0["boba-fett.v1.0.0"]
+    end
+  end
 `,
 		},
 	}
-	startVersion := ""
 	for _, s := range specs {
 		t.Run(s.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			err := WriteMermaidChannels(s.cfg, &buf, startVersion)
+			writer := NewMermaidWriter(WithMinEdgeName(s.startEdge), WithSpecifiedPackageName(s.packageFilter))
+			err := writer.WriteChannels(s.cfg, &buf)
 			require.NoError(t, err)
 			require.Equal(t, s.expected, buf.String())
 		})

--- a/staging/operator-registry/cmd/opm/alpha/veneer/semver.go
+++ b/staging/operator-registry/cmd/opm/alpha/veneer/semver.go
@@ -43,8 +43,8 @@ When FILE is '-' or not provided, the veneer is read from standard input`,
 				write = declcfg.WriteYAML
 			case "mermaid":
 				write = func(cfg declcfg.DeclarativeConfig, writer io.Writer) error {
-					startVersion := ""
-					return declcfg.WriteMermaidChannels(cfg, writer, startVersion)
+					mermaidWriter := declcfg.NewMermaidWriter()
+					return mermaidWriter.WriteChannels(cfg, writer)
 				}
 			default:
 				return fmt.Errorf("invalid output format %q", output)

--- a/vendor/github.com/operator-framework/operator-registry/cmd/opm/alpha/veneer/semver.go
+++ b/vendor/github.com/operator-framework/operator-registry/cmd/opm/alpha/veneer/semver.go
@@ -43,8 +43,8 @@ When FILE is '-' or not provided, the veneer is read from standard input`,
 				write = declcfg.WriteYAML
 			case "mermaid":
 				write = func(cfg declcfg.DeclarativeConfig, writer io.Writer) error {
-					startVersion := ""
-					return declcfg.WriteMermaidChannels(cfg, writer, startVersion)
+					mermaidWriter := declcfg.NewMermaidWriter()
+					return mermaidWriter.WriteChannels(cfg, writer)
 				}
 			default:
 				return fmt.Errorf("invalid output format %q", output)


### PR DESCRIPTION
…

handle invalid SkipRange with output to stderr and ignoring the instance instead of dying determine package of min filter to weed out mismatches 
Upstream-repository: operator-registry
Upstream-commit: 0e53cafe2df4222611796ca252b23abac3b442aa

Signed-off-by: Jordan Keister <jordan@nimblewidget.com>