### PR TITLE
OCPBUGS-3209: Stop corrupting resolver cache. (#2604)

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/resolver.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/resolver.go
@@ -149,6 +149,25 @@ func (r *SatResolver) SolveOperators(namespaces []string, csvs []*v1alpha1.Clust
 			errs = append(errs, err)
 			continue
 		}
+
+		// copy consumed fields to avoid directly mutating cache
+		op = &Operator{
+			name:         op.name,
+			replaces:     op.replaces,
+			providedAPIs: op.providedAPIs,
+			requiredAPIs: op.requiredAPIs,
+			version:      op.version,
+			sourceInfo: &OperatorSourceInfo{
+				Package:        op.sourceInfo.Package,
+				Channel:        op.sourceInfo.Channel,
+				StartingCSV:    op.sourceInfo.StartingCSV,
+				Catalog:        op.sourceInfo.Catalog,
+				DefaultChannel: op.sourceInfo.DefaultChannel,
+				Subscription:   op.sourceInfo.Subscription,
+			},
+			properties: op.properties,
+			skips:      op.skips,
+		}
 		if len(installableOperator.Replaces) > 0 {
 			op.replaces = installableOperator.Replaces
 		}

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/resolver.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/resolver.go
@@ -149,6 +149,25 @@ func (r *SatResolver) SolveOperators(namespaces []string, csvs []*v1alpha1.Clust
 			errs = append(errs, err)
 			continue
 		}
+
+		// copy consumed fields to avoid directly mutating cache
+		op = &Operator{
+			name:         op.name,
+			replaces:     op.replaces,
+			providedAPIs: op.providedAPIs,
+			requiredAPIs: op.requiredAPIs,
+			version:      op.version,
+			sourceInfo: &OperatorSourceInfo{
+				Package:        op.sourceInfo.Package,
+				Channel:        op.sourceInfo.Channel,
+				StartingCSV:    op.sourceInfo.StartingCSV,
+				Catalog:        op.sourceInfo.Catalog,
+				DefaultChannel: op.sourceInfo.DefaultChannel,
+				Subscription:   op.sourceInfo.Subscription,
+			},
+			properties: op.properties,
+			skips:      op.skips,
+		}
 		if len(installableOperator.Replaces) > 0 {
 			op.replaces = installableOperator.Replaces
 		}


### PR DESCRIPTION
It's important to note that the changes introduced in this PR differ from the upstream changes due to the size of the backport that would be required to introduce the package changes that were made in 4.10.

Signed-off-by: Ben Luddy <bluddy@redhat.com>
Upstream-repository: operator-lifecycle-manager
Upstream-commit: f42891859d429ee92da04869ecca56917afccaf2