### PR TITLE
Allow E2E to skip multiple tests (#2892)

### DIFF
--- a/staging/operator-lifecycle-manager/Makefile
+++ b/staging/operator-lifecycle-manager/Makefile
@@ -21,6 +21,7 @@ IMAGE_REPO := quay.io/operator-framework/olm
 IMAGE_TAG ?= "dev"
 SPECIFIC_UNIT_TEST := $(if $(TEST),-run $(TEST),)
 LOCAL_NAMESPACE := "olm"
+SPLIT_SKIP=$(shell ./scripts/split_skips_string.sh "$(SKIP)")
 export GO111MODULE=on
 YQ_INTERNAL := go run $(MOD_FLAGS) ./vendor/github.com/mikefarah/yq/v3/
 KUBEBUILDER_ASSETS := $(or $(or $(KUBEBUILDER_ASSETS),$(dir $(shell command -v kubebuilder))),/usr/local/kubebuilder/bin)
@@ -132,7 +133,9 @@ E2E_TEST_NUM_CHUNKS ?= 4
 ifneq (all,$(E2E_TEST_CHUNK))
 TEST := $(shell go run ./test/e2e/split/... -chunks $(E2E_TEST_NUM_CHUNKS) -print-chunk $(E2E_TEST_CHUNK) ./test/e2e)
 endif
-E2E_OPTS ?= $(if $(E2E_SEED),-seed '$(E2E_SEED)') $(if $(SKIP), -skip '$(SKIP)') $(if $(TEST),-focus '$(TEST)') $(if $(ARTIFACT_DIR), -output-dir $(ARTIFACT_DIR) -junit-report junit_e2e.xml) -flake-attempts $(E2E_FLAKE_ATTEMPTS) -nodes $(E2E_NODES) -timeout $(E2E_TIMEOUT) -v -randomize-suites -race -trace -progress
+
+
+E2E_OPTS ?= $(if $(E2E_SEED),-seed '$(E2E_SEED)') $(if $(SKIP), $(SPLIT_SKIP)) $(if $(TEST),-focus '$(TEST)') $(if $(ARTIFACT_DIR), -output-dir $(ARTIFACT_DIR) -junit-report junit_e2e.xml) -flake-attempts $(E2E_FLAKE_ATTEMPTS) -nodes $(E2E_NODES) -timeout $(E2E_TIMEOUT) -v -randomize-suites -race -trace -progress
 E2E_INSTALL_NS ?= operator-lifecycle-manager
 E2E_CATALOG_NS ?= $(E2E_INSTALL_NS)
 E2E_TEST_NS ?= operators

--- a/staging/operator-lifecycle-manager/scripts/split_skips_string.sh
+++ b/staging/operator-lifecycle-manager/scripts/split_skips_string.sh
@@ -1,0 +1,14 @@
+# Set the delimiter
+IFS=';'
+
+# Read the split words into an array
+read -ra skipped_tests <<< "$1"
+
+# Construct the skip arguments for the e2e test
+output=""
+for test in "${skipped_tests[@]}";
+do
+ output="$output -skip '$test'"
+done
+
+echo $output


### PR DESCRIPTION
Problem: There are instances where a user may wish to skip multiple e2e tests.

Solution: Allow users to specify multple tests to skip in the e2e suite by setting multiple test names separated by the semicolon (;) symbol.`

Signed-off-by: Alexander Greene <greene.al1991@gmail.com>

Upstream-repository: operator-lifecycle-manager
Upstream-commit: 6cfd86cfd5c91c6b5232fb99a623c1fa5d63edbc