### PR TITLE
test/e2e: Preserve the existing environment when using exec.Command

### DIFF
--- a/staging/operator-lifecycle-manager/test/e2e/ctx/ctx.go
+++ b/staging/operator-lifecycle-manager/test/e2e/ctx/ctx.go
@@ -130,7 +130,7 @@ func (ctx TestContext) DumpNamespaceArtifacts(namespace string) error {
 	}
 
 	cmd := exec.Command(ctx.artifactsScriptPath)
-	cmd.Env = append(cmd.Env, envvars...)
+	cmd.Env = append(os.Environ(), envvars...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
Signed-off-by: timflannagan <timflannagan@gmail.com>

Upstream-commit: 91e5d90b3ea330c681656af7d0dc160ecb535876
Upstream-repository: operator-lifecycle-manager