### PR TITLE
OCPBUGS-5294: backport cert rotation fix

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,48 @@
+run:
+  timeout: 5m
+  skip-dirs:
+  - pkg/lib
+  - pkg/api
+  - pkg/fakes
+  - pkg/package-server/apis
+  - test/e2e
+
+linters:
+  enable:
+  - depguard
+  - gofmt
+  - goimports
+  - importas
+  - misspell
+  - stylecheck
+  - tparallel
+  - unconvert
+  - whitespace
+  disable:
+  - errcheck
+
+linters-settings:
+  importas:
+    alias:
+    - pkg: k8s.io/api/core/v1
+      alias: corev1
+    - pkg: k8s.io/api/apps/v1
+      alias: appsv1
+    - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+      alias: metav1
+    - pkg: k8s.io/apimachinery/pkg/api/errors
+      alias: apierrors
+    - pkg: github.com/operator-framework/api/pkg/operators/v1alpha1
+      alias: operatorsv1alpha1
+    - pkg: github.com/operator-framework/api/pkg/operators/v1
+      alias: operatorsv1
+    - pkg: github.com/operator-framework/api/pkg/operators/v2
+      alias: operatorsv2
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+output:
+  format: tab
+  sort-results: true

--- a/staging/operator-lifecycle-manager/cmd/olm/main.go
+++ b/staging/operator-lifecycle-manager/cmd/olm/main.go
@@ -13,7 +13,7 @@ import (
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -103,8 +103,8 @@ func main() {
 	// the empty string, the resulting array will be `[]string{""}`.
 	namespaces := strings.Split(*watchedNamespaces, ",")
 	for _, ns := range namespaces {
-		if ns == v1.NamespaceAll {
-			namespaces = []string{v1.NamespaceAll}
+		if ns == corev1.NamespaceAll {
+			namespaces = []string{corev1.NamespaceAll}
 			break
 		}
 	}

--- a/staging/operator-lifecycle-manager/pkg/controller/install/apiservice.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/install/apiservice.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 
@@ -26,7 +26,7 @@ func (i *StrategyDeploymentInstaller) createOrUpdateAPIService(caPEM []byte, des
 	exists := true
 	apiService, err := i.strategyClient.GetOpLister().APIRegistrationV1().APIServiceLister().Get(apiServiceName)
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 
@@ -120,14 +120,14 @@ func IsAPIServiceAdoptable(opLister operatorlister.OperatorLister, target *v1alp
 
 	// Get the CSV that target replaces
 	replacing, replaceGetErr := opLister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(target.GetNamespace()).Get(target.Spec.Replaces)
-	if replaceGetErr != nil && !k8serrors.IsNotFound(replaceGetErr) && !k8serrors.IsGone(replaceGetErr) {
+	if replaceGetErr != nil && !apierrors.IsNotFound(replaceGetErr) && !apierrors.IsGone(replaceGetErr) {
 		err = replaceGetErr
 		return
 	}
 
 	// Get the current owner CSV of the APIService
 	currentOwnerCSV, ownerGetErr := opLister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(ownerNamespace).Get(ownerName)
-	if ownerGetErr != nil && !k8serrors.IsNotFound(ownerGetErr) && !k8serrors.IsGone(ownerGetErr) {
+	if ownerGetErr != nil && !apierrors.IsNotFound(ownerGetErr) && !apierrors.IsGone(ownerGetErr) {
 		err = ownerGetErr
 		return
 	}
@@ -179,13 +179,13 @@ func (i *StrategyDeploymentInstaller) deleteLegacyAPIServiceResources(desc apiSe
 		// Attempt to delete the legacy Service.
 		existingService, err := i.strategyClient.GetOpClient().GetService(namespace, legacyServiceName)
 		if err != nil {
-			if !k8serrors.IsNotFound(err) {
+			if !apierrors.IsNotFound(err) {
 				return err
 			}
 		} else if ownerutil.AdoptableLabels(existingService.GetLabels(), true, i.owner) {
 			logger.Infof("Deleting Service with legacy APIService name %s", existingService.Name)
 			err = i.strategyClient.GetOpClient().DeleteService(namespace, legacyServiceName, &metav1.DeleteOptions{})
-			if err != nil && !k8serrors.IsNotFound(err) {
+			if err != nil && !apierrors.IsNotFound(err) {
 				return err
 			}
 		} else {
@@ -198,13 +198,13 @@ func (i *StrategyDeploymentInstaller) deleteLegacyAPIServiceResources(desc apiSe
 	// Attempt to delete the legacy Secret.
 	existingSecret, err := i.strategyClient.GetOpClient().GetSecret(namespace, SecretName(apiServiceName))
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else if ownerutil.AdoptableLabels(existingSecret.GetLabels(), true, i.owner) {
 		logger.Infof("Deleting Secret with legacy APIService name %s", existingSecret.Name)
 		err = i.strategyClient.GetOpClient().DeleteSecret(namespace, SecretName(apiServiceName), &metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else {
@@ -214,13 +214,13 @@ func (i *StrategyDeploymentInstaller) deleteLegacyAPIServiceResources(desc apiSe
 	// Attempt to delete the legacy Role.
 	existingRole, err := i.strategyClient.GetOpClient().GetRole(namespace, SecretName(apiServiceName))
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else if ownerutil.AdoptableLabels(existingRole.GetLabels(), true, i.owner) {
 		logger.Infof("Deleting Role with legacy APIService name %s", existingRole.Name)
 		err = i.strategyClient.GetOpClient().DeleteRole(namespace, SecretName(apiServiceName), &metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else {
@@ -230,13 +230,13 @@ func (i *StrategyDeploymentInstaller) deleteLegacyAPIServiceResources(desc apiSe
 	// Attempt to delete the legacy secret RoleBinding.
 	existingRoleBinding, err := i.strategyClient.GetOpClient().GetRoleBinding(namespace, SecretName(apiServiceName))
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else if ownerutil.AdoptableLabels(existingRoleBinding.GetLabels(), true, i.owner) {
 		logger.Infof("Deleting RoleBinding with legacy APIService name %s", existingRoleBinding.Name)
 		err = i.strategyClient.GetOpClient().DeleteRoleBinding(namespace, SecretName(apiServiceName), &metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else {
@@ -246,13 +246,13 @@ func (i *StrategyDeploymentInstaller) deleteLegacyAPIServiceResources(desc apiSe
 	// Attempt to delete the legacy ClusterRoleBinding.
 	existingClusterRoleBinding, err := i.strategyClient.GetOpClient().GetClusterRoleBinding(apiServiceName + "-system:auth-delegator")
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else if ownerutil.AdoptableLabels(existingClusterRoleBinding.GetLabels(), true, i.owner) {
 		logger.Infof("Deleting ClusterRoleBinding with legacy APIService name %s", existingClusterRoleBinding.Name)
 		err = i.strategyClient.GetOpClient().DeleteClusterRoleBinding(apiServiceName+"-system:auth-delegator", &metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else {
@@ -262,13 +262,13 @@ func (i *StrategyDeploymentInstaller) deleteLegacyAPIServiceResources(desc apiSe
 	// Attempt to delete the legacy AuthReadingRoleBinding.
 	existingRoleBinding, err = i.strategyClient.GetOpClient().GetRoleBinding(KubeSystem, apiServiceName+"-auth-reader")
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else if ownerutil.AdoptableLabels(existingRoleBinding.GetLabels(), true, i.owner) {
 		logger.Infof("Deleting RoleBinding with legacy APIService name %s", existingRoleBinding.Name)
 		err = i.strategyClient.GetOpClient().DeleteRoleBinding(KubeSystem, apiServiceName+"-auth-reader", &metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else {

--- a/staging/operator-lifecycle-manager/pkg/controller/install/certresources.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/install/certresources.go
@@ -160,7 +160,7 @@ func (i *StrategyDeploymentInstaller) getCertResources() []certResource {
 }
 
 func (i *StrategyDeploymentInstaller) certResourcesForDeployment(deploymentName string) []certResource {
-	result := []certResource{}
+	var result []certResource
 	for _, desc := range i.getCertResources() {
 		if desc.getDeploymentName() == deploymentName {
 			result = append(result, desc)
@@ -185,8 +185,8 @@ func (i *StrategyDeploymentInstaller) installCertRequirements(strategy Strategy)
 	}
 
 	// Create the CA
-	expiration, _ := CalculateCertExpirationAndRotateAt()
-	ca, err := certs.GenerateCA(expiration, Organization)
+	i.certificateExpirationTime = CalculateCertExpiration(time.Now())
+	ca, err := certs.GenerateCA(i.certificateExpirationTime, Organization)
 	if err != nil {
 		logger.Debug("failed to generate CA")
 		return nil, err
@@ -201,7 +201,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirements(strategy Strategy)
 		}
 
 		// Update the deployment for each certResource
-		newDepSpec, caPEM, err := i.installCertRequirementsForDeployment(sddSpec.Name, ca, expiration, sddSpec.Spec, getServicePorts(certResources))
+		newDepSpec, caPEM, err := i.installCertRequirementsForDeployment(sddSpec.Name, ca, i.certificateExpirationTime, sddSpec.Spec, getServicePorts(certResources))
 		if err != nil {
 			return nil, err
 		}
@@ -213,6 +213,14 @@ func (i *StrategyDeploymentInstaller) installCertRequirements(strategy Strategy)
 	return strategyDetailsDeployment, nil
 }
 
+func (i *StrategyDeploymentInstaller) CertsRotateAt() time.Time {
+	return CalculateCertRotatesAt(i.certificateExpirationTime)
+}
+
+func (i *StrategyDeploymentInstaller) CertsRotated() bool {
+	return i.certificatesRotated
+}
+
 func ShouldRotateCerts(csv *v1alpha1.ClusterServiceVersion) bool {
 	now := metav1.Now()
 	if !csv.Status.CertsRotateAt.IsZero() && csv.Status.CertsRotateAt.Before(&now) {
@@ -222,10 +230,12 @@ func ShouldRotateCerts(csv *v1alpha1.ClusterServiceVersion) bool {
 	return false
 }
 
-func CalculateCertExpirationAndRotateAt() (expiration time.Time, rotateAt time.Time) {
-	expiration = time.Now().Add(DefaultCertValidFor)
-	rotateAt = expiration.Add(-1 * DefaultCertMinFresh)
-	return
+func CalculateCertExpiration(startingFrom time.Time) time.Time {
+	return startingFrom.Add(DefaultCertValidFor)
+}
+
+func CalculateCertRotatesAt(certExpirationTime time.Time) time.Time {
+	return certExpirationTime.Add(-1 * DefaultCertMinFresh)
 }
 
 func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deploymentName string, ca *certs.KeyPair, expiration time.Time, depSpec appsv1.DeploymentSpec, ports []corev1.ServicePort) (*appsv1.DeploymentSpec, []byte, error) {
@@ -316,9 +326,12 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 			secret = existingSecret
 			caPEM = existingCAPEM
 			caHash = certs.PEMSHA256(caPEM)
-		} else if _, err := i.strategyClient.GetOpClient().UpdateSecret(secret); err != nil {
-			logger.Warnf("could not update secret %s", secret.GetName())
-			return nil, nil, err
+		} else {
+			if _, err := i.strategyClient.GetOpClient().UpdateSecret(secret); err != nil {
+				logger.Warnf("could not update secret %s", secret.GetName())
+				return nil, nil, err
+			}
+			i.certificatesRotated = true
 		}
 	} else if apierrors.IsNotFound(err) {
 		// Create the secret
@@ -335,6 +348,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 				return nil, nil, err
 			}
 		}
+		i.certificatesRotated = true
 	} else {
 		return nil, nil, err
 	}

--- a/staging/operator-lifecycle-manager/pkg/controller/install/certresources.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/install/certresources.go
@@ -9,7 +9,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -246,7 +246,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 
 		// Delete the Service to replace
 		deleteErr := i.strategyClient.GetOpClient().DeleteService(service.GetNamespace(), service.GetName(), &metav1.DeleteOptions{})
-		if deleteErr != nil && !k8serrors.IsNotFound(deleteErr) {
+		if deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
 			return nil, nil, fmt.Errorf("could not delete existing service %s", service.GetName())
 		}
 	}
@@ -315,12 +315,11 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 			logger.Warnf("could not update secret %s", secret.GetName())
 			return nil, nil, err
 		}
-
-	} else if k8serrors.IsNotFound(err) {
+	} else if apierrors.IsNotFound(err) {
 		// Create the secret
 		ownerutil.AddNonBlockingOwner(secret, i.owner)
 		if _, err := i.strategyClient.GetOpClient().CreateSecret(secret); err != nil {
-			if !k8serrors.IsAlreadyExists(err) {
+			if !apierrors.IsAlreadyExists(err) {
 				log.Warnf("could not create secret %s: %v", secret.GetName(), err)
 				return nil, nil, err
 			}
@@ -361,7 +360,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 			logger.Warnf("could not update secret role %s", secretRole.GetName())
 			return nil, nil, err
 		}
-	} else if k8serrors.IsNotFound(err) {
+	} else if apierrors.IsNotFound(err) {
 		// Create the role
 		ownerutil.AddNonBlockingOwner(secretRole, i.owner)
 		_, err = i.strategyClient.GetOpClient().CreateRole(secretRole)
@@ -407,7 +406,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 			logger.Warnf("could not update secret rolebinding %s", secretRoleBinding.GetName())
 			return nil, nil, err
 		}
-	} else if k8serrors.IsNotFound(err) {
+	} else if apierrors.IsNotFound(err) {
 		// Create the role
 		ownerutil.AddNonBlockingOwner(secretRoleBinding, i.owner)
 		_, err = i.strategyClient.GetOpClient().CreateRoleBinding(secretRoleBinding)
@@ -452,7 +451,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 			logger.Warnf("could not update auth delegator clusterrolebinding %s", authDelegatorClusterRoleBinding.GetName())
 			return nil, nil, err
 		}
-	} else if k8serrors.IsNotFound(err) {
+	} else if apierrors.IsNotFound(err) {
 		// Create the role.
 		if err := ownerutil.AddOwnerLabels(authDelegatorClusterRoleBinding, i.owner); err != nil {
 			return nil, nil, err
@@ -499,7 +498,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 			logger.Warnf("could not update auth reader role binding %s", authReaderRoleBinding.GetName())
 			return nil, nil, err
 		}
-	} else if k8serrors.IsNotFound(err) {
+	} else if apierrors.IsNotFound(err) {
 		// Create the role.
 		if err := ownerutil.AddOwnerLabels(authReaderRoleBinding, i.owner); err != nil {
 			return nil, nil, err

--- a/staging/operator-lifecycle-manager/pkg/controller/install/deployment.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/install/deployment.go
@@ -3,6 +3,7 @@ package install
 import (
 	"fmt"
 	"hash/fnv"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
@@ -22,13 +23,15 @@ import (
 const DeploymentSpecHashLabelKey = "olm.deployment-spec-hash"
 
 type StrategyDeploymentInstaller struct {
-	strategyClient         wrappers.InstallStrategyDeploymentInterface
-	owner                  ownerutil.Owner
-	previousStrategy       Strategy
-	templateAnnotations    map[string]string
-	initializers           DeploymentInitializerFuncChain
-	apiServiceDescriptions []certResource
-	webhookDescriptions    []certResource
+	strategyClient            wrappers.InstallStrategyDeploymentInterface
+	owner                     ownerutil.Owner
+	previousStrategy          Strategy
+	templateAnnotations       map[string]string
+	initializers              DeploymentInitializerFuncChain
+	apiServiceDescriptions    []certResource
+	webhookDescriptions       []certResource
+	certificateExpirationTime time.Time
+	certificatesRotated       bool
 }
 
 var _ Strategy = &v1alpha1.StrategyDetailsDeployment{}
@@ -77,13 +80,15 @@ func NewStrategyDeploymentInstaller(strategyClient wrappers.InstallStrategyDeplo
 	}
 
 	return &StrategyDeploymentInstaller{
-		strategyClient:         strategyClient,
-		owner:                  owner,
-		previousStrategy:       previousStrategy,
-		templateAnnotations:    templateAnnotations,
-		initializers:           initializers,
-		apiServiceDescriptions: apiDescs,
-		webhookDescriptions:    webhookDescs,
+		strategyClient:            strategyClient,
+		owner:                     owner,
+		previousStrategy:          previousStrategy,
+		templateAnnotations:       templateAnnotations,
+		initializers:              initializers,
+		apiServiceDescriptions:    apiDescs,
+		webhookDescriptions:       webhookDescs,
+		certificatesRotated:       false,
+		certificateExpirationTime: time.Time{},
 	}
 }
 

--- a/staging/operator-lifecycle-manager/pkg/controller/install/deployment.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/install/deployment.go
@@ -7,7 +7,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/utils/pointer"
@@ -209,7 +209,7 @@ func (i *StrategyDeploymentInstaller) Install(s Strategy) error {
 	}
 
 	if err := i.installDeployments(updatedStrategy.DeploymentSpecs); err != nil {
-		if k8serrors.IsForbidden(err) {
+		if apierrors.IsForbidden(err) {
 			return StrategyError{Reason: StrategyErrInsufficientPermissions, Message: fmt.Sprintf("install strategy failed: %s", err)}
 		}
 		return err

--- a/staging/operator-lifecycle-manager/pkg/controller/install/resolver.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/install/resolver.go
@@ -5,6 +5,7 @@ package install
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/wrappers"
@@ -20,6 +21,8 @@ type Strategy interface {
 type StrategyInstaller interface {
 	Install(strategy Strategy) error
 	CheckInstalled(strategy Strategy) (bool, error)
+	CertsRotateAt() time.Time
+	CertsRotated() bool
 }
 
 type StrategyResolverInterface interface {
@@ -67,4 +70,12 @@ func (i *NullStrategyInstaller) Install(s Strategy) error {
 
 func (i *NullStrategyInstaller) CheckInstalled(s Strategy) (bool, error) {
 	return true, nil
+}
+
+func (i *NullStrategyInstaller) CertsRotateAt() time.Time {
+	return time.Time{}
+}
+
+func (i *NullStrategyInstaller) CertsRotated() bool {
+	return false
 }

--- a/staging/operator-lifecycle-manager/pkg/controller/install/rule_checker_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/install/rule_checker_test.go
@@ -18,13 +18,12 @@ import (
 	"k8s.io/client-go/tools/cache"
 	apiregistrationfake "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake"
 
-	v1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 )
 
 func TestRuleSatisfied(t *testing.T) {
-
-	csv := &v1alpha1.ClusterServiceVersion{}
+	csv := &operatorsv1alpha1.ClusterServiceVersion{}
 	csv.SetName("barista-operator")
 	csv.SetUID(types.UID("barista-operator"))
 
@@ -573,7 +572,7 @@ func TestRuleSatisfied(t *testing.T) {
 	}
 }
 
-func NewFakeCSVRuleChecker(k8sObjs []runtime.Object, csv *v1alpha1.ClusterServiceVersion, namespace string, stopCh <-chan struct{}) (*CSVRuleChecker, error) {
+func NewFakeCSVRuleChecker(k8sObjs []runtime.Object, csv *operatorsv1alpha1.ClusterServiceVersion, namespace string, stopCh <-chan struct{}) (*CSVRuleChecker, error) {
 	// create client fakes
 	opClientFake := operatorclient.NewClient(k8sfake.NewSimpleClientset(k8sObjs...), apiextensionsfake.NewSimpleClientset(), apiregistrationfake.NewSimpleClientset())
 

--- a/staging/operator-lifecycle-manager/pkg/controller/install/status_viewer_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/install/status_viewer_test.go
@@ -5,24 +5,24 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	apps "k8s.io/api/apps/v1"
-	core "k8s.io/api/core/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestDeploymentStatusViewerStatus(t *testing.T) {
 	tests := []struct {
 		generation int64
-		status     apps.DeploymentStatus
+		status     appsv1.DeploymentStatus
 		err        error
 		msg        string
 		done       bool
 	}{
 		{
-			status: apps.DeploymentStatus{
-				Conditions: []apps.DeploymentCondition{
+			status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{
 					{
-						Type:   apps.DeploymentProgressing,
+						Type:   appsv1.DeploymentProgressing,
 						Reason: TimedOutReason,
 					},
 				},
@@ -31,15 +31,15 @@ func TestDeploymentStatusViewerStatus(t *testing.T) {
 			done: false,
 		},
 		{
-			status: apps.DeploymentStatus{
-				Conditions: []apps.DeploymentCondition{
+			status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{
 					{
-						Type:   apps.DeploymentProgressing,
+						Type:   appsv1.DeploymentProgressing,
 						Reason: "NotTimedOut",
 					},
 					{
-						Type:   apps.DeploymentAvailable,
-						Status: core.ConditionTrue,
+						Type:   appsv1.DeploymentAvailable,
+						Status: corev1.ConditionTrue,
 					},
 				},
 			},
@@ -48,14 +48,14 @@ func TestDeploymentStatusViewerStatus(t *testing.T) {
 		},
 		{
 			generation: 1,
-			status: apps.DeploymentStatus{
+			status: appsv1.DeploymentStatus{
 				ObservedGeneration: 0,
 			},
 			msg:  "waiting for spec update of deployment \"foo\" to be observed...",
 			done: false,
 		},
 		{
-			status: apps.DeploymentStatus{
+			status: appsv1.DeploymentStatus{
 				Replicas:        5,
 				UpdatedReplicas: 3,
 			},
@@ -63,16 +63,16 @@ func TestDeploymentStatusViewerStatus(t *testing.T) {
 			done: false,
 		},
 		{
-			status: apps.DeploymentStatus{},
-			msg:    fmt.Sprintf("deployment \"foo\" not available: missing condition %q", apps.DeploymentAvailable),
+			status: appsv1.DeploymentStatus{},
+			msg:    fmt.Sprintf("deployment \"foo\" not available: missing condition %q", appsv1.DeploymentAvailable),
 			done:   false,
 		},
 		{
-			status: apps.DeploymentStatus{
-				Conditions: []apps.DeploymentCondition{
+			status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{
 					{
-						Type:    apps.DeploymentAvailable,
-						Status:  core.ConditionFalse,
+						Type:    appsv1.DeploymentAvailable,
+						Status:  corev1.ConditionFalse,
 						Message: "test message",
 					},
 				},
@@ -81,11 +81,11 @@ func TestDeploymentStatusViewerStatus(t *testing.T) {
 			done: false,
 		},
 		{
-			status: apps.DeploymentStatus{
-				Conditions: []apps.DeploymentCondition{
+			status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{
 					{
-						Type:    apps.DeploymentAvailable,
-						Status:  core.ConditionUnknown,
+						Type:    appsv1.DeploymentAvailable,
+						Status:  corev1.ConditionUnknown,
 						Message: "test message",
 					},
 				},
@@ -94,11 +94,11 @@ func TestDeploymentStatusViewerStatus(t *testing.T) {
 			done: false,
 		},
 		{
-			status: apps.DeploymentStatus{
-				Conditions: []apps.DeploymentCondition{
+			status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{
 					{
-						Type:   apps.DeploymentAvailable,
-						Status: core.ConditionTrue,
+						Type:   appsv1.DeploymentAvailable,
+						Status: corev1.ConditionTrue,
 					},
 				},
 			},
@@ -109,7 +109,7 @@ func TestDeploymentStatusViewerStatus(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("%d", i+1), func(t *testing.T) {
-			d := &apps.Deployment{
+			d := &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:  "bar",
 					Name:       "foo",

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
@@ -21,7 +21,7 @@ import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
 	extinf "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -628,7 +628,7 @@ func (o *Operator) syncConfigMap(logger *logrus.Entry, in *v1alpha1.CatalogSourc
 	// Get the catalog source's config map
 	configMap, err := o.lister.CoreV1().ConfigMapLister().ConfigMaps(in.GetNamespace()).Get(in.Spec.ConfigMap)
 	// Attempt to look up the CM via api call if there is a cache miss
-	if k8serrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		configMap, err = o.opClient.KubernetesInterface().CoreV1().ConfigMaps(in.GetNamespace()).Get(context.TODO(), in.Spec.ConfigMap, metav1.GetOptions{})
 		// Found cm in the cluster, add managed label to configmap
 		if err == nil {
@@ -2306,7 +2306,7 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 			}
 			return nil
 		}(i, step); err != nil {
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				// Check for APIVersions present in the installplan steps that are not available on the server.
 				// The check is made via discovery per step in the plan. Transient communication failures to the api-server are handled by the plan retry logic.
 				notFoundErr := discoveryQuerier.WithStepResource(step.Resource).QueryForGVK()

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/step.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/step.go
@@ -10,7 +10,7 @@ import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsv1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	apiextensionsv1beta1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/util/retry"
@@ -100,7 +100,7 @@ func (b *builder) NewCRDV1Step(client apiextensionsv1client.ApiextensionsV1Inter
 		case v1alpha1.StepStatusWaitingForAPI:
 			crd, err := client.CustomResourceDefinitions().Get(context.TODO(), step.Resource.Name, metav1.GetOptions{})
 			if err != nil {
-				if k8serrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					return v1alpha1.StepStatusNotPresent, nil
 				} else {
 					return v1alpha1.StepStatusNotPresent, errors.Wrapf(err, "error finding the %s CRD", crd.Name)
@@ -131,7 +131,7 @@ func (b *builder) NewCRDV1Step(client apiextensionsv1client.ApiextensionsV1Inter
 			setInstalledAlongsideAnnotation(b.annotator, crd, b.plan.GetNamespace(), step.Resolving, b.csvLister, crd)
 
 			_, createError := client.CustomResourceDefinitions().Create(context.TODO(), crd, metav1.CreateOptions{})
-			if k8serrors.IsAlreadyExists(createError) {
+			if apierrors.IsAlreadyExists(createError) {
 				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 					currentCRD, _ := client.CustomResourceDefinitions().Get(context.TODO(), crd.GetName(), metav1.GetOptions{})
 					crd.SetResourceVersion(currentCRD.GetResourceVersion())
@@ -184,7 +184,7 @@ func (b *builder) NewCRDV1Beta1Step(client apiextensionsv1beta1client.Apiextensi
 		case v1alpha1.StepStatusWaitingForAPI:
 			crd, err := client.CustomResourceDefinitions().Get(context.TODO(), step.Resource.Name, metav1.GetOptions{})
 			if err != nil {
-				if k8serrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					return v1alpha1.StepStatusNotPresent, nil
 				} else {
 					return v1alpha1.StepStatusNotPresent, fmt.Errorf("error finding the %q CRD: %w", crd.Name, err)
@@ -215,7 +215,7 @@ func (b *builder) NewCRDV1Beta1Step(client apiextensionsv1beta1client.Apiextensi
 			setInstalledAlongsideAnnotation(b.annotator, crd, b.plan.GetNamespace(), step.Resolving, b.csvLister, crd)
 
 			_, createError := client.CustomResourceDefinitions().Create(context.TODO(), crd, metav1.CreateOptions{})
-			if k8serrors.IsAlreadyExists(createError) {
+			if apierrors.IsAlreadyExists(createError) {
 				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 					currentCRD, _ := client.CustomResourceDefinitions().Get(context.TODO(), crd.GetName(), metav1.GetOptions{})
 					crd.SetResourceVersion(currentCRD.GetResourceVersion())
@@ -272,7 +272,7 @@ func setInstalledAlongsideAnnotation(a alongside.Annotator, dst metav1.Object, n
 				continue
 			}
 
-			if csv, err := lister.ClusterServiceVersions(nn.Namespace).Get(nn.Name); k8serrors.IsNotFound(err) {
+			if csv, err := lister.ClusterServiceVersions(nn.Namespace).Get(nn.Name); apierrors.IsNotFound(err) {
 				continue
 			} else if err == nil && csv.IsCopied() {
 				continue

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/step_ensurer.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/step_ensurer.go
@@ -8,7 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
@@ -43,7 +43,7 @@ func (o *StepEnsurer) EnsureClusterServiceVersion(csv *v1alpha1.ClusterServiceVe
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating csv %s", csv.GetName())
 		return
 	}
@@ -60,7 +60,7 @@ func (o *StepEnsurer) EnsureSubscription(subscription *v1alpha1.Subscription) (s
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating subscription %s", subscription.GetName())
 		return
 	}
@@ -74,7 +74,7 @@ func (o *StepEnsurer) EnsureSubscription(subscription *v1alpha1.Subscription) (s
 func (o *StepEnsurer) EnsureSecret(operatorNamespace, planNamespace, name string) (status v1alpha1.StepStatus, err error) {
 	secret, getError := o.kubeClient.KubernetesInterface().CoreV1().Secrets(operatorNamespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if getError != nil {
-		if k8serrors.IsNotFound(getError) {
+		if apierrors.IsNotFound(getError) {
 			err = fmt.Errorf("secret %s does not exist - %v", name, getError)
 			return
 		}
@@ -97,7 +97,7 @@ func (o *StepEnsurer) EnsureSecret(operatorNamespace, planNamespace, name string
 	}
 
 	if _, createError := o.kubeClient.KubernetesInterface().CoreV1().Secrets(planNamespace).Create(context.TODO(), newSecret, metav1.CreateOptions{}); createError != nil {
-		if k8serrors.IsAlreadyExists(createError) {
+		if apierrors.IsAlreadyExists(createError) {
 			status = v1alpha1.StepStatusPresent
 			return
 		}
@@ -118,7 +118,7 @@ func (o *StepEnsurer) EnsureBundleSecret(namespace string, secret *corev1.Secret
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error updating secret: %s", secret.GetName())
 		return
 	}
@@ -142,7 +142,7 @@ func (o *StepEnsurer) EnsureServiceAccount(namespace string, sa *corev1.ServiceA
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating service account: %s", sa.GetName())
 		return
 	}
@@ -180,7 +180,7 @@ func (o *StepEnsurer) EnsureService(namespace string, service *corev1.Service) (
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error updating service: %s", service.GetName())
 		return
 	}
@@ -203,7 +203,7 @@ func (o *StepEnsurer) EnsureClusterRole(cr *rbacv1.ClusterRole, step *v1alpha1.S
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating clusterrole %s", cr.GetName())
 		return
 	}
@@ -230,7 +230,7 @@ func (o *StepEnsurer) EnsureClusterRoleBinding(crb *rbacv1.ClusterRoleBinding, s
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating clusterrolebinding %s", crb.GetName())
 		return
 	}
@@ -257,7 +257,7 @@ func (o *StepEnsurer) EnsureRole(namespace string, role *rbacv1.Role) (status v1
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating role %s", role.GetName())
 		return
 	}
@@ -281,7 +281,7 @@ func (o *StepEnsurer) EnsureRoleBinding(namespace string, rb *rbacv1.RoleBinding
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating rolebinding %s", rb.GetName())
 		return
 	}
@@ -304,7 +304,7 @@ func (o *StepEnsurer) EnsureUnstructuredObject(client dynamic.ResourceInterface,
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating unstructured object %s", obj.GetName())
 		return
 	}
@@ -336,7 +336,7 @@ func (o *StepEnsurer) EnsureConfigMap(namespace string, configmap *corev1.Config
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error updating configmap: %s", configmap.GetName())
 		return
 	}

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/apiservices.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/apiservices.go
@@ -7,7 +7,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -148,7 +148,7 @@ func (a *Operator) checkAPIServiceResources(csv *v1alpha1.ClusterServiceVersion,
 
 		// Ensure the existing Deployment has a matching CA hash annotation
 		deployment, err := a.lister.AppsV1().DeploymentLister().Deployments(csv.GetNamespace()).Get(desc.DeploymentName)
-		if k8serrors.IsNotFound(err) || err != nil {
+		if apierrors.IsNotFound(err) || err != nil {
 			logger.WithField("deployment", desc.DeploymentName).Warnf("expected Deployment could not be retrieved")
 			errs = append(errs, err)
 			continue
@@ -227,7 +227,7 @@ func (a *Operator) checkAPIServiceResources(csv *v1alpha1.ClusterServiceVersion,
 func (a *Operator) areAPIServicesAvailable(csv *v1alpha1.ClusterServiceVersion) (bool, error) {
 	for _, desc := range csv.Spec.APIServiceDefinitions.Owned {
 		apiService, err := a.lister.APIRegistrationV1().APIServiceLister().Get(desc.GetName())
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return false, nil
 		}
 
@@ -410,7 +410,7 @@ func (a *Operator) cleanUpRemovedWebhooks(csv *v1alpha1.ClusterServiceVersion) e
 		}
 		if _, ok := csvWebhookGenerateNames[webhookGenerateNameLabel]; !ok {
 			err = a.opClient.KubernetesInterface().AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(context.TODO(), webhook.Name, metav1.DeleteOptions{})
-			if err != nil && k8serrors.IsNotFound(err) {
+			if err != nil && apierrors.IsNotFound(err) {
 				return err
 			}
 		}
@@ -428,7 +428,7 @@ func (a *Operator) cleanUpRemovedWebhooks(csv *v1alpha1.ClusterServiceVersion) e
 		}
 		if _, ok := csvWebhookGenerateNames[webhookGenerateNameLabel]; !ok {
 			err = a.opClient.KubernetesInterface().AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(context.TODO(), webhook.Name, metav1.DeleteOptions{})
-			if err != nil && k8serrors.IsNotFound(err) {
+			if err != nil && apierrors.IsNotFound(err) {
 				return err
 			}
 		}

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/groups.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/groups.go
@@ -3,7 +3,7 @@ package olm
 import (
 	"strings"
 
-	v1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 )
 
@@ -106,14 +106,14 @@ type OperatorGroup struct {
 	providedAPIs cache.APISet
 }
 
-func NewOperatorGroup(group *v1.OperatorGroup) *OperatorGroup {
+func NewOperatorGroup(group *operatorsv1.OperatorGroup) *OperatorGroup {
 	// Add operatorgroup namespace if not NamespaceAll
 	namespaces := group.Status.Namespaces
 	if len(namespaces) >= 1 && namespaces[0] != "" {
 		namespaces = append(namespaces, group.GetNamespace())
 	}
 	// TODO: Sanitize OperatorGroup if len(namespaces) > 1 and contains ""
-	gvksStr := group.GetAnnotations()[v1.OperatorGroupProvidedAPIsAnnotationKey]
+	gvksStr := group.GetAnnotations()[operatorsv1.OperatorGroupProvidedAPIsAnnotationKey]
 
 	return &OperatorGroup{
 		namespace:    group.GetNamespace(),
@@ -123,7 +123,7 @@ func NewOperatorGroup(group *v1.OperatorGroup) *OperatorGroup {
 	}
 }
 
-func NewOperatorGroupSurfaces(groups ...v1.OperatorGroup) []OperatorGroupSurface {
+func NewOperatorGroupSurfaces(groups ...operatorsv1.OperatorGroup) []OperatorGroupSurface {
 	operatorGroups := make([]OperatorGroupSurface, len(groups))
 	for i, group := range groups {
 		operatorGroups[i] = NewOperatorGroup(&group)

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/groups_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/groups_test.go
@@ -4,24 +4,24 @@ import (
 	"strings"
 	"testing"
 
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 )
 
-func buildAPIOperatorGroup(namespace, name string, targets []string, gvks []string) *v1.OperatorGroup {
-	return &v1.OperatorGroup{
+func buildAPIOperatorGroup(namespace, name string, targets []string, gvks []string) *operatorsv1.OperatorGroup {
+	return &operatorsv1.OperatorGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
 			Annotations: map[string]string{
-				v1.OperatorGroupProvidedAPIsAnnotationKey: strings.Join(gvks, ","),
+				operatorsv1.OperatorGroupProvidedAPIsAnnotationKey: strings.Join(gvks, ","),
 			},
 		},
-		Status: v1.OperatorGroupStatus{
+		Status: operatorsv1.OperatorGroupStatus{
 			Namespaces: targets,
 		},
 	}
@@ -29,7 +29,7 @@ func buildAPIOperatorGroup(namespace, name string, targets []string, gvks []stri
 func TestNewOperatorGroup(t *testing.T) {
 	tests := []struct {
 		name string
-		in   *v1.OperatorGroup
+		in   *operatorsv1.OperatorGroup
 		want *OperatorGroup
 	}{
 		{

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
@@ -1893,10 +1893,19 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 			return
 		}
 
-		if out.HasCAResources() {
+		// Only update certificate status if:
+		//  - the CSV has CAResources; and
+		//  - the certificate lastUpdated and rotateAt timestamps have not already been set, or the certificate should be rotated
+		// Note: the code here is a bit wonky and it wasn't clear how to clean it up without some major refactoring:
+		// the installer is in charge of generating and rotating the certificates. It detects whether a certificate should be rotated by
+		// looking at the csv.status.RotateAt value. But, it does not update this value or surface
+		// the certificate expiry information. So, the rotatedAt value is to be re-calculated here. This is bad because you have
+		// two different components doing the same thing (installer and operator are both calculating RotateAt). If we're not careful
+		// there could be skew
+		// See pkg/controller/install/certresources.go
+		if shouldUpdateCertificateDates(out) {
 			now := metav1.Now()
-			expiration := now.Add(install.DefaultCertValidFor)
-			rotateAt := expiration.Add(-1 * install.DefaultCertMinFresh)
+			_, rotateAt := install.CalculateCertExpirationAndRotateAt()
 			rotateTime := metav1.NewTime(rotateAt)
 			out.Status.CertsLastUpdated = &now
 			out.Status.CertsRotateAt = &rotateTime
@@ -2490,4 +2499,12 @@ func (a *Operator) ensureLabels(in *v1alpha1.ClusterServiceVersion, labelSets ..
 	out.SetLabels(merged)
 	out, err := a.client.OperatorsV1alpha1().ClusterServiceVersions(out.GetNamespace()).Update(context.TODO(), out, metav1.UpdateOptions{})
 	return out, err
+}
+
+// shouldUpdateCertificateDates checks the csv status to decide whether
+// status.CertsLastUpdated and status.CertsRotateAt should be updated
+// returns true if the CSV has CAResources and status.RotatedAt is not set OR its time to rotate the certificates
+func shouldUpdateCertificateDates(csv *v1alpha1.ClusterServiceVersion) bool {
+	isNotSet := csv.Status.CertsRotateAt == nil || csv.Status.CertsRotateAt.IsZero()
+	return csv.HasCAResources() && (isNotSet || install.ShouldRotateCerts(csv))
 }

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
@@ -7,13 +7,12 @@ import (
 	"strings"
 	"time"
 
-	v1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/sirupsen/logrus"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	extinf "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -30,6 +29,7 @@ import (
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	kagg "k8s.io/kube-aggregator/pkg/client/informers/externalversions"
 
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/informers/externalversions"
@@ -636,14 +636,14 @@ func (a *Operator) syncAPIService(obj interface{}) (syncError error) {
 
 	if name, ns, ok := ownerutil.GetOwnerByKindLabel(apiService, v1alpha1.ClusterServiceVersionKind); ok {
 		_, err := a.lister.CoreV1().NamespaceLister().Get(ns)
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			logger.Debug("Deleting api service since owning namespace is not found")
 			syncError = a.opClient.DeleteAPIService(apiService.GetName(), &metav1.DeleteOptions{})
 			return
 		}
 
 		_, err = a.lister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(ns).Get(name)
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			logger.Debug("Deleting api service since owning CSV is not found")
 			syncError = a.opClient.DeleteAPIService(apiService.GetName(), &metav1.DeleteOptions{})
 			return
@@ -714,7 +714,7 @@ func (a *Operator) syncGCObject(obj interface{}) (syncError error) {
 				logger.Debugf("CSV still present, must wait until it is deleted (owners=%v/%v)", ns, name)
 				syncError = fmt.Errorf("cleanup must wait")
 				return
-			} else if !k8serrors.IsNotFound(err) {
+			} else if !apierrors.IsNotFound(err) {
 				syncError = err
 				return
 			}
@@ -732,7 +732,7 @@ func (a *Operator) syncGCObject(obj interface{}) (syncError error) {
 				logger.Debugf("CSV still present, must wait until it is deleted (owners=%v)", name)
 				syncError = fmt.Errorf("cleanup must wait")
 				return
-			} else if !k8serrors.IsNotFound(err) {
+			} else if !apierrors.IsNotFound(err) {
 				syncError = err
 				return
 			}
@@ -750,7 +750,7 @@ func (a *Operator) syncGCObject(obj interface{}) (syncError error) {
 				logger.Debugf("CSV still present, must wait until it is deleted (owners=%v)", name)
 				syncError = fmt.Errorf("cleanup must wait")
 				return
-			} else if !k8serrors.IsNotFound(err) {
+			} else if !apierrors.IsNotFound(err) {
 				logger.Infof("error CSV retrieval error")
 				syncError = err
 				return
@@ -769,7 +769,7 @@ func (a *Operator) syncGCObject(obj interface{}) (syncError error) {
 				logger.Debugf("CSV still present, must wait until it is deleted (owners=%v)", name)
 				syncError = fmt.Errorf("cleanup must wait")
 				return
-			} else if !k8serrors.IsNotFound(err) {
+			} else if !apierrors.IsNotFound(err) {
 				logger.Infof("Error CSV retrieval error")
 				syncError = err
 				return
@@ -807,7 +807,7 @@ func (a *Operator) syncObject(obj interface{}) (syncError error) {
 			logger.Error("unexpected owner label retrieval failure")
 		}
 		_, err := a.lister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(ns).Get(name)
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			logger.Debug("requeueing owner csvs from owner label")
 			a.requeueOwnerCSVs(metaObj)
 		} else {
@@ -908,7 +908,7 @@ func (a *Operator) syncNamespace(obj interface{}) error {
 
 	// Remove existing OperatorGroup labels
 	for label := range namespace.GetLabels() {
-		if v1.IsOperatorGroupLabel(label) {
+		if operatorsv1.IsOperatorGroupLabel(label) {
 			delete(namespace.Labels, label)
 		}
 	}
@@ -998,19 +998,19 @@ func (a *Operator) handleClusterServiceVersionDeletion(obj interface{}) {
 		}
 	}(*clusterServiceVersion)
 
-	targetNamespaces, ok := clusterServiceVersion.Annotations[v1.OperatorGroupTargetsAnnotationKey]
+	targetNamespaces, ok := clusterServiceVersion.Annotations[operatorsv1.OperatorGroupTargetsAnnotationKey]
 	if !ok {
 		logger.Debug("missing target namespaces annotation on csv")
 		return
 	}
 
-	operatorNamespace, ok := clusterServiceVersion.Annotations[v1.OperatorGroupNamespaceAnnotationKey]
+	operatorNamespace, ok := clusterServiceVersion.Annotations[operatorsv1.OperatorGroupNamespaceAnnotationKey]
 	if !ok {
 		logger.Debug("missing operator namespace annotation on csv")
 		return
 	}
 
-	if _, ok = clusterServiceVersion.Annotations[v1.OperatorGroupAnnotationKey]; !ok {
+	if _, ok = clusterServiceVersion.Annotations[operatorsv1.OperatorGroupAnnotationKey]; !ok {
 		logger.Debug("missing operatorgroup name annotation on csv")
 		return
 	}
@@ -1041,7 +1041,7 @@ func (a *Operator) handleClusterServiceVersionDeletion(obj interface{}) {
 	for _, desc := range clusterServiceVersion.Spec.APIServiceDefinitions.Owned {
 		apiServiceName := fmt.Sprintf("%s.%s", desc.Version, desc.Group)
 		fetched, err := a.lister.APIRegistrationV1().APIServiceLister().Get(apiServiceName)
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			continue
 		}
 		if err != nil {
@@ -1118,7 +1118,7 @@ func (a *Operator) removeDanglingChildCSVs(csv *v1alpha1.ClusterServiceVersion) 
 		return nil
 	}
 
-	operatorNamespace, ok := csv.Annotations[v1.OperatorGroupNamespaceAnnotationKey]
+	operatorNamespace, ok := csv.Annotations[operatorsv1.OperatorGroupNamespaceAnnotationKey]
 	if !ok {
 		logger.Debug("missing operator namespace annotation on copied CSV")
 		return a.deleteChild(csv, logger)
@@ -1126,7 +1126,7 @@ func (a *Operator) removeDanglingChildCSVs(csv *v1alpha1.ClusterServiceVersion) 
 
 	logger = logger.WithField("parentNamespace", operatorNamespace)
 	parent, err := a.lister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(operatorNamespace).Get(csv.GetName())
-	if k8serrors.IsNotFound(err) || k8serrors.IsGone(err) || parent == nil {
+	if apierrors.IsNotFound(err) || apierrors.IsGone(err) || parent == nil {
 		logger.Debug("deleting copied CSV since parent is missing")
 		return a.deleteChild(csv, logger)
 	}
@@ -1137,8 +1137,8 @@ func (a *Operator) removeDanglingChildCSVs(csv *v1alpha1.ClusterServiceVersion) 
 	}
 
 	if annotations := parent.GetAnnotations(); annotations != nil {
-		if !NewNamespaceSetFromString(annotations[v1.OperatorGroupTargetsAnnotationKey]).Contains(csv.GetNamespace()) {
-			logger.WithField("parentTargets", annotations[v1.OperatorGroupTargetsAnnotationKey]).
+		if !NewNamespaceSetFromString(annotations[operatorsv1.OperatorGroupTargetsAnnotationKey]).Contains(csv.GetNamespace()) {
+			logger.WithField("parentTargets", annotations[operatorsv1.OperatorGroupTargetsAnnotationKey]).
 				Debug("deleting copied CSV since parent no longer lists this as a target namespace")
 			return a.deleteChild(csv, logger)
 		}
@@ -1236,13 +1236,13 @@ func (a *Operator) syncClusterServiceVersion(obj interface{}) (syncError error) 
 	return
 }
 
-func (a *Operator) allNamespaceOperatorGroups() ([]*v1.OperatorGroup, error) {
+func (a *Operator) allNamespaceOperatorGroups() ([]*operatorsv1.OperatorGroup, error) {
 	operatorGroups, err := a.lister.OperatorsV1().OperatorGroupLister().List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
 
-	result := []*v1.OperatorGroup{}
+	result := []*operatorsv1.OperatorGroup{}
 	for _, operatorGroup := range operatorGroups {
 		if NewNamespaceSet(operatorGroup.Status.Namespaces).IsAllNamespaces() {
 			result = append(result, operatorGroup.DeepCopy())
@@ -1252,8 +1252,8 @@ func (a *Operator) allNamespaceOperatorGroups() ([]*v1.OperatorGroup, error) {
 }
 
 func (a *Operator) syncOLMConfig(obj interface{}) (syncError error) {
-	a.logger.Info("Processing olmConfig")
-	olmConfig, ok := obj.(*v1.OLMConfig)
+	a.logger.Debug("Processing olmConfig")
+	olmConfig, ok := obj.(*operatorsv1.OLMConfig)
 	if !ok {
 		return fmt.Errorf("casting OLMConfig failed")
 	}
@@ -1331,7 +1331,7 @@ func isStatusConditionPresentAndAreTypeReasonMessageStatusEqual(conditions []met
 
 func getCopiedCSVsCondition(isDisabled, csvIsRequeued bool) metav1.Condition {
 	condition := metav1.Condition{
-		Type:               v1.DisabledCopiedCSVsConditionType,
+		Type:               operatorsv1.DisabledCopiedCSVsConditionType,
 		LastTransitionTime: metav1.Now(),
 		Status:             metav1.ConditionFalse,
 	}
@@ -1365,7 +1365,7 @@ func (a *Operator) syncCopyCSV(obj interface{}) (syncError error) {
 	}
 
 	olmConfig, err := a.client.OperatorsV1().OLMConfigs().Get(context.TODO(), "cluster", metav1.GetOptions{})
-	if err != nil && !k8serrors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
 
@@ -1429,7 +1429,7 @@ func (a *Operator) syncCopyCSV(obj interface{}) (syncError error) {
 
 	for _, copiedCSV := range copiedCSVs {
 		err := a.client.OperatorsV1alpha1().ClusterServiceVersions(copiedCSV.Namespace).Delete(context.TODO(), copiedCSV.Name, metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	}
@@ -1457,7 +1457,7 @@ func (a *Operator) copiedCSVsAreEnabled() (bool, error) {
 	olmConfig, err := a.client.OperatorsV1().OLMConfigs().Get(context.TODO(), "cluster", metav1.GetOptions{})
 	if err != nil {
 		// Default to true if olmConfig singleton cannot be found
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return true, nil
 		}
 		// If there was an error that wasn't an IsNotFound, return the error
@@ -1483,7 +1483,7 @@ func (a *Operator) getCopiedCSVDisabledEventsForCSV(csv *v1alpha1.ClusterService
 		if event.InvolvedObject.Namespace == csv.GetNamespace() &&
 			event.InvolvedObject.Name == csv.GetName() &&
 			event.InvolvedObject.UID == csv.GetUID() &&
-			event.Reason == v1.DisabledCopiedCSVsConditionType {
+			event.Reason == operatorsv1.DisabledCopiedCSVsConditionType {
 			result = append(result, *event.DeepCopy())
 		}
 	}
@@ -1504,7 +1504,7 @@ func (a *Operator) deleteCSVCopyingDisabledEvent(csv *v1alpha1.ClusterServiceVer
 func (a *Operator) deleteEvents(events []corev1.Event) error {
 	for _, event := range events {
 		err := a.opClient.KubernetesInterface().EventsV1().Events(event.GetNamespace()).Delete(context.TODO(), event.GetName(), metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	}
@@ -1528,7 +1528,7 @@ func (a *Operator) createCSVCopyingDisabledEvent(csv *v1alpha1.ClusterServiceVer
 		}
 	}
 
-	a.recorder.Eventf(csv, corev1.EventTypeWarning, v1.DisabledCopiedCSVsConditionType, "CSV copying disabled for %s/%s", csv.GetNamespace(), csv.GetName())
+	a.recorder.Eventf(csv, corev1.EventTypeWarning, operatorsv1.DisabledCopiedCSVsConditionType, "CSV copying disabled for %s/%s", csv.GetNamespace(), csv.GetName())
 
 	return nil
 }
@@ -1547,7 +1547,7 @@ func (a *Operator) syncGcCsv(obj interface{}) (syncError error) {
 }
 
 // operatorGroupFromAnnotations returns the OperatorGroup for the CSV only if the CSV is active one in the group
-func (a *Operator) operatorGroupFromAnnotations(logger *logrus.Entry, csv *v1alpha1.ClusterServiceVersion) *v1.OperatorGroup {
+func (a *Operator) operatorGroupFromAnnotations(logger *logrus.Entry, csv *v1alpha1.ClusterServiceVersion) *operatorsv1.OperatorGroup {
 	annotations := csv.GetAnnotations()
 
 	// Not part of a group yet
@@ -1557,12 +1557,12 @@ func (a *Operator) operatorGroupFromAnnotations(logger *logrus.Entry, csv *v1alp
 	}
 
 	// Not in the OperatorGroup namespace
-	if annotations[v1.OperatorGroupNamespaceAnnotationKey] != csv.GetNamespace() {
+	if annotations[operatorsv1.OperatorGroupNamespaceAnnotationKey] != csv.GetNamespace() {
 		logger.Info("not in operatorgroup namespace")
 		return nil
 	}
 
-	operatorGroupName, ok := annotations[v1.OperatorGroupAnnotationKey]
+	operatorGroupName, ok := annotations[operatorsv1.OperatorGroupAnnotationKey]
 
 	// No OperatorGroup annotation
 	if !ok {
@@ -1579,7 +1579,7 @@ func (a *Operator) operatorGroupFromAnnotations(logger *logrus.Entry, csv *v1alp
 		return nil
 	}
 
-	targets, ok := annotations[v1.OperatorGroupTargetsAnnotationKey]
+	targets, ok := annotations[operatorsv1.OperatorGroupTargetsAnnotationKey]
 
 	// No target annotation
 	if !ok {
@@ -1596,7 +1596,7 @@ func (a *Operator) operatorGroupFromAnnotations(logger *logrus.Entry, csv *v1alp
 	return operatorGroup.DeepCopy()
 }
 
-func (a *Operator) operatorGroupForCSV(csv *v1alpha1.ClusterServiceVersion, logger *logrus.Entry) (*v1.OperatorGroup, error) {
+func (a *Operator) operatorGroupForCSV(csv *v1alpha1.ClusterServiceVersion, logger *logrus.Entry) (*operatorsv1.OperatorGroup, error) {
 	now := a.now()
 
 	// Attempt to associate an OperatorGroup with the CSV.
@@ -1605,7 +1605,7 @@ func (a *Operator) operatorGroupForCSV(csv *v1alpha1.ClusterServiceVersion, logg
 		logger.Errorf("error occurred while attempting to associate csv with operatorgroup")
 		return nil, err
 	}
-	var operatorGroup *v1.OperatorGroup
+	var operatorGroup *operatorsv1.OperatorGroup
 
 	switch len(operatorGroups) {
 	case 0:
@@ -1702,7 +1702,7 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 	}
 
 	// Check if the CSV supports its operatorgroup's selected namespaces
-	targets, ok := out.GetAnnotations()[v1.OperatorGroupTargetsAnnotationKey]
+	targets, ok := out.GetAnnotations()[operatorsv1.OperatorGroupTargetsAnnotationKey]
 	if ok {
 		namespaces := strings.Split(targets, ",")
 
@@ -1719,7 +1719,11 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 
 	// Check for intersecting provided APIs in intersecting OperatorGroups
 	allGroups, err := a.lister.OperatorsV1().OperatorGroupLister().List(labels.Everything())
-	otherGroups := make([]v1.OperatorGroup, 0, len(allGroups))
+	if err != nil {
+		logger.WithError(err).Warn("failed to list operatorgroups")
+		return
+	}
+	otherGroups := make([]operatorsv1.OperatorGroup, 0, len(allGroups))
 	for _, g := range allGroups {
 		if g.GetName() != operatorGroup.GetName() || g.GetNamespace() != operatorGroup.GetNamespace() {
 			otherGroups = append(otherGroups, *g)
@@ -1755,16 +1759,16 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 		if unionedAnnotations == nil {
 			unionedAnnotations = make(map[string]string)
 		}
-		if unionedAnnotations[v1.OperatorGroupProvidedAPIsAnnotationKey] == union.String() {
+		if unionedAnnotations[operatorsv1.OperatorGroupProvidedAPIsAnnotationKey] == union.String() {
 			// resolver may think apis need adding with invalid input, so continue when there's no work
 			// to be done so that the CSV can progress far enough to get requirements checked
 			a.logger.Debug("operator group annotations up to date, continuing")
 			break
 		}
-		unionedAnnotations[v1.OperatorGroupProvidedAPIsAnnotationKey] = union.String()
+		unionedAnnotations[operatorsv1.OperatorGroupProvidedAPIsAnnotationKey] = union.String()
 		operatorGroup.SetAnnotations(unionedAnnotations)
-		if _, err := a.client.OperatorsV1().OperatorGroups(operatorGroup.GetNamespace()).Update(context.TODO(), operatorGroup, metav1.UpdateOptions{}); err != nil && !k8serrors.IsNotFound(err) {
-			syncError = fmt.Errorf("could not update operatorgroups %s annotation: %v", v1.OperatorGroupProvidedAPIsAnnotationKey, err)
+		if _, err := a.client.OperatorsV1().OperatorGroups(operatorGroup.GetNamespace()).Update(context.TODO(), operatorGroup, metav1.UpdateOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			syncError = fmt.Errorf("could not update operatorgroups %s annotation: %v", operatorsv1.OperatorGroupProvidedAPIsAnnotationKey, err)
 		}
 		if err := a.csvQueueSet.Requeue(out.GetNamespace(), out.GetName()); err != nil {
 			a.logger.WithError(err).Warn("unable to requeue")
@@ -1775,10 +1779,10 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 		logger.WithField("apis", providedAPIs).Debug("removing csv provided apis from operatorgroup")
 		difference := groupSurface.ProvidedAPIs().Difference(providedAPIs)
 		if diffedAnnotations := operatorGroup.GetAnnotations(); diffedAnnotations != nil {
-			diffedAnnotations[v1.OperatorGroupProvidedAPIsAnnotationKey] = difference.String()
+			diffedAnnotations[operatorsv1.OperatorGroupProvidedAPIsAnnotationKey] = difference.String()
 			operatorGroup.SetAnnotations(diffedAnnotations)
-			if _, err := a.client.OperatorsV1().OperatorGroups(operatorGroup.GetNamespace()).Update(context.TODO(), operatorGroup, metav1.UpdateOptions{}); err != nil && !k8serrors.IsNotFound(err) {
-				syncError = fmt.Errorf("could not update operatorgroups %s annotation: %v", v1.OperatorGroupProvidedAPIsAnnotationKey, err)
+			if _, err := a.client.OperatorsV1().OperatorGroups(operatorGroup.GetNamespace()).Update(context.TODO(), operatorGroup, metav1.UpdateOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				syncError = fmt.Errorf("could not update operatorgroups %s annotation: %v", operatorsv1.OperatorGroupProvidedAPIsAnnotationKey, err)
 			}
 		}
 		if err := a.csvQueueSet.Requeue(out.GetNamespace(), out.GetName()); err != nil {
@@ -1919,7 +1923,7 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 		}
 		if installErr := a.updateInstallStatus(out, installer, strategy, v1alpha1.CSVPhaseInstalling, v1alpha1.CSVReasonWaiting); installErr != nil {
 			// Re-sync if kube-apiserver was unavailable
-			if k8serrors.IsServiceUnavailable(installErr) {
+			if apierrors.IsServiceUnavailable(installErr) {
 				logger.WithError(installErr).Info("could not update install status")
 				syncError = installErr
 				return
@@ -1981,7 +1985,7 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 		}
 		if installErr := a.updateInstallStatus(out, installer, strategy, v1alpha1.CSVPhaseFailed, v1alpha1.CSVReasonComponentUnhealthy); installErr != nil {
 			// Re-sync if kube-apiserver was unavailable
-			if k8serrors.IsServiceUnavailable(installErr) {
+			if apierrors.IsServiceUnavailable(installErr) {
 				logger.WithError(installErr).Info("could not update install status")
 				syncError = installErr
 				return
@@ -2069,7 +2073,7 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 		}
 		if installErr := a.updateInstallStatus(out, installer, strategy, v1alpha1.CSVPhasePending, v1alpha1.CSVReasonNeedsReinstall); installErr != nil {
 			// Re-sync if kube-apiserver was unavailable
-			if k8serrors.IsServiceUnavailable(installErr) {
+			if apierrors.IsServiceUnavailable(installErr) {
 				logger.WithError(installErr).Info("could not update install status")
 				syncError = installErr
 				return
@@ -2152,7 +2156,7 @@ func (a *Operator) updateInstallStatus(csv *v1alpha1.ClusterServiceVersion, inst
 		return nil
 	}
 
-	if err := findFirstError(k8serrors.IsServiceUnavailable, strategyErr, apiServiceErr, webhookErr); err != nil {
+	if err := findFirstError(apierrors.IsServiceUnavailable, strategyErr, apiServiceErr, webhookErr); err != nil {
 		return err
 	}
 
@@ -2324,7 +2328,7 @@ func (a *Operator) apiServiceOwnerConflicts(csv *v1alpha1.ClusterServiceVersion)
 	for _, desc := range csv.GetOwnedAPIServiceDescriptions() {
 		// Check if the APIService exists
 		apiService, err := a.lister.APIRegistrationV1().APIServiceLister().Get(desc.GetName())
-		if err != nil && !k8serrors.IsNotFound(err) && !k8serrors.IsGone(err) {
+		if err != nil && !apierrors.IsNotFound(err) && !apierrors.IsGone(err) {
 			return err
 		}
 
@@ -2415,7 +2419,7 @@ func (a *Operator) requeueOwnerCSVs(ownee metav1.Object) {
 	if len(owners) > 0 && ownee.GetNamespace() != metav1.NamespaceAll {
 		for _, ownerCSV := range owners {
 			_, err := a.lister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(ownee.GetNamespace()).Get(ownerCSV.Name)
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				logger.Debugf("skipping requeue since CSV %v is not in cache", ownerCSV.Name)
 				continue
 			}
@@ -2431,7 +2435,7 @@ func (a *Operator) requeueOwnerCSVs(ownee metav1.Object) {
 	// Requeue owners based on labels
 	if name, ns, ok := ownerutil.GetOwnerByKindLabel(ownee, v1alpha1.ClusterServiceVersionKind); ok {
 		_, err := a.lister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(ns).Get(name)
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			logger.Debugf("skipping requeue since CSV %v is not in cache", name)
 			return
 		}

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
@@ -1893,20 +1893,9 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 			return
 		}
 
-		// Only update certificate status if:
-		//  - the CSV has CAResources; and
-		//  - the certificate lastUpdated and rotateAt timestamps have not already been set, or the certificate should be rotated
-		// Note: the code here is a bit wonky and it wasn't clear how to clean it up without some major refactoring:
-		// the installer is in charge of generating and rotating the certificates. It detects whether a certificate should be rotated by
-		// looking at the csv.status.RotateAt value. But, it does not update this value or surface
-		// the certificate expiry information. So, the rotatedAt value is to be re-calculated here. This is bad because you have
-		// two different components doing the same thing (installer and operator are both calculating RotateAt). If we're not careful
-		// there could be skew
-		// See pkg/controller/install/certresources.go
-		if shouldUpdateCertificateDates(out) {
+		if installer.CertsRotated() {
 			now := metav1.Now()
-			_, rotateAt := install.CalculateCertExpirationAndRotateAt()
-			rotateTime := metav1.NewTime(rotateAt)
+			rotateTime := metav1.NewTime(installer.CertsRotateAt())
 			out.Status.CertsLastUpdated = &now
 			out.Status.CertsRotateAt = &rotateTime
 		}
@@ -2499,12 +2488,4 @@ func (a *Operator) ensureLabels(in *v1alpha1.ClusterServiceVersion, labelSets ..
 	out.SetLabels(merged)
 	out, err := a.client.OperatorsV1alpha1().ClusterServiceVersions(out.GetNamespace()).Update(context.TODO(), out, metav1.UpdateOptions{})
 	return out, err
-}
-
-// shouldUpdateCertificateDates checks the csv status to decide whether
-// status.CertsLastUpdated and status.CertsRotateAt should be updated
-// returns true if the CSV has CAResources and status.RotatedAt is not set OR its time to rotate the certificates
-func shouldUpdateCertificateDates(csv *v1alpha1.ClusterServiceVersion) bool {
-	isNotSet := csv.Status.CertsRotateAt == nil || csv.Status.CertsRotateAt.IsZero()
-	return csv.HasCAResources() && (isNotSet || install.ShouldRotateCerts(csv))
 }

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operator_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operator_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
 	"math"
 	"math/big"
@@ -403,7 +404,7 @@ func serviceAccount(name, namespace string) *corev1.ServiceAccount {
 	return serviceAccount
 }
 
-func service(name, namespace, deploymentName string, targetPort int) *corev1.Service {
+func service(name, namespace, deploymentName string, targetPort int, ownerReferences ...metav1.OwnerReference) *corev1.Service {
 	service := &corev1.Service{
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
@@ -419,6 +420,7 @@ func service(name, namespace, deploymentName string, targetPort int) *corev1.Ser
 	}
 	service.SetName(name)
 	service.SetNamespace(namespace)
+	service.SetOwnerReferences(ownerReferences)
 
 	return service
 }
@@ -499,10 +501,21 @@ func tlsSecret(name, namespace string, certPEM, privPEM []byte) *corev1.Secret {
 	return secret
 }
 
+func withCA(secret *corev1.Secret, caPEM []byte) *corev1.Secret {
+	secret.Data[install.OLMCAPEMKey] = caPEM
+	return secret
+}
+
 func keyPairToTLSSecret(name, namespace string, kp *certs.KeyPair) *corev1.Secret {
-	certPEM, privPEM, err := kp.ToPEM()
-	if err != nil {
-		panic(err)
+	var privPEM []byte
+	var certPEM []byte
+
+	if kp != nil {
+		var err error
+		certPEM, privPEM, err = kp.ToPEM()
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	return tlsSecret(name, namespace, certPEM, privPEM)
@@ -768,7 +781,8 @@ func apis(apis ...string) []v1alpha1.APIServiceDescription {
 func apiService(group, version, serviceName, serviceNamespace, deploymentName string, caBundle []byte, availableStatus apiregistrationv1.ConditionStatus, ownerLabel map[string]string) *apiregistrationv1.APIService {
 	apiService := &apiregistrationv1.APIService{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: ownerLabel,
+			Labels:          ownerLabel,
+			OwnerReferences: []metav1.OwnerReference{},
 		},
 		Spec: apiregistrationv1.APIServiceSpec{
 			Group:                group,
@@ -4836,12 +4850,318 @@ func RequireObjectsInNamespace(t *testing.T, opClient operatorclient.ClientInter
 			fetched.(*v1alpha1.ClusterServiceVersion).Status.Conditions = nil
 		case *operatorsv1.OperatorGroup:
 			fetched, err = client.OperatorsV1().OperatorGroups(namespace).Get(context.TODO(), o.GetName(), metav1.GetOptions{})
+		case *corev1.Secret:
+			fetched, err = opClient.GetSecret(namespace, o.GetName())
 		default:
 			require.Failf(t, "couldn't find expected object", "%#v", object)
 		}
 		require.NoError(t, err, "couldn't fetch %s %v", namespace, object)
 		require.True(t, reflect.DeepEqual(object, fetched), cmp.Diff(object, fetched))
 	}
+}
+
+func TestCARotation(t *testing.T) {
+	logrus.SetLevel(logrus.DebugLevel)
+	namespace := "ns"
+
+	//apiHash, err := resolvercache.APIKeyToGVKHash(opregistry.APIKey{Group: "g1", Version: "v1", Kind: "c1"})
+	//require.NoError(t, err)
+
+	defaultOperatorGroup := &operatorsv1.OperatorGroup{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "OperatorGroup",
+			APIVersion: operatorsv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: namespace,
+		},
+		Spec: operatorsv1.OperatorGroupSpec{},
+		Status: operatorsv1.OperatorGroupStatus{
+			Namespaces: []string{namespace},
+		},
+	}
+
+	defaultTemplateAnnotations := map[string]string{
+		operatorsv1.OperatorGroupTargetsAnnotationKey:   namespace,
+		operatorsv1.OperatorGroupNamespaceAnnotationKey: namespace,
+		operatorsv1.OperatorGroupAnnotationKey:          defaultOperatorGroup.GetName(),
+	}
+
+	// Generate valid and expired CA fixtures
+	expirationTime, rotationTime := install.CalculateCertExpirationAndRotateAt()
+	expiresAt := metav1.Time{Time: expirationTime}
+	rotateAt := metav1.Time{Time: rotationTime}
+
+	lastUpdate := metav1.Time{Time: time.Now().UTC()}
+
+	validCA, err := generateCA(expiresAt.Time, install.Organization)
+	require.NoError(t, err)
+	validCAPEM, _, err := validCA.ToPEM()
+	require.NoError(t, err)
+	validCAHash := certs.PEMSHA256(validCAPEM)
+
+	ownerReference := metav1.OwnerReference{
+		Kind: v1alpha1.ClusterServiceVersionKind,
+		UID:  "csv-uid",
+	}
+
+	type operatorConfig struct {
+		apiReconciler APIIntersectionReconciler
+		apiLabeler    labeler.Labeler
+	}
+	type initial struct {
+		csvs       []runtime.Object
+		clientObjs []runtime.Object
+		crds       []runtime.Object
+		objs       []runtime.Object
+		apis       []runtime.Object
+	}
+	tests := []struct {
+		name    string
+		config  operatorConfig
+		initial initial
+	}{
+		{
+			// Happy path: cert is created and csv status contains the right cert dates
+			name: "NoCertificate/CertificateCreated",
+			initial: initial{
+				csvs: []runtime.Object{
+					withAPIServices(csvWithAnnotations(csv("csv1",
+						namespace,
+						"0.0.0",
+						"",
+						installStrategy("a1", nil, nil),
+						[]*apiextensionsv1.CustomResourceDefinition{crd("c1", "v1", "g1")},
+						[]*apiextensionsv1.CustomResourceDefinition{},
+						v1alpha1.CSVPhaseInstallReady,
+					), defaultTemplateAnnotations), apis("a1.v1.a1Kind"), nil),
+				},
+				clientObjs: []runtime.Object{addAnnotation(defaultOperatorGroup, operatorsv1.OperatorGroupProvidedAPIsAnnotationKey, "c1.v1.g1,a1Kind.v1.a1")},
+				crds: []runtime.Object{
+					crd("c1", "v1", "g1"),
+				},
+			},
+		}, {
+			// If a CSV finds itself in the InstallReady phase with a valid certificate
+			// it's likely that a deployment pod or other resource is gone and the installer will re-apply the
+			// resources. If the certs exist and are valid, no need to rotate or update the csv status.
+			name: "HasValidCertificate/ManagedPodDeleted/NoRotation",
+			initial: initial{
+				csvs: []runtime.Object{
+					withUID(withCertInfo(withAPIServices(csvWithAnnotations(csv("csv1",
+						namespace,
+						"0.0.0",
+						"",
+						installStrategy("a1", nil, nil),
+						[]*apiextensionsv1.CustomResourceDefinition{crd("c1", "v1", "g1")},
+						[]*apiextensionsv1.CustomResourceDefinition{},
+						v1alpha1.CSVPhaseInstallReady,
+					), defaultTemplateAnnotations), apis("a1.v1.a1Kind"), nil), rotateAt, lastUpdate), types.UID("csv-uid")),
+				},
+				clientObjs: []runtime.Object{defaultOperatorGroup},
+				crds: []runtime.Object{
+					crd("c1", "v1", "g1"),
+				},
+				apis: []runtime.Object{
+					apiService("a1", "v1", "a1-service", namespace, "a1", validCAPEM, apiregistrationv1.ConditionTrue, ownerLabelFromCSV("csv1", namespace)),
+				},
+				objs: []runtime.Object{
+					deployment("a1", namespace, "sa", addAnnotations(defaultTemplateAnnotations, map[string]string{
+						install.OLMCAHashAnnotationKey: validCAHash,
+					})),
+					withLabels(withAnnotations(withCA(keyPairToTLSSecret("a1-service-cert", namespace, signedServingPair(expiresAt.Time, validCA, []string{"a1-service.ns", "a1-service.ns.svc"})), validCAPEM), map[string]string{
+						install.OLMCAHashAnnotationKey: validCAHash,
+					}), map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue}),
+					service("a1-service", namespace, "a1", 80, ownerReference),
+					serviceAccount("sa", namespace),
+					role("a1-service-cert", namespace, []rbacv1.PolicyRule{
+						{
+							Verbs:         []string{"get"},
+							APIGroups:     []string{""},
+							Resources:     []string{"secrets"},
+							ResourceNames: []string{"a1-service-cert"},
+						},
+					}),
+					roleBinding("a1-service-cert", namespace, "a1-service-cert", "sa", namespace),
+					role("extension-apiserver-authentication-reader", "kube-system", []rbacv1.PolicyRule{
+						{
+							Verbs:         []string{"get"},
+							APIGroups:     []string{""},
+							Resources:     []string{"configmaps"},
+							ResourceNames: []string{"extension-apiserver-authentication"},
+						},
+					}),
+					roleBinding("a1-service-auth-reader", "kube-system", "extension-apiserver-authentication-reader", "sa", namespace),
+					clusterRole("system:auth-delegator", []rbacv1.PolicyRule{
+						{
+							Verbs:     []string{"create"},
+							APIGroups: []string{"authentication.k8s.io"},
+							Resources: []string{"tokenreviews"},
+						},
+						{
+							Verbs:     []string{"create"},
+							APIGroups: []string{"authentication.k8s.io"},
+							Resources: []string{"subjectaccessreviews"},
+						},
+					}),
+				},
+			},
+		}, {
+			// If the cert secret is deleted, a new one is created
+			name: "ValidCert/SecretMissing/NewCertCreated",
+			initial: initial{
+				csvs: []runtime.Object{
+					withUID(withCertInfo(withAPIServices(csvWithAnnotations(csv("csv1",
+						namespace,
+						"0.0.0",
+						"",
+						installStrategy("a1", nil, nil),
+						[]*apiextensionsv1.CustomResourceDefinition{crd("c1", "v1", "g1")},
+						[]*apiextensionsv1.CustomResourceDefinition{},
+						v1alpha1.CSVPhaseInstallReady,
+					), defaultTemplateAnnotations), apis("a1.v1.a1Kind"), nil), rotateAt, lastUpdate), types.UID("csv-uid")),
+				},
+				clientObjs: []runtime.Object{defaultOperatorGroup},
+				crds: []runtime.Object{
+					crd("c1", "v1", "g1"),
+				},
+				apis: []runtime.Object{
+					apiService("a1", "v1", "a1-service", namespace, "a1", validCAPEM, apiregistrationv1.ConditionTrue, ownerLabelFromCSV("csv1", namespace)),
+				},
+				objs: []runtime.Object{
+					deployment("a1", namespace, "sa", addAnnotations(defaultTemplateAnnotations, map[string]string{
+						install.OLMCAHashAnnotationKey: validCAHash,
+					})),
+					service("a1-service", namespace, "a1", 80, ownerReference),
+					serviceAccount("sa", namespace),
+					role("a1-service-cert", namespace, []rbacv1.PolicyRule{
+						{
+							Verbs:         []string{"get"},
+							APIGroups:     []string{""},
+							Resources:     []string{"secrets"},
+							ResourceNames: []string{"a1-service-cert"},
+						},
+					}),
+					roleBinding("a1-service-cert", namespace, "a1-service-cert", "sa", namespace),
+					role("extension-apiserver-authentication-reader", "kube-system", []rbacv1.PolicyRule{
+						{
+							Verbs:         []string{"get"},
+							APIGroups:     []string{""},
+							Resources:     []string{"configmaps"},
+							ResourceNames: []string{"extension-apiserver-authentication"},
+						},
+					}),
+					roleBinding("a1-service-auth-reader", "kube-system", "extension-apiserver-authentication-reader", "sa", namespace),
+					clusterRole("system:auth-delegator", []rbacv1.PolicyRule{
+						{
+							Verbs:     []string{"create"},
+							APIGroups: []string{"authentication.k8s.io"},
+							Resources: []string{"tokenreviews"},
+						},
+						{
+							Verbs:     []string{"create"},
+							APIGroups: []string{"authentication.k8s.io"},
+							Resources: []string{"subjectaccessreviews"},
+						},
+					}),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test operator
+			ctx, cancel := context.WithCancel(context.TODO())
+			defer cancel()
+			op, err := NewFakeOperator(
+				ctx,
+				withNamespaces(namespace, "kube-system"),
+				withClientObjs(append(tt.initial.csvs, tt.initial.clientObjs...)...),
+				withK8sObjs(tt.initial.objs...),
+				withExtObjs(tt.initial.crds...),
+				withRegObjs(tt.initial.apis...),
+				withOperatorNamespace(namespace),
+				withAPIReconciler(tt.config.apiReconciler),
+				withAPILabeler(tt.config.apiLabeler),
+			)
+			require.NoError(t, err)
+
+			// run csv sync for each CSV
+			for _, runtimeObject := range tt.initial.csvs {
+				// Convert the rt object to a proper csv for ease
+				csv, ok := runtimeObject.(*v1alpha1.ClusterServiceVersion)
+				require.True(t, ok)
+
+				// sync works
+				err := op.syncClusterServiceVersion(csv)
+				require.NoError(t, err)
+
+				outCSV, err := op.client.OperatorsV1alpha1().ClusterServiceVersions(namespace).Get(context.Background(), csv.GetName(), metav1.GetOptions{})
+				require.NoError(t, err)
+
+				require.Equal(t, outCSV.Status.Phase, v1alpha1.CSVPhaseInstalling)
+
+				for _, apiServiceDescriptor := range outCSV.GetAllAPIServiceDescriptions() {
+					// Get secret with the certificate
+					secretName := fmt.Sprintf("%s-service-cert", apiServiceDescriptor.DeploymentName)
+					serviceSecret, err := op.opClient.GetSecret(csv.GetNamespace(), secretName)
+					require.NoError(t, err)
+					require.NotNil(t, serviceSecret)
+
+					// Extract certificate
+					start, end, err := GetServiceCertificaValidityPeriod(serviceSecret)
+					require.NoError(t, err)
+					require.NotNil(t, start)
+					require.NotNil(t, end)
+
+					// Compare csv status timestamps with certificate timestamps
+					// NOTE: These values (csv.Status.Certs* and the certificate expiry and rotation are calculated
+					// with the same method but independently, therefore a second granularity will need to suffice.
+					// See https://github.com/operator-framework/operator-lifecycle-manager/issues/2764 for more info.
+					rotationTime := end.Add(-1 * install.DefaultCertMinFresh)
+					require.Equal(t, start.Unix(), outCSV.Status.CertsLastUpdated.Unix())
+					require.Equal(t, rotationTime.Unix(), outCSV.Status.CertsRotateAt.Unix())
+				}
+			}
+
+			// get csvs in the cluster
+			outCSVMap := map[string]*v1alpha1.ClusterServiceVersion{}
+			outCSVs, err := op.client.OperatorsV1alpha1().ClusterServiceVersions(namespace).List(context.TODO(), metav1.ListOptions{})
+			require.NoError(t, err)
+			for _, csv := range outCSVs.Items {
+				outCSVMap[csv.GetName()] = csv.DeepCopy()
+			}
+		})
+	}
+}
+
+func GetServiceCertificaValidityPeriod(serviceSecret *corev1.Secret) (start *time.Time, end *time.Time, err error) {
+	// Extract certificate
+	root := x509.NewCertPool()
+	rootPEM, ok := serviceSecret.Data[install.OLMCAPEMKey]
+	if !ok {
+		return nil, nil, fmt.Errorf("could not find the service root certificate")
+	}
+
+	ok = root.AppendCertsFromPEM(rootPEM)
+	if !ok {
+		return nil, nil, fmt.Errorf("could not append the service root certificate")
+	}
+
+	certPEM, ok := serviceSecret.Data["tls.crt"]
+	if !ok {
+		return nil, nil, fmt.Errorf("could not find the service certificate")
+	}
+	block, _ := pem.Decode(certPEM)
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &cert.NotBefore, &cert.NotAfter, nil
 }
 
 func TestIsReplacing(t *testing.T) {

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operator_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operator_test.go
@@ -27,7 +27,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -46,7 +46,7 @@ import (
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	apiregistrationfake "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake"
 
-	v1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
@@ -290,7 +290,7 @@ func NewFakeOperator(ctx context.Context, options ...fakeOperatorOption) (*Opera
 	for _, ns := range config.namespaces {
 		_, err := config.operatorClient.KubernetesInterface().CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
 		// Ignore already-exists errors
-		if err != nil && !k8serrors.IsAlreadyExists(err) {
+		if err != nil && !apierrors.IsAlreadyExists(err) {
 			return nil, err
 		}
 	}
@@ -881,25 +881,25 @@ func TestTransitionCSV(t *testing.T) {
 	apiHash, err := resolvercache.APIKeyToGVKHash(opregistry.APIKey{Group: "g1", Version: "v1", Kind: "c1"})
 	require.NoError(t, err)
 
-	defaultOperatorGroup := &v1.OperatorGroup{
+	defaultOperatorGroup := &operatorsv1.OperatorGroup{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "OperatorGroup",
-			APIVersion: v1.SchemeGroupVersion.String(),
+			APIVersion: operatorsv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "default",
 			Namespace: namespace,
 		},
-		Spec: v1.OperatorGroupSpec{},
-		Status: v1.OperatorGroupStatus{
+		Spec: operatorsv1.OperatorGroupSpec{},
+		Status: operatorsv1.OperatorGroupStatus{
 			Namespaces: []string{namespace},
 		},
 	}
 
 	defaultTemplateAnnotations := map[string]string{
-		v1.OperatorGroupTargetsAnnotationKey:   namespace,
-		v1.OperatorGroupNamespaceAnnotationKey: namespace,
-		v1.OperatorGroupAnnotationKey:          defaultOperatorGroup.GetName(),
+		operatorsv1.OperatorGroupTargetsAnnotationKey:   namespace,
+		operatorsv1.OperatorGroupNamespaceAnnotationKey: namespace,
+		operatorsv1.OperatorGroupAnnotationKey:          defaultOperatorGroup.GetName(),
 	}
 
 	// Generate valid and expired CA fixtures
@@ -956,7 +956,7 @@ func TestTransitionCSV(t *testing.T) {
 						v1alpha1.CSVPhaseNone,
 					), defaultTemplateAnnotations),
 				},
-				clientObjs: []runtime.Object{addAnnotation(defaultOperatorGroup, v1.OperatorGroupProvidedAPIsAnnotationKey, "c1.v1.g1")},
+				clientObjs: []runtime.Object{addAnnotation(defaultOperatorGroup, operatorsv1.OperatorGroupProvidedAPIsAnnotationKey, "c1.v1.g1")},
 			},
 			expected: expected{
 				csvStates: map[string]csvState{
@@ -978,7 +978,7 @@ func TestTransitionCSV(t *testing.T) {
 						v1alpha1.CSVPhaseNone,
 					), defaultTemplateAnnotations), nil, apis("a1.corev1.a1Kind")),
 				},
-				clientObjs: []runtime.Object{addAnnotation(defaultOperatorGroup, v1.OperatorGroupProvidedAPIsAnnotationKey, "a1Kind.corev1.a1")},
+				clientObjs: []runtime.Object{addAnnotation(defaultOperatorGroup, operatorsv1.OperatorGroupProvidedAPIsAnnotationKey, "a1Kind.corev1.a1")},
 			},
 			expected: expected{
 				csvStates: map[string]csvState{
@@ -1013,7 +1013,7 @@ func TestTransitionCSV(t *testing.T) {
 						v1alpha1.CSVPhasePending,
 					), defaultTemplateAnnotations), types.UID("csv-uid")),
 				},
-				clientObjs: []runtime.Object{addAnnotation(defaultOperatorGroup, v1.OperatorGroupProvidedAPIsAnnotationKey, "c1.v1.g1")},
+				clientObjs: []runtime.Object{addAnnotation(defaultOperatorGroup, operatorsv1.OperatorGroupProvidedAPIsAnnotationKey, "c1.v1.g1")},
 				crds: []runtime.Object{
 					crd("c1", "v1", "g1"),
 				},
@@ -1052,7 +1052,7 @@ func TestTransitionCSV(t *testing.T) {
 						v1alpha1.CSVPhasePending,
 					), defaultTemplateAnnotations),
 				},
-				clientObjs: []runtime.Object{addAnnotation(defaultOperatorGroup, v1.OperatorGroupProvidedAPIsAnnotationKey, "c1.v1.g1")},
+				clientObjs: []runtime.Object{addAnnotation(defaultOperatorGroup, operatorsv1.OperatorGroupProvidedAPIsAnnotationKey, "c1.v1.g1")},
 				crds:       []runtime.Object{},
 			},
 			expected: expected{
@@ -1155,7 +1155,7 @@ func TestTransitionCSV(t *testing.T) {
 						v1alpha1.CSVPhasePending,
 					), defaultTemplateAnnotations), apis("a1.v1.a1Kind"), nil),
 				},
-				clientObjs: []runtime.Object{addAnnotation(defaultOperatorGroup, v1.OperatorGroupProvidedAPIsAnnotationKey, "c1.v1.g1,a1Kind.v1.a1")},
+				clientObjs: []runtime.Object{addAnnotation(defaultOperatorGroup, operatorsv1.OperatorGroupProvidedAPIsAnnotationKey, "c1.v1.g1,a1Kind.v1.a1")},
 				crds: []runtime.Object{
 					crd("c1", "v1", "g1"),
 				},
@@ -1192,7 +1192,7 @@ func TestTransitionCSV(t *testing.T) {
 						v1alpha1.CSVPhasePending,
 					), defaultTemplateAnnotations),
 				},
-				clientObjs: []runtime.Object{addAnnotation(defaultOperatorGroup, v1.OperatorGroupProvidedAPIsAnnotationKey, "c1.v1.g1")},
+				clientObjs: []runtime.Object{addAnnotation(defaultOperatorGroup, operatorsv1.OperatorGroupProvidedAPIsAnnotationKey, "c1.v1.g1")},
 				crds: []runtime.Object{
 					crd("c1", "v1", "g1"),
 				},
@@ -1238,7 +1238,7 @@ func TestTransitionCSV(t *testing.T) {
 					), defaultTemplateAnnotations),
 						apis("a1.v1.a1Kind"), nil),
 				},
-				clientObjs: []runtime.Object{addAnnotation(defaultOperatorGroup, v1.OperatorGroupProvidedAPIsAnnotationKey, "a1Kind.v1.a1")},
+				clientObjs: []runtime.Object{addAnnotation(defaultOperatorGroup, operatorsv1.OperatorGroupProvidedAPIsAnnotationKey, "a1Kind.v1.a1")},
 				apis:       []runtime.Object{apiService("a1", "v1", "a1-service", namespace, "", validCAPEM, apiregistrationv1.ConditionTrue, ownerLabelFromCSV("csv1", namespace))},
 				objs: []runtime.Object{
 					withLabels(
@@ -1311,7 +1311,7 @@ func TestTransitionCSV(t *testing.T) {
 						v1alpha1.CSVPhaseFailed,
 					), defaultTemplateAnnotations),
 				},
-				clientObjs: []runtime.Object{addAnnotation(defaultOperatorGroup, v1.OperatorGroupProvidedAPIsAnnotationKey, "c1.v1.g1")},
+				clientObjs: []runtime.Object{addAnnotation(defaultOperatorGroup, operatorsv1.OperatorGroupProvidedAPIsAnnotationKey, "c1.v1.g1")},
 				crds: []runtime.Object{
 					crd("c1", "v1", "g1"),
 				},
@@ -1336,7 +1336,7 @@ func TestTransitionCSV(t *testing.T) {
 						v1alpha1.CSVPhaseFailed,
 					), defaultTemplateAnnotations),
 				},
-				clientObjs: []runtime.Object{addAnnotation(defaultOperatorGroup, v1.OperatorGroupProvidedAPIsAnnotationKey, "c1.v1.g1")},
+				clientObjs: []runtime.Object{addAnnotation(defaultOperatorGroup, operatorsv1.OperatorGroupProvidedAPIsAnnotationKey, "c1.v1.g1")},
 				objs: []runtime.Object{
 					deployment("a1", namespace, "sa", defaultTemplateAnnotations),
 				},
@@ -1361,7 +1361,7 @@ func TestTransitionCSV(t *testing.T) {
 						v1alpha1.CSVPhasePending,
 					), defaultTemplateAnnotations),
 				},
-				clientObjs: []runtime.Object{addAnnotation(defaultOperatorGroup, v1.OperatorGroupProvidedAPIsAnnotationKey, "c1.v1.g1")},
+				clientObjs: []runtime.Object{addAnnotation(defaultOperatorGroup, operatorsv1.OperatorGroupProvidedAPIsAnnotationKey, "c1.v1.g1")},
 				crds: []runtime.Object{
 					crd("c1", "v1", "g1"),
 				},
@@ -1409,7 +1409,7 @@ func TestTransitionCSV(t *testing.T) {
 						v1alpha1.CSVPhaseInstallReady,
 					), defaultTemplateAnnotations),
 				},
-				clientObjs: []runtime.Object{addAnnotation(defaultOperatorGroup, v1.OperatorGroupProvidedAPIsAnnotationKey, "c1.v1.g1")},
+				clientObjs: []runtime.Object{addAnnotation(defaultOperatorGroup, operatorsv1.OperatorGroupProvidedAPIsAnnotationKey, "c1.v1.g1")},
 				crds: []runtime.Object{
 					crd("c1", "v1", "g1"),
 				},
@@ -1434,7 +1434,7 @@ func TestTransitionCSV(t *testing.T) {
 						v1alpha1.CSVPhaseInstallReady,
 					), defaultTemplateAnnotations), apis("a1.v1.a1Kind"), nil),
 				},
-				clientObjs: []runtime.Object{addAnnotation(defaultOperatorGroup, v1.OperatorGroupProvidedAPIsAnnotationKey, "c1.v1.g1,a1Kind.v1.a1")},
+				clientObjs: []runtime.Object{addAnnotation(defaultOperatorGroup, operatorsv1.OperatorGroupProvidedAPIsAnnotationKey, "c1.v1.g1,a1Kind.v1.a1")},
 				crds: []runtime.Object{
 					crd("c1", "v1", "g1"),
 				},
@@ -2172,17 +2172,17 @@ func TestTransitionCSV(t *testing.T) {
 				},
 				clientObjs: []runtime.Object{
 					defaultOperatorGroup,
-					&v1.OperatorGroup{
+					&operatorsv1.OperatorGroup{
 						TypeMeta: metav1.TypeMeta{
 							Kind:       "OperatorGroup",
-							APIVersion: v1.SchemeGroupVersion.String(),
+							APIVersion: operatorsv1.SchemeGroupVersion.String(),
 						},
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "default-2",
 							Namespace: namespace,
 						},
-						Spec: v1.OperatorGroupSpec{},
-						Status: v1.OperatorGroupStatus{
+						Spec: operatorsv1.OperatorGroupSpec{},
+						Status: operatorsv1.OperatorGroupStatus{
 							Namespaces: []string{namespace},
 						},
 					},
@@ -2220,17 +2220,17 @@ func TestTransitionCSV(t *testing.T) {
 					), defaultTemplateAnnotations), v1alpha1.CSVReasonInstallSuccessful),
 				},
 				clientObjs: []runtime.Object{
-					&v1.OperatorGroup{
+					&operatorsv1.OperatorGroup{
 						TypeMeta: metav1.TypeMeta{
 							Kind:       "OperatorGroup",
-							APIVersion: v1.SchemeGroupVersion.String(),
+							APIVersion: operatorsv1.SchemeGroupVersion.String(),
 						},
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "default",
 							Namespace: namespace,
 						},
-						Spec: v1.OperatorGroupSpec{},
-						Status: v1.OperatorGroupStatus{
+						Spec: operatorsv1.OperatorGroupSpec{},
+						Status: operatorsv1.OperatorGroupStatus{
 							Namespaces: []string{namespace, "new-namespace"},
 						},
 					},
@@ -2865,7 +2865,7 @@ func TestTransitionCSV(t *testing.T) {
 					), defaultTemplateAnnotations),
 				},
 				clientObjs: []runtime.Object{
-					func() *v1.OperatorGroup {
+					func() *operatorsv1.OperatorGroup {
 						// Make the default OperatorGroup static
 						static := defaultOperatorGroup.DeepCopy()
 						static.Spec.StaticProvidedAPIs = true
@@ -2895,7 +2895,7 @@ func TestTransitionCSV(t *testing.T) {
 					), defaultTemplateAnnotations),
 				},
 				clientObjs: []runtime.Object{
-					func() *v1.OperatorGroup {
+					func() *operatorsv1.OperatorGroup {
 						// Make the default OperatorGroup static
 						static := defaultOperatorGroup.DeepCopy()
 						static.Spec.StaticProvidedAPIs = true
@@ -2925,7 +2925,7 @@ func TestTransitionCSV(t *testing.T) {
 					), defaultTemplateAnnotations),
 				},
 				clientObjs: []runtime.Object{
-					func() *v1.OperatorGroup {
+					func() *operatorsv1.OperatorGroup {
 						// Make the default OperatorGroup static
 						static := defaultOperatorGroup.DeepCopy()
 						static.Spec.StaticProvidedAPIs = true
@@ -2978,7 +2978,7 @@ func TestTransitionCSV(t *testing.T) {
 					), v1alpha1.CSVReasonCannotModifyStaticOperatorGroupProvidedAPIs), defaultTemplateAnnotations),
 				},
 				clientObjs: []runtime.Object{
-					func() *v1.OperatorGroup {
+					func() *operatorsv1.OperatorGroup {
 						// Make the default OperatorGroup static
 						static := defaultOperatorGroup.DeepCopy()
 						static.Spec.StaticProvidedAPIs = true
@@ -3031,7 +3031,7 @@ func TestTransitionCSV(t *testing.T) {
 					), v1alpha1.CSVReasonCannotModifyStaticOperatorGroupProvidedAPIs), defaultTemplateAnnotations),
 				},
 				clientObjs: []runtime.Object{
-					func() *v1.OperatorGroup {
+					func() *operatorsv1.OperatorGroup {
 						// Make the default OperatorGroup static
 						static := defaultOperatorGroup.DeepCopy()
 						static.Spec.StaticProvidedAPIs = true
@@ -3061,7 +3061,7 @@ func TestTransitionCSV(t *testing.T) {
 					), v1alpha1.CSVReasonCannotModifyStaticOperatorGroupProvidedAPIs), defaultTemplateAnnotations),
 				},
 				clientObjs: []runtime.Object{
-					func() *v1.OperatorGroup {
+					func() *operatorsv1.OperatorGroup {
 						// Make the default OperatorGroup static
 						static := defaultOperatorGroup.DeepCopy()
 						static.Spec.StaticProvidedAPIs = true
@@ -3367,26 +3367,26 @@ func TestWebhookCABundleRetrieval(t *testing.T) {
 func TestUpdates(t *testing.T) {
 	// A - replacedby -> B - replacedby -> C
 	namespace := "ns"
-	defaultOperatorGroup := &v1.OperatorGroup{
+	defaultOperatorGroup := &operatorsv1.OperatorGroup{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "OperatorGroup",
-			APIVersion: v1.SchemeGroupVersion.String(),
+			APIVersion: operatorsv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "default",
 			Namespace: namespace,
 		},
-		Spec: v1.OperatorGroupSpec{
+		Spec: operatorsv1.OperatorGroupSpec{
 			TargetNamespaces: []string{namespace},
 		},
-		Status: v1.OperatorGroupStatus{
+		Status: operatorsv1.OperatorGroupStatus{
 			Namespaces: []string{namespace},
 		},
 	}
 	defaultTemplateAnnotations := map[string]string{
-		v1.OperatorGroupTargetsAnnotationKey:   namespace,
-		v1.OperatorGroupNamespaceAnnotationKey: namespace,
-		v1.OperatorGroupAnnotationKey:          defaultOperatorGroup.GetName(),
+		operatorsv1.OperatorGroupTargetsAnnotationKey:   namespace,
+		operatorsv1.OperatorGroupNamespaceAnnotationKey: namespace,
+		operatorsv1.OperatorGroupAnnotationKey:          defaultOperatorGroup.GetName(),
 	}
 	runningOperator := []runtime.Object{
 		withLabels(
@@ -3815,7 +3815,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 	})
 
 	annotatedDeployment := ownedDeployment.DeepCopy()
-	annotatedDeployment.Spec.Template.SetAnnotations(map[string]string{v1.OperatorGroupTargetsAnnotationKey: operatorNamespace + "," + targetNamespace, v1.OperatorGroupAnnotationKey: "operator-group-1", v1.OperatorGroupNamespaceAnnotationKey: operatorNamespace})
+	annotatedDeployment.Spec.Template.SetAnnotations(map[string]string{operatorsv1.OperatorGroupTargetsAnnotationKey: operatorNamespace + "," + targetNamespace, operatorsv1.OperatorGroupAnnotationKey: "operator-group-1", operatorsv1.OperatorGroupNamespaceAnnotationKey: operatorNamespace})
 	annotatedDeployment.SetLabels(map[string]string{
 		"olm.owner":                        "csv1",
 		"olm.owner.namespace":              "operator-ns",
@@ -3824,7 +3824,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 	})
 
 	annotatedGlobalDeployment := ownedDeployment.DeepCopy()
-	annotatedGlobalDeployment.Spec.Template.SetAnnotations(map[string]string{v1.OperatorGroupTargetsAnnotationKey: "", v1.OperatorGroupAnnotationKey: "operator-group-1", v1.OperatorGroupNamespaceAnnotationKey: operatorNamespace})
+	annotatedGlobalDeployment.Spec.Template.SetAnnotations(map[string]string{operatorsv1.OperatorGroupTargetsAnnotationKey: "", operatorsv1.OperatorGroupAnnotationKey: "operator-group-1", operatorsv1.OperatorGroupNamespaceAnnotationKey: operatorNamespace})
 	annotatedGlobalDeployment.SetLabels(map[string]string{
 		"olm.owner":                        "csv1",
 		"olm.owner.namespace":              "operator-ns",
@@ -3873,7 +3873,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 	}
 
 	type initial struct {
-		operatorGroup *v1.OperatorGroup
+		operatorGroup *operatorsv1.OperatorGroup
 		clientObjs    []runtime.Object
 		crds          []runtime.Object
 		k8sObjs       []runtime.Object
@@ -3886,7 +3886,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 		initial         initial
 		name            string
 		expectedEqual   bool
-		expectedStatus  v1.OperatorGroupStatus
+		expectedStatus  operatorsv1.OperatorGroupStatus
 		final           final
 		ignoreCopyError bool
 	}{
@@ -3894,12 +3894,12 @@ func TestSyncOperatorGroups(t *testing.T) {
 			name:          "NoMatchingNamespace/NoCSVs",
 			expectedEqual: true,
 			initial: initial{
-				operatorGroup: &v1.OperatorGroup{
+				operatorGroup: &operatorsv1.OperatorGroup{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "operator-group-1",
 						Namespace: operatorNamespace,
 					},
-					Spec: v1.OperatorGroupSpec{
+					Spec: operatorsv1.OperatorGroupSpec{
 						Selector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{"a": "app-a"},
 						},
@@ -3918,18 +3918,18 @@ func TestSyncOperatorGroups(t *testing.T) {
 					},
 				},
 			},
-			expectedStatus: v1.OperatorGroupStatus{},
+			expectedStatus: operatorsv1.OperatorGroupStatus{},
 		},
 		{
 			name:          "NoMatchingNamespace/CSVPresent",
 			expectedEqual: true,
 			initial: initial{
-				operatorGroup: &v1.OperatorGroup{
+				operatorGroup: &operatorsv1.OperatorGroup{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "operator-group-1",
 						Namespace: operatorNamespace,
 					},
-					Spec: v1.OperatorGroupSpec{
+					Spec: operatorsv1.OperatorGroupSpec{
 						Selector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{"a": "app-a"},
 						},
@@ -3954,10 +3954,10 @@ func TestSyncOperatorGroups(t *testing.T) {
 				},
 				crds: []runtime.Object{crd},
 			},
-			expectedStatus: v1.OperatorGroupStatus{},
+			expectedStatus: operatorsv1.OperatorGroupStatus{},
 			final: final{objects: map[string][]runtime.Object{
 				operatorNamespace: {
-					withAnnotations(operatorCSVFailedNoTargetNS.DeepCopy(), map[string]string{v1.OperatorGroupAnnotationKey: "operator-group-1", v1.OperatorGroupNamespaceAnnotationKey: operatorNamespace}),
+					withAnnotations(operatorCSVFailedNoTargetNS.DeepCopy(), map[string]string{operatorsv1.OperatorGroupAnnotationKey: "operator-group-1", operatorsv1.OperatorGroupNamespaceAnnotationKey: operatorNamespace}),
 				},
 			}},
 			ignoreCopyError: true,
@@ -3966,12 +3966,12 @@ func TestSyncOperatorGroups(t *testing.T) {
 			name:          "MatchingNamespace/NoCSVs",
 			expectedEqual: true,
 			initial: initial{
-				operatorGroup: &v1.OperatorGroup{
+				operatorGroup: &operatorsv1.OperatorGroup{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "operator-group-1",
 						Namespace: operatorNamespace,
 					},
-					Spec: v1.OperatorGroupSpec{
+					Spec: operatorsv1.OperatorGroupSpec{
 						Selector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{"app": "app-a"},
 						},
@@ -3991,7 +3991,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 					},
 				},
 			},
-			expectedStatus: v1.OperatorGroupStatus{
+			expectedStatus: operatorsv1.OperatorGroupStatus{
 				Namespaces:  []string{targetNamespace},
 				LastUpdated: &now,
 			},
@@ -4000,12 +4000,12 @@ func TestSyncOperatorGroups(t *testing.T) {
 			name:          "MatchingNamespace/CSVPresent/Found",
 			expectedEqual: true,
 			initial: initial{
-				operatorGroup: &v1.OperatorGroup{
+				operatorGroup: &operatorsv1.OperatorGroup{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "operator-group-1",
 						Namespace: operatorNamespace,
 					},
-					Spec: v1.OperatorGroupSpec{
+					Spec: operatorsv1.OperatorGroupSpec{
 						Selector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{"app": "app-a"},
 						},
@@ -4032,18 +4032,18 @@ func TestSyncOperatorGroups(t *testing.T) {
 				},
 				crds: []runtime.Object{crd},
 			},
-			expectedStatus: v1.OperatorGroupStatus{
+			expectedStatus: operatorsv1.OperatorGroupStatus{
 				Namespaces:  []string{operatorNamespace, targetNamespace},
 				LastUpdated: &now,
 			},
 			final: final{objects: map[string][]runtime.Object{
 				operatorNamespace: {
-					withAnnotations(operatorCSVFinal.DeepCopy(), map[string]string{v1.OperatorGroupTargetsAnnotationKey: operatorNamespace + "," + targetNamespace, v1.OperatorGroupAnnotationKey: "operator-group-1", v1.OperatorGroupNamespaceAnnotationKey: operatorNamespace}),
+					withAnnotations(operatorCSVFinal.DeepCopy(), map[string]string{operatorsv1.OperatorGroupTargetsAnnotationKey: operatorNamespace + "," + targetNamespace, operatorsv1.OperatorGroupAnnotationKey: "operator-group-1", operatorsv1.OperatorGroupNamespaceAnnotationKey: operatorNamespace}),
 					annotatedDeployment,
 				},
 				targetNamespace: {
 					withLabels(
-						withAnnotations(targetCSV.DeepCopy(), map[string]string{v1.OperatorGroupAnnotationKey: "operator-group-1", v1.OperatorGroupNamespaceAnnotationKey: operatorNamespace}),
+						withAnnotations(targetCSV.DeepCopy(), map[string]string{operatorsv1.OperatorGroupAnnotationKey: "operator-group-1", operatorsv1.OperatorGroupNamespaceAnnotationKey: operatorNamespace}),
 						labels.Merge(targetCSV.GetLabels(), map[string]string{v1alpha1.CopiedLabelKey: operatorNamespace}),
 					),
 					&rbacv1.Role{
@@ -4106,12 +4106,12 @@ func TestSyncOperatorGroups(t *testing.T) {
 			name:          "MatchingNamespace/CSVPresent/Found/ExplicitTargetNamespaces",
 			expectedEqual: true,
 			initial: initial{
-				operatorGroup: &v1.OperatorGroup{
+				operatorGroup: &operatorsv1.OperatorGroup{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "operator-group-1",
 						Namespace: operatorNamespace,
 					},
-					Spec: v1.OperatorGroupSpec{
+					Spec: operatorsv1.OperatorGroupSpec{
 						TargetNamespaces: []string{operatorNamespace, targetNamespace},
 					},
 				},
@@ -4134,18 +4134,18 @@ func TestSyncOperatorGroups(t *testing.T) {
 				},
 				crds: []runtime.Object{crd},
 			},
-			expectedStatus: v1.OperatorGroupStatus{
+			expectedStatus: operatorsv1.OperatorGroupStatus{
 				Namespaces:  []string{operatorNamespace, targetNamespace},
 				LastUpdated: &now,
 			},
 			final: final{objects: map[string][]runtime.Object{
 				operatorNamespace: {
-					withAnnotations(operatorCSVFinal.DeepCopy(), map[string]string{v1.OperatorGroupTargetsAnnotationKey: operatorNamespace + "," + targetNamespace, v1.OperatorGroupAnnotationKey: "operator-group-1", v1.OperatorGroupNamespaceAnnotationKey: operatorNamespace}),
+					withAnnotations(operatorCSVFinal.DeepCopy(), map[string]string{operatorsv1.OperatorGroupTargetsAnnotationKey: operatorNamespace + "," + targetNamespace, operatorsv1.OperatorGroupAnnotationKey: "operator-group-1", operatorsv1.OperatorGroupNamespaceAnnotationKey: operatorNamespace}),
 					annotatedDeployment,
 				},
 				targetNamespace: {
 					withLabels(
-						withAnnotations(targetCSV.DeepCopy(), map[string]string{v1.OperatorGroupAnnotationKey: "operator-group-1", v1.OperatorGroupNamespaceAnnotationKey: operatorNamespace}),
+						withAnnotations(targetCSV.DeepCopy(), map[string]string{operatorsv1.OperatorGroupAnnotationKey: "operator-group-1", operatorsv1.OperatorGroupNamespaceAnnotationKey: operatorNamespace}),
 						labels.Merge(targetCSV.GetLabels(), map[string]string{v1alpha1.CopiedLabelKey: operatorNamespace}),
 					),
 					&rbacv1.Role{
@@ -4208,13 +4208,13 @@ func TestSyncOperatorGroups(t *testing.T) {
 			name:          "AllNamespaces/CSVPresent/Found",
 			expectedEqual: true,
 			initial: initial{
-				operatorGroup: &v1.OperatorGroup{
+				operatorGroup: &operatorsv1.OperatorGroup{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "operator-group-1",
 						Namespace: operatorNamespace,
 						Labels:    map[string]string{"app": "app-a"},
 					},
-					Spec: v1.OperatorGroupSpec{},
+					Spec: operatorsv1.OperatorGroupSpec{},
 				},
 				clientObjs: []runtime.Object{operatorCSV},
 				k8sObjs: []runtime.Object{
@@ -4239,13 +4239,13 @@ func TestSyncOperatorGroups(t *testing.T) {
 				},
 				crds: []runtime.Object{crd},
 			},
-			expectedStatus: v1.OperatorGroupStatus{
+			expectedStatus: operatorsv1.OperatorGroupStatus{
 				Namespaces:  []string{corev1.NamespaceAll},
 				LastUpdated: &now,
 			},
 			final: final{objects: map[string][]runtime.Object{
 				operatorNamespace: {
-					withAnnotations(operatorCSVFinal.DeepCopy(), map[string]string{v1.OperatorGroupTargetsAnnotationKey: "", v1.OperatorGroupAnnotationKey: "operator-group-1", v1.OperatorGroupNamespaceAnnotationKey: operatorNamespace}),
+					withAnnotations(operatorCSVFinal.DeepCopy(), map[string]string{operatorsv1.OperatorGroupTargetsAnnotationKey: "", operatorsv1.OperatorGroupAnnotationKey: "operator-group-1", operatorsv1.OperatorGroupNamespaceAnnotationKey: operatorNamespace}),
 					annotatedGlobalDeployment,
 				},
 				"": {
@@ -4297,7 +4297,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 				},
 				targetNamespace: {
 					withLabels(
-						withAnnotations(targetCSV.DeepCopy(), map[string]string{v1.OperatorGroupAnnotationKey: "operator-group-1", v1.OperatorGroupNamespaceAnnotationKey: operatorNamespace}),
+						withAnnotations(targetCSV.DeepCopy(), map[string]string{operatorsv1.OperatorGroupAnnotationKey: "operator-group-1", operatorsv1.OperatorGroupNamespaceAnnotationKey: operatorNamespace}),
 						labels.Merge(targetCSV.GetLabels(), map[string]string{v1alpha1.CopiedLabelKey: operatorNamespace}),
 					),
 				},
@@ -4307,20 +4307,20 @@ func TestSyncOperatorGroups(t *testing.T) {
 			name:          "AllNamespaces/CSVPresent/Found/PruneMissingProvidedAPI/StaticProvidedAPIs",
 			expectedEqual: true,
 			initial: initial{
-				operatorGroup: &v1.OperatorGroup{
+				operatorGroup: &operatorsv1.OperatorGroup{
 					TypeMeta: metav1.TypeMeta{
-						Kind:       v1.OperatorGroupKind,
-						APIVersion: v1.GroupVersion.String(),
+						Kind:       operatorsv1.OperatorGroupKind,
+						APIVersion: operatorsv1.GroupVersion.String(),
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "operator-group-1",
 						Namespace: operatorNamespace,
 						Labels:    map[string]string{"app": "app-a"},
 						Annotations: map[string]string{
-							v1.OperatorGroupProvidedAPIsAnnotationKey: "missing.fake.api.group",
+							operatorsv1.OperatorGroupProvidedAPIsAnnotationKey: "missing.fake.api.group",
 						},
 					},
-					Spec: v1.OperatorGroupSpec{
+					Spec: operatorsv1.OperatorGroupSpec{
 						StaticProvidedAPIs: true,
 					},
 				},
@@ -4334,29 +4334,29 @@ func TestSyncOperatorGroups(t *testing.T) {
 					},
 				},
 			},
-			expectedStatus: v1.OperatorGroupStatus{
+			expectedStatus: operatorsv1.OperatorGroupStatus{
 				Namespaces:  []string{corev1.NamespaceAll},
 				LastUpdated: &now,
 			},
 			final: final{objects: map[string][]runtime.Object{
 				operatorNamespace: {
-					&v1.OperatorGroup{
+					&operatorsv1.OperatorGroup{
 						TypeMeta: metav1.TypeMeta{
-							Kind:       v1.OperatorGroupKind,
-							APIVersion: v1.GroupVersion.String(),
+							Kind:       operatorsv1.OperatorGroupKind,
+							APIVersion: operatorsv1.GroupVersion.String(),
 						},
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "operator-group-1",
 							Namespace: operatorNamespace,
 							Labels:    map[string]string{"app": "app-a"},
 							Annotations: map[string]string{
-								v1.OperatorGroupProvidedAPIsAnnotationKey: "missing.fake.api.group",
+								operatorsv1.OperatorGroupProvidedAPIsAnnotationKey: "missing.fake.api.group",
 							},
 						},
-						Spec: v1.OperatorGroupSpec{
+						Spec: operatorsv1.OperatorGroupSpec{
 							StaticProvidedAPIs: true,
 						},
-						Status: v1.OperatorGroupStatus{
+						Status: operatorsv1.OperatorGroupStatus{
 							Namespaces:  []string{corev1.NamespaceAll},
 							LastUpdated: &now,
 						},
@@ -4368,12 +4368,12 @@ func TestSyncOperatorGroups(t *testing.T) {
 			name:          "AllNamespaces/CSVPresent/InstallModeNotSupported",
 			expectedEqual: true,
 			initial: initial{
-				operatorGroup: &v1.OperatorGroup{
+				operatorGroup: &operatorsv1.OperatorGroup{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "operator-group-1",
 						Namespace: operatorNamespace,
 					},
-					Spec: v1.OperatorGroupSpec{},
+					Spec: operatorsv1.OperatorGroupSpec{},
 				},
 				clientObjs: []runtime.Object{
 					withInstallModes(operatorCSV.DeepCopy(), []v1alpha1.InstallMode{
@@ -4403,7 +4403,7 @@ func TestSyncOperatorGroups(t *testing.T) {
 				},
 				crds: []runtime.Object{crd},
 			},
-			expectedStatus: v1.OperatorGroupStatus{
+			expectedStatus: operatorsv1.OperatorGroupStatus{
 				Namespaces:  []string{corev1.NamespaceAll},
 				LastUpdated: &now,
 			},
@@ -4412,9 +4412,9 @@ func TestSyncOperatorGroups(t *testing.T) {
 					withPhase(
 						withInstallModes(
 							withAnnotations(operatorCSV.DeepCopy(), map[string]string{
-								v1.OperatorGroupTargetsAnnotationKey:   "",
-								v1.OperatorGroupAnnotationKey:          "operator-group-1",
-								v1.OperatorGroupNamespaceAnnotationKey: operatorNamespace,
+								operatorsv1.OperatorGroupTargetsAnnotationKey:   "",
+								operatorsv1.OperatorGroupAnnotationKey:          "operator-group-1",
+								operatorsv1.OperatorGroupNamespaceAnnotationKey: operatorNamespace,
 							}).(*v1alpha1.ClusterServiceVersion),
 							[]v1alpha1.InstallMode{
 								{
@@ -4594,7 +4594,7 @@ func TestOperatorGroupConditions(t *testing.T) {
 	serviceAccount := serviceAccount("sa", operatorNamespace)
 
 	type initial struct {
-		operatorGroup *v1.OperatorGroup
+		operatorGroup *operatorsv1.OperatorGroup
 		clientObjs    []runtime.Object
 		k8sObjs       []runtime.Object
 	}
@@ -4608,13 +4608,13 @@ func TestOperatorGroupConditions(t *testing.T) {
 		{
 			name: "ValidOperatorGroup/NoServiceAccount",
 			initial: initial{
-				operatorGroup: &v1.OperatorGroup{
+				operatorGroup: &operatorsv1.OperatorGroup{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "operator-group-1",
 						Namespace: operatorNamespace,
 						UID:       "135e02a5-a7e2-44e7-abaa-88c63838993c",
 					},
-					Spec: v1.OperatorGroupSpec{
+					Spec: operatorsv1.OperatorGroupSpec{
 						TargetNamespaces: []string{operatorNamespace},
 					},
 				},
@@ -4632,13 +4632,13 @@ func TestOperatorGroupConditions(t *testing.T) {
 		{
 			name: "ValidOperatorGroup/ValidServiceAccount",
 			initial: initial{
-				operatorGroup: &v1.OperatorGroup{
+				operatorGroup: &operatorsv1.OperatorGroup{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "operator-group-1",
 						Namespace: operatorNamespace,
 						UID:       "135e02a5-a7e2-44e7-abaa-88c63838993c",
 					},
-					Spec: v1.OperatorGroupSpec{
+					Spec: operatorsv1.OperatorGroupSpec{
 						ServiceAccountName: "sa",
 						TargetNamespaces:   []string{operatorNamespace},
 					},
@@ -4658,13 +4658,13 @@ func TestOperatorGroupConditions(t *testing.T) {
 		{
 			name: "BadOperatorGroup/MissingServiceAccount",
 			initial: initial{
-				operatorGroup: &v1.OperatorGroup{
+				operatorGroup: &operatorsv1.OperatorGroup{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "operator-group-1",
 						Namespace: operatorNamespace,
 						UID:       "135e02a5-a7e2-44e7-abaa-88c63838993c",
 					},
-					Spec: v1.OperatorGroupSpec{
+					Spec: operatorsv1.OperatorGroupSpec{
 						ServiceAccountName: "nonexistingSA",
 						TargetNamespaces:   []string{operatorNamespace},
 					},
@@ -4680,9 +4680,9 @@ func TestOperatorGroupConditions(t *testing.T) {
 			expectError: true,
 			expectedConditions: []metav1.Condition{
 				{
-					Type:    v1.OperatorGroupServiceAccountCondition,
+					Type:    operatorsv1.OperatorGroupServiceAccountCondition,
 					Status:  metav1.ConditionTrue,
-					Reason:  v1.OperatorGroupServiceAccountReason,
+					Reason:  operatorsv1.OperatorGroupServiceAccountReason,
 					Message: "ServiceAccount nonexistingSA not found",
 				},
 			},
@@ -4690,24 +4690,24 @@ func TestOperatorGroupConditions(t *testing.T) {
 		{
 			name: "BadOperatorGroup/MultipleOperatorGroups",
 			initial: initial{
-				operatorGroup: &v1.OperatorGroup{
+				operatorGroup: &operatorsv1.OperatorGroup{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "operator-group-1",
 						Namespace: operatorNamespace,
 						UID:       "135e02a5-a7e2-44e7-abaa-88c63838993c",
 					},
-					Spec: v1.OperatorGroupSpec{
+					Spec: operatorsv1.OperatorGroupSpec{
 						TargetNamespaces: []string{operatorNamespace},
 					},
 				},
 				clientObjs: []runtime.Object{
-					&v1.OperatorGroup{
+					&operatorsv1.OperatorGroup{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "operator-group-2",
 							Namespace: operatorNamespace,
 							UID:       "cdc9643e-7c52-4f7c-ae75-28ccb6aec97d",
 						},
-						Spec: v1.OperatorGroupSpec{
+						Spec: operatorsv1.OperatorGroupSpec{
 							TargetNamespaces: []string{operatorNamespace, "some-namespace"},
 						},
 					},
@@ -4723,9 +4723,9 @@ func TestOperatorGroupConditions(t *testing.T) {
 			expectError: true,
 			expectedConditions: []metav1.Condition{
 				{
-					Type:    v1.MutlipleOperatorGroupCondition,
+					Type:    operatorsv1.MutlipleOperatorGroupCondition,
 					Status:  metav1.ConditionTrue,
-					Reason:  v1.MultipleOperatorGroupsReason,
+					Reason:  operatorsv1.MultipleOperatorGroupsReason,
 					Message: "Multiple OperatorGroup found in the same namespace",
 				},
 			},
@@ -4795,7 +4795,7 @@ func RequireObjectsInCache(t *testing.T, lister operatorlister.OperatorLister, n
 			fetched, err = lister.RbacV1().RoleBindingLister().RoleBindings(namespace).Get(o.GetName())
 		case *v1alpha1.ClusterServiceVersion:
 			fetched, err = lister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(namespace).Get(o.GetName())
-		case *v1.OperatorGroup:
+		case *operatorsv1.OperatorGroup:
 			fetched, err = lister.OperatorsV1().OperatorGroupLister().OperatorGroups(namespace).Get(o.GetName())
 		default:
 			require.Failf(t, "couldn't find expected object", "%#v", object)
@@ -4834,7 +4834,7 @@ func RequireObjectsInNamespace(t *testing.T, opClient operatorclient.ClientInter
 			// and this will still check that the final state is correct
 			object.(*v1alpha1.ClusterServiceVersion).Status.Conditions = nil
 			fetched.(*v1alpha1.ClusterServiceVersion).Status.Conditions = nil
-		case *v1.OperatorGroup:
+		case *operatorsv1.OperatorGroup:
 			fetched, err = client.OperatorsV1().OperatorGroups(namespace).Get(context.TODO(), o.GetName(), metav1.GetOptions{})
 		default:
 			require.Failf(t, "couldn't find expected object", "%#v", object)

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operator_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operator_test.go
@@ -95,6 +95,14 @@ func (i *TestInstaller) CheckInstalled(s install.Strategy) (bool, error) {
 	return true, nil
 }
 
+func (i *TestInstaller) CertsRotateAt() time.Time {
+	return time.Time{}
+}
+
+func (i *TestInstaller) CertsRotated() bool {
+	return false
+}
+
 func ownerLabelFromCSV(name, namespace string) map[string]string {
 	return map[string]string{
 		ownerutil.OwnerKey:          name,
@@ -4864,9 +4872,6 @@ func TestCARotation(t *testing.T) {
 	logrus.SetLevel(logrus.DebugLevel)
 	namespace := "ns"
 
-	//apiHash, err := resolvercache.APIKeyToGVKHash(opregistry.APIKey{Group: "g1", Version: "v1", Kind: "c1"})
-	//require.NoError(t, err)
-
 	defaultOperatorGroup := &operatorsv1.OperatorGroup{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "OperatorGroup",
@@ -4889,9 +4894,8 @@ func TestCARotation(t *testing.T) {
 	}
 
 	// Generate valid and expired CA fixtures
-	expirationTime, rotationTime := install.CalculateCertExpirationAndRotateAt()
-	expiresAt := metav1.Time{Time: expirationTime}
-	rotateAt := metav1.Time{Time: rotationTime}
+	expiresAt := metav1.NewTime(install.CalculateCertExpiration(time.Now()))
+	rotateAt := metav1.NewTime(install.CalculateCertRotatesAt(expiresAt.Time))
 
 	lastUpdate := metav1.Time{Time: time.Now().UTC()}
 
@@ -5110,18 +5114,17 @@ func TestCARotation(t *testing.T) {
 					require.NoError(t, err)
 					require.NotNil(t, serviceSecret)
 
-					// Extract certificate
+					// Extract certificate validity period
 					start, end, err := GetServiceCertificaValidityPeriod(serviceSecret)
 					require.NoError(t, err)
 					require.NotNil(t, start)
 					require.NotNil(t, end)
 
-					// Compare csv status timestamps with certificate timestamps
-					// NOTE: These values (csv.Status.Certs* and the certificate expiry and rotation are calculated
-					// with the same method but independently, therefore a second granularity will need to suffice.
-					// See https://github.com/operator-framework/operator-lifecycle-manager/issues/2764 for more info.
 					rotationTime := end.Add(-1 * install.DefaultCertMinFresh)
-					require.Equal(t, start.Unix(), outCSV.Status.CertsLastUpdated.Unix())
+					// The csv status is updated after the certificate is created/rotated
+					require.LessOrEqual(t, start.Unix(), outCSV.Status.CertsLastUpdated.Unix())
+
+					// Rotation time should always be the same between the certificate and the status
 					require.Equal(t, rotationTime.Unix(), outCSV.Status.CertsRotateAt.Unix())
 				}
 			}

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operatorconditions.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operatorconditions.go
@@ -3,7 +3,7 @@ package olm
 import (
 	"fmt"
 
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -19,7 +19,7 @@ func (a *Operator) isOperatorUpgradeable(csv *v1alpha1.ClusterServiceVersion) (b
 
 	cond, err := a.lister.OperatorsV2().OperatorConditionLister().OperatorConditions(csv.GetNamespace()).Get(csv.GetName())
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return true, nil
 		}
 		return false, err

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operatorgroup.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operatorgroup.go
@@ -7,17 +7,17 @@ import (
 	"reflect"
 	"strings"
 
-	v1 "github.com/operator-framework/api/pkg/operators/v1"
 	utillabels "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/util/labels"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/errors"
 
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/decorators"
@@ -54,7 +54,7 @@ func aggregationLabelFromAPIKey(k opregistry.APIKey, suffix string) (string, err
 }
 
 func (a *Operator) syncOperatorGroups(obj interface{}) error {
-	op, ok := obj.(*v1.OperatorGroup)
+	op, ok := obj.(*operatorsv1.OperatorGroup)
 	if !ok {
 		a.logger.Debugf("wrong type: %#v\n", obj)
 		return fmt.Errorf("casting OperatorGroup failed")
@@ -74,10 +74,10 @@ func (a *Operator) syncOperatorGroups(obj interface{}) error {
 	// Check if there is a stale multiple OG condition and clear it if existed.
 	if len(groups) == 1 {
 		og := groups[0].DeepCopy()
-		if c := meta.FindStatusCondition(og.Status.Conditions, v1.MutlipleOperatorGroupCondition); c != nil {
-			meta.RemoveStatusCondition(&og.Status.Conditions, v1.MutlipleOperatorGroupCondition)
+		if c := meta.FindStatusCondition(og.Status.Conditions, operatorsv1.MutlipleOperatorGroupCondition); c != nil {
+			meta.RemoveStatusCondition(&og.Status.Conditions, operatorsv1.MutlipleOperatorGroupCondition)
 			if og.GetName() == op.GetName() {
-				meta.RemoveStatusCondition(&op.Status.Conditions, v1.MutlipleOperatorGroupCondition)
+				meta.RemoveStatusCondition(&op.Status.Conditions, operatorsv1.MutlipleOperatorGroupCondition)
 			}
 			_, err = a.client.OperatorsV1().OperatorGroups(op.GetNamespace()).UpdateStatus(context.TODO(), og, metav1.UpdateOptions{})
 			if err != nil {
@@ -88,14 +88,14 @@ func (a *Operator) syncOperatorGroups(obj interface{}) error {
 		// Add to all OG's status conditions to indicate they're multiple OGs in the
 		// same namespace which is not allowed.
 		cond := metav1.Condition{
-			Type:    v1.MutlipleOperatorGroupCondition,
+			Type:    operatorsv1.MutlipleOperatorGroupCondition,
 			Status:  metav1.ConditionTrue,
-			Reason:  v1.MultipleOperatorGroupsReason,
+			Reason:  operatorsv1.MultipleOperatorGroupsReason,
 			Message: "Multiple OperatorGroup found in the same namespace",
 		}
 		for i := range groups {
 			og := groups[i].DeepCopy()
-			if c := meta.FindStatusCondition(og.Status.Conditions, v1.MutlipleOperatorGroupCondition); c != nil {
+			if c := meta.FindStatusCondition(og.Status.Conditions, operatorsv1.MutlipleOperatorGroupCondition); c != nil {
 				continue
 			}
 			meta.SetStatusCondition(&og.Status.Conditions, cond)
@@ -122,7 +122,7 @@ func (a *Operator) syncOperatorGroups(obj interface{}) error {
 		}
 		for i := range csvList {
 			csv := csvList[i].DeepCopy()
-			if group, ok := csv.GetAnnotations()[v1.OperatorGroupAnnotationKey]; !ok || group != op.GetName() {
+			if group, ok := csv.GetAnnotations()[operatorsv1.OperatorGroupAnnotationKey]; !ok || group != op.GetName() {
 				continue
 			}
 			if csv.Status.Reason == v1alpha1.CSVReasonComponentFailedNoRetry {
@@ -152,13 +152,13 @@ func (a *Operator) syncOperatorGroups(obj interface{}) error {
 
 		// Update operatorgroup target namespace selection
 		logger.WithField("targets", targetNamespaces).Debug("namespace change detected")
-		op.Status = v1.OperatorGroupStatus{
+		op.Status = operatorsv1.OperatorGroupStatus{
 			Namespaces:  targetNamespaces,
 			LastUpdated: a.now(),
 			Conditions:  op.Status.Conditions,
 		}
 
-		if _, err = a.client.OperatorsV1().OperatorGroups(op.GetNamespace()).UpdateStatus(context.TODO(), op, metav1.UpdateOptions{}); err != nil && !k8serrors.IsNotFound(err) {
+		if _, err = a.client.OperatorsV1().OperatorGroups(op.GetNamespace()).UpdateStatus(context.TODO(), op, metav1.UpdateOptions{}); err != nil && !apierrors.IsNotFound(err) {
 			logger.WithError(err).Warn("operatorgroup update failed")
 			return err
 		}
@@ -223,7 +223,7 @@ func (a *Operator) syncOperatorGroups(obj interface{}) error {
 }
 
 func (a *Operator) operatorGroupDeleted(obj interface{}) {
-	op, ok := obj.(*v1.OperatorGroup)
+	op, ok := obj.(*operatorsv1.OperatorGroup)
 	if !ok {
 		a.logger.Debugf("casting OperatorGroup failed, wrong type: %#v\n", obj)
 		return
@@ -254,7 +254,7 @@ func (a *Operator) operatorGroupDeleted(obj interface{}) {
 	}
 }
 
-func (a *Operator) annotateCSVs(group *v1.OperatorGroup, targetNamespaces []string, logger *logrus.Entry) error {
+func (a *Operator) annotateCSVs(group *operatorsv1.OperatorGroup, targetNamespaces []string, logger *logrus.Entry) error {
 	updateErrs := []error{}
 	targetNamespaceSet := NewNamespaceSet(targetNamespaces)
 
@@ -264,13 +264,13 @@ func (a *Operator) annotateCSVs(group *v1.OperatorGroup, targetNamespaces []stri
 		}
 		logger := logger.WithField("csv", csv.GetName())
 
-		originalNamespacesAnnotation, _ := a.copyOperatorGroupAnnotations(&csv.ObjectMeta)[v1.OperatorGroupTargetsAnnotationKey]
+		originalNamespacesAnnotation, _ := a.copyOperatorGroupAnnotations(&csv.ObjectMeta)[operatorsv1.OperatorGroupTargetsAnnotationKey]
 		originalNamespaceSet := NewNamespaceSetFromString(originalNamespacesAnnotation)
 
 		if a.operatorGroupAnnotationsDiffer(&csv.ObjectMeta, group) {
 			a.setOperatorGroupAnnotations(&csv.ObjectMeta, group, true)
 			// CRDs don't support strategic merge patching, but in the future if they do this should be updated to patch
-			if _, err := a.client.OperatorsV1alpha1().ClusterServiceVersions(csv.GetNamespace()).Update(context.TODO(), csv, metav1.UpdateOptions{}); err != nil && !k8serrors.IsNotFound(err) {
+			if _, err := a.client.OperatorsV1alpha1().ClusterServiceVersions(csv.GetNamespace()).Update(context.TODO(), csv, metav1.UpdateOptions{}); err != nil && !apierrors.IsNotFound(err) {
 				logger.WithError(err).Warnf("error adding operatorgroup annotations")
 				updateErrs = append(updateErrs, err)
 				continue
@@ -298,7 +298,7 @@ func (a *Operator) annotateCSVs(group *v1.OperatorGroup, targetNamespaces []stri
 	return errors.NewAggregate(updateErrs)
 }
 
-func (a *Operator) providedAPIsFromCSVs(group *v1.OperatorGroup, logger *logrus.Entry) map[opregistry.APIKey]*v1alpha1.ClusterServiceVersion {
+func (a *Operator) providedAPIsFromCSVs(group *operatorsv1.OperatorGroup, logger *logrus.Entry) map[opregistry.APIKey]*v1alpha1.ClusterServiceVersion {
 	set := a.csvSet(group.Namespace, v1alpha1.CSVPhaseAny)
 	providedAPIsFromCSVs := make(map[opregistry.APIKey]*v1alpha1.ClusterServiceVersion)
 	for _, csv := range set {
@@ -323,7 +323,7 @@ func (a *Operator) providedAPIsFromCSVs(group *v1.OperatorGroup, logger *logrus.
 	return providedAPIsFromCSVs
 }
 
-func (a *Operator) pruneProvidedAPIs(group *v1.OperatorGroup, groupProvidedAPIs cache.APISet, providedAPIsFromCSVs map[opregistry.APIKey]*v1alpha1.ClusterServiceVersion, logger *logrus.Entry) {
+func (a *Operator) pruneProvidedAPIs(group *operatorsv1.OperatorGroup, groupProvidedAPIs cache.APISet, providedAPIsFromCSVs map[opregistry.APIKey]*v1alpha1.ClusterServiceVersion, logger *logrus.Entry) {
 	// Don't prune providedAPIsFromCSVs if static
 	if group.Spec.StaticProvidedAPIs {
 		a.logger.Debug("group has static provided apis. skipping provided api pruning")
@@ -337,7 +337,7 @@ func (a *Operator) pruneProvidedAPIs(group *v1.OperatorGroup, groupProvidedAPIs 
 		} else {
 			csv := providedAPIsFromCSVs[api]
 			_, err := a.lister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(csv.GetNamespace()).Get(csv.GetName())
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				continue
 			}
 			if csv.DeletionTimestamp == nil && (csv.Status.Phase == v1alpha1.CSVPhaseNone || csv.Status.Phase == v1alpha1.CSVPhasePending) {
@@ -360,10 +360,10 @@ func (a *Operator) pruneProvidedAPIs(group *v1.OperatorGroup, groupProvidedAPIs 
 
 		// Don't need to check for nil annotations since we already know |annotations| > 0
 		annotations := group.GetAnnotations()
-		annotations[v1.OperatorGroupProvidedAPIsAnnotationKey] = intersection.String()
+		annotations[operatorsv1.OperatorGroupProvidedAPIsAnnotationKey] = intersection.String()
 		group.SetAnnotations(annotations)
 		logger.Debug("removing provided apis from annotation to match cluster state")
-		if _, err := a.client.OperatorsV1().OperatorGroups(group.GetNamespace()).Update(context.TODO(), group, metav1.UpdateOptions{}); err != nil && !k8serrors.IsNotFound(err) {
+		if _, err := a.client.OperatorsV1().OperatorGroups(group.GetNamespace()).Update(context.TODO(), group, metav1.UpdateOptions{}); err != nil && !apierrors.IsNotFound(err) {
 			logger.WithError(err).Warn("could not update provided api annotations")
 		}
 	}
@@ -391,12 +391,15 @@ func (a *Operator) ensureProvidedAPIClusterRole(namePrefix, suffix string, verbs
 	}
 
 	existingCR, err := a.lister.RbacV1().ClusterRoleLister().Get(clusterRole.Name)
-	if existingCR == nil {
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	if apierrors.IsNotFound(err) {
 		existingCR, err = a.opClient.KubernetesInterface().RbacV1().ClusterRoles().Create(context.TODO(), clusterRole, metav1.CreateOptions{})
 		if err == nil {
 			return nil
 		}
-		if !k8serrors.IsAlreadyExists(err) {
+		if !apierrors.IsAlreadyExists(err) {
 			a.logger.WithError(err).Errorf("Create cluster role failed: %v", clusterRole)
 			return err
 		}
@@ -454,7 +457,7 @@ func (a *Operator) ensureClusterRolesForCSV(csv *v1alpha1.ClusterServiceVersion)
 	return nil
 }
 
-func (a *Operator) ensureRBACInTargetNamespace(csv *v1alpha1.ClusterServiceVersion, operatorGroup *v1.OperatorGroup) error {
+func (a *Operator) ensureRBACInTargetNamespace(csv *v1alpha1.ClusterServiceVersion, operatorGroup *operatorsv1.OperatorGroup) error {
 	targetNamespaces := operatorGroup.Status.Namespaces
 	if targetNamespaces == nil {
 		return nil
@@ -535,7 +538,7 @@ func (a *Operator) ensureSingletonRBAC(operatorNamespace string, csv *v1alpha1.C
 			// TODO: this should do something smarter if the cluster role already exists
 			if cr, err := a.opClient.CreateClusterRole(clusterRole); err != nil {
 				// If the CR already exists, but the label is correct, the cache is just behind
-				if k8serrors.IsAlreadyExists(err) && cr != nil && ownerutil.IsOwnedByLabel(cr, csv) {
+				if apierrors.IsAlreadyExists(err) && cr != nil && ownerutil.IsOwnedByLabel(cr, csv) {
 					continue
 				}
 				return err
@@ -574,7 +577,7 @@ func (a *Operator) ensureSingletonRBAC(operatorNamespace string, csv *v1alpha1.C
 			// TODO: this should do something smarter if the cluster role binding already exists
 			if crb, err := a.opClient.CreateClusterRoleBinding(clusterRoleBinding); err != nil {
 				// If the CRB already exists, but the label is correct, the cache is just behind
-				if k8serrors.IsAlreadyExists(err) && crb != nil && ownerutil.IsOwnedByLabel(crb, csv) {
+				if apierrors.IsAlreadyExists(err) && crb != nil && ownerutil.IsOwnedByLabel(crb, csv) {
 					continue
 				}
 				return err
@@ -688,7 +691,7 @@ func (a *Operator) ensureTenantRBAC(operatorNamespace, targetNamespace string, c
 	return nil
 }
 
-func (a *Operator) ensureCSVsInNamespaces(csv *v1alpha1.ClusterServiceVersion, operatorGroup *v1.OperatorGroup, targets NamespaceSet) error {
+func (a *Operator) ensureCSVsInNamespaces(csv *v1alpha1.ClusterServiceVersion, operatorGroup *operatorsv1.OperatorGroup, targets NamespaceSet) error {
 	namespaces, err := a.lister.CoreV1().NamespaceLister().List(labels.Everything())
 	if err != nil {
 		return err
@@ -798,8 +801,8 @@ func (a *Operator) copyToNamespace(prototype *v1alpha1.ClusterServiceVersion, ns
 	prototype.UID = ""
 
 	existing, err := a.copiedCSVLister.ClusterServiceVersions(nsTo).Get(prototype.GetName())
-	if k8serrors.IsNotFound(err) {
 
+	if apierrors.IsNotFound(err) {
 		created, err := a.client.OperatorsV1alpha1().ClusterServiceVersions(nsTo).Create(context.TODO(), prototype, metav1.CreateOptions{})
 		if err != nil {
 			return nil, err
@@ -856,7 +859,7 @@ func (a *Operator) pruneFromNamespace(operatorGroupName, namespace string) error
 	}
 
 	for _, csv := range fetchedCSVs {
-		if csv.IsCopied() && csv.GetAnnotations()[v1.OperatorGroupAnnotationKey] == operatorGroupName {
+		if csv.IsCopied() && csv.GetAnnotations()[operatorsv1.OperatorGroupAnnotationKey] == operatorGroupName {
 			a.logger.Debugf("Found CSV '%v' in namespace %v to delete", csv.GetName(), namespace)
 			if err := a.copiedCSVGCQueueSet.Requeue(csv.GetNamespace(), csv.GetName()); err != nil {
 				return err
@@ -866,36 +869,36 @@ func (a *Operator) pruneFromNamespace(operatorGroupName, namespace string) error
 	return nil
 }
 
-func (a *Operator) setOperatorGroupAnnotations(obj *metav1.ObjectMeta, op *v1.OperatorGroup, addTargets bool) {
-	metav1.SetMetaDataAnnotation(obj, v1.OperatorGroupNamespaceAnnotationKey, op.GetNamespace())
-	metav1.SetMetaDataAnnotation(obj, v1.OperatorGroupAnnotationKey, op.GetName())
+func (a *Operator) setOperatorGroupAnnotations(obj *metav1.ObjectMeta, op *operatorsv1.OperatorGroup, addTargets bool) {
+	metav1.SetMetaDataAnnotation(obj, operatorsv1.OperatorGroupNamespaceAnnotationKey, op.GetNamespace())
+	metav1.SetMetaDataAnnotation(obj, operatorsv1.OperatorGroupAnnotationKey, op.GetName())
 
 	if addTargets && op.Status.Namespaces != nil {
-		metav1.SetMetaDataAnnotation(obj, v1.OperatorGroupTargetsAnnotationKey, op.BuildTargetNamespaces())
+		metav1.SetMetaDataAnnotation(obj, operatorsv1.OperatorGroupTargetsAnnotationKey, op.BuildTargetNamespaces())
 	}
 }
 
-func (a *Operator) operatorGroupAnnotationsDiffer(obj *metav1.ObjectMeta, op *v1.OperatorGroup) bool {
+func (a *Operator) operatorGroupAnnotationsDiffer(obj *metav1.ObjectMeta, op *operatorsv1.OperatorGroup) bool {
 	annotations := obj.GetAnnotations()
 	if annotations == nil {
 		return true
 	}
-	if operatorGroupNamespace, ok := annotations[v1.OperatorGroupNamespaceAnnotationKey]; !ok || operatorGroupNamespace != op.GetNamespace() {
+	if operatorGroupNamespace, ok := annotations[operatorsv1.OperatorGroupNamespaceAnnotationKey]; !ok || operatorGroupNamespace != op.GetNamespace() {
 		return true
 	}
-	if operatorGroup, ok := annotations[v1.OperatorGroupAnnotationKey]; !ok || operatorGroup != op.GetName() {
+	if operatorGroup, ok := annotations[operatorsv1.OperatorGroupAnnotationKey]; !ok || operatorGroup != op.GetName() {
 		return true
 	}
-	if targets, ok := annotations[v1.OperatorGroupTargetsAnnotationKey]; !ok || targets != op.BuildTargetNamespaces() {
+	if targets, ok := annotations[operatorsv1.OperatorGroupTargetsAnnotationKey]; !ok || targets != op.BuildTargetNamespaces() {
 		a.logger.WithFields(logrus.Fields{
-			"annotationTargets": annotations[v1.OperatorGroupTargetsAnnotationKey],
+			"annotationTargets": annotations[operatorsv1.OperatorGroupTargetsAnnotationKey],
 			"opgroupTargets":    op.BuildTargetNamespaces(),
 		}).Debug("annotations different")
 		return true
 	}
 
 	a.logger.WithFields(logrus.Fields{
-		"annotationTargets": annotations[v1.OperatorGroupTargetsAnnotationKey],
+		"annotationTargets": annotations[operatorsv1.OperatorGroupTargetsAnnotationKey],
 		"opgroupTargets":    op.BuildTargetNamespaces(),
 	}).Debug("annotations correct")
 	return false
@@ -905,11 +908,11 @@ func (a *Operator) copyOperatorGroupAnnotations(obj *metav1.ObjectMeta) map[stri
 	copiedAnnotations := make(map[string]string)
 	for k, v := range obj.GetAnnotations() {
 		switch k {
-		case v1.OperatorGroupNamespaceAnnotationKey:
+		case operatorsv1.OperatorGroupNamespaceAnnotationKey:
 			fallthrough
-		case v1.OperatorGroupAnnotationKey:
+		case operatorsv1.OperatorGroupAnnotationKey:
 			fallthrough
-		case v1.OperatorGroupTargetsAnnotationKey:
+		case operatorsv1.OperatorGroupTargetsAnnotationKey:
 			copiedAnnotations[k] = v
 		}
 	}
@@ -933,7 +936,7 @@ func namespacesChanged(clusterNamespaces []string, statusNamespaces []string) bo
 	return false
 }
 
-func (a *Operator) getOperatorGroupTargets(op *v1.OperatorGroup) (map[string]struct{}, error) {
+func (a *Operator) getOperatorGroupTargets(op *operatorsv1.OperatorGroup) (map[string]struct{}, error) {
 	selector, err := metav1.LabelSelectorAsSelector(op.Spec.Selector)
 
 	if err != nil {
@@ -965,7 +968,7 @@ func (a *Operator) getOperatorGroupTargets(op *v1.OperatorGroup) (map[string]str
 	return namespaceSet, nil
 }
 
-func (a *Operator) updateNamespaceList(op *v1.OperatorGroup) ([]string, error) {
+func (a *Operator) updateNamespaceList(op *operatorsv1.OperatorGroup) ([]string, error) {
 	namespaceSet, err := a.getOperatorGroupTargets(op)
 	if err != nil {
 		return nil, err
@@ -978,7 +981,7 @@ func (a *Operator) updateNamespaceList(op *v1.OperatorGroup) ([]string, error) {
 	return namespaceList, nil
 }
 
-func (a *Operator) ensureOpGroupClusterRole(op *v1.OperatorGroup, suffix string, apis cache.APISet) error {
+func (a *Operator) ensureOpGroupClusterRole(op *operatorsv1.OperatorGroup, suffix string, apis cache.APISet) error {
 	clusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: strings.Join([]string{op.GetName(), suffix}, "-"),
@@ -1007,12 +1010,15 @@ func (a *Operator) ensureOpGroupClusterRole(op *v1.OperatorGroup, suffix string,
 	}
 
 	existingRole, err := a.lister.RbacV1().ClusterRoleLister().Get(clusterRole.Name)
-	if existingRole == nil {
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	if apierrors.IsNotFound(err) {
 		existingRole, err = a.opClient.KubernetesInterface().RbacV1().ClusterRoles().Create(context.TODO(), clusterRole, metav1.CreateOptions{})
 		if err == nil {
 			return nil
 		}
-		if !k8serrors.IsAlreadyExists(err) {
+		if !apierrors.IsAlreadyExists(err) {
 			a.logger.WithError(err).Errorf("Create cluster role failed: %v", clusterRole)
 			return err
 		}
@@ -1029,7 +1035,7 @@ func (a *Operator) ensureOpGroupClusterRole(op *v1.OperatorGroup, suffix string,
 	return nil
 }
 
-func (a *Operator) ensureOpGroupClusterRoles(op *v1.OperatorGroup, apis cache.APISet) error {
+func (a *Operator) ensureOpGroupClusterRoles(op *operatorsv1.OperatorGroup, apis cache.APISet) error {
 	for _, suffix := range Suffices {
 		if err := a.ensureOpGroupClusterRole(op, suffix, apis); err != nil {
 			return err
@@ -1105,7 +1111,7 @@ func csvCopyPrototype(src, dst *v1alpha1.ClusterServiceVersion) {
 		Status: src.Status,
 	}
 	for k, v := range src.Annotations {
-		if k == v1.OperatorGroupTargetsAnnotationKey {
+		if k == operatorsv1.OperatorGroupTargetsAnnotationKey {
 			continue
 		}
 		if k == "kubectl.kubernetes.io/last-applied-configuration" {

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/operatorcondition_controller.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/operatorcondition_controller.go
@@ -8,7 +8,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -150,7 +150,7 @@ func (r *OperatorConditionReconciler) ensureOperatorConditionRole(operatorCondit
 	existingRole := &rbacv1.Role{}
 	err := r.Client.Get(context.TODO(), client.ObjectKey{Name: role.GetName(), Namespace: role.GetNamespace()}, existingRole)
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 		return r.Client.Create(context.TODO(), role)
@@ -196,7 +196,7 @@ func (r *OperatorConditionReconciler) ensureOperatorConditionRoleBinding(operato
 	existingRoleBinding := &rbacv1.RoleBinding{}
 	err := r.Client.Get(context.TODO(), client.ObjectKey{Name: roleBinding.GetName(), Namespace: roleBinding.GetNamespace()}, existingRoleBinding)
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 		return r.Client.Create(context.TODO(), roleBinding)

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/operatorconditiongenerator_controller.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/operatorconditiongenerator_controller.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 
 	"github.com/go-logr/logr"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -156,7 +156,7 @@ func (r *OperatorConditionGeneratorReconciler) ensureOperatorCondition(operatorC
 	existingOperatorCondition := &operatorsv2.OperatorCondition{}
 	err := r.Client.Get(context.TODO(), client.ObjectKey{Name: operatorCondition.GetName(), Namespace: operatorCondition.GetNamespace()}, existingOperatorCondition)
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 		return r.Client.Create(context.TODO(), &operatorCondition)

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/operatorconditiongenerator_controller_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/operatorconditiongenerator_controller_test.go
@@ -8,7 +8,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -147,7 +147,7 @@ var _ = Describe("The OperatorConditionsGenerator Controller", func() {
 		time.Sleep(time.Second * 10)
 		err := k8sClient.Get(ctx, namespacedName, operatorCondition)
 		Expect(err).ToNot(BeNil())
-		Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
 	})
 
 	It("creates an OperatorCondition for a CSV with multiple ServiceAccounts and Deployments", func() {

--- a/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/grpc.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/grpc.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	k8serror "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -208,7 +208,7 @@ func (c *GrpcRegistryReconciler) EnsureRegistryServer(catalogSource *v1alpha1.Ca
 	// recreate the pod if no existing pod is serving the latest image or correct spec
 	overwritePod := overwrite || len(c.currentPodsWithCorrectImageAndSpec(source, sa.GetName())) == 0
 
-	if err != nil && !k8serror.IsAlreadyExists(err) {
+	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return errors.Wrapf(err, "error ensuring service account: %s", source.GetName())
 	}
 	if err := c.ensurePod(source, sa.GetName(), overwritePod); err != nil {
@@ -261,7 +261,7 @@ func (c *GrpcRegistryReconciler) ensurePod(source grpcCatalogSourceDecorator, sa
 			return nil
 		}
 		for _, p := range currentLivePods {
-			if err := c.OpClient.KubernetesInterface().CoreV1().Pods(source.GetNamespace()).Delete(context.TODO(), p.GetName(), *metav1.NewDeleteOptions(1)); err != nil && !k8serror.IsNotFound(err) {
+			if err := c.OpClient.KubernetesInterface().CoreV1().Pods(source.GetNamespace()).Delete(context.TODO(), p.GetName(), *metav1.NewDeleteOptions(1)); err != nil && !apierrors.IsNotFound(err) {
 				return errors.Wrapf(err, "error deleting old pod: %s", p.GetName())
 			}
 		}
@@ -343,7 +343,7 @@ func (c *GrpcRegistryReconciler) ensureService(source grpcCatalogSourceDecorator
 			return nil
 		}
 		// TODO(tflannag): Do we care about force deleting services?
-		if err := c.OpClient.DeleteService(service.GetNamespace(), service.GetName(), metav1.NewDeleteOptions(0)); err != nil && !k8serror.IsNotFound(err) {
+		if err := c.OpClient.DeleteService(service.GetNamespace(), service.GetName(), metav1.NewDeleteOptions(0)); err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	}
@@ -438,7 +438,7 @@ func imageID(pod *corev1.Pod) string {
 
 func (c *GrpcRegistryReconciler) removePods(pods []*corev1.Pod, namespace string) error {
 	for _, p := range pods {
-		if err := c.OpClient.KubernetesInterface().CoreV1().Pods(namespace).Delete(context.TODO(), p.GetName(), *metav1.NewDeleteOptions(1)); err != nil && !k8serror.IsNotFound(err) {
+		if err := c.OpClient.KubernetesInterface().CoreV1().Pods(namespace).Delete(context.TODO(), p.GetName(), *metav1.NewDeleteOptions(1)); err != nil && !apierrors.IsNotFound(err) {
 			return errors.Wrapf(err, "error deleting pod: %s", p.GetName())
 		}
 	}

--- a/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/grpc_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/grpc_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -360,7 +360,7 @@ func TestGrpcRegistryReconciler(t *testing.T) {
 				require.NoError(t, podErr)
 				require.Len(t, outPods.Items, 0)
 				require.NoError(t, err)
-				require.True(t, k8serrors.IsNotFound(serviceErr))
+				require.True(t, apierrors.IsNotFound(serviceErr))
 			}
 
 		})

--- a/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
@@ -6,12 +6,12 @@ import (
 	"hash/fnv"
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	controllerclient "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/controller-runtime/client"
 	hashutil "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/util/hash"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
@@ -34,13 +34,13 @@ const (
 // RegistryEnsurer describes methods for ensuring a registry exists.
 type RegistryEnsurer interface {
 	// EnsureRegistryServer ensures a registry server exists for the given CatalogSource.
-	EnsureRegistryServer(catalogSource *v1alpha1.CatalogSource) error
+	EnsureRegistryServer(catalogSource *operatorsv1alpha1.CatalogSource) error
 }
 
 // RegistryChecker describes methods for checking a registry.
 type RegistryChecker interface {
 	// CheckRegistryServer returns true if the given CatalogSource is considered healthy; false otherwise.
-	CheckRegistryServer(catalogSource *v1alpha1.CatalogSource) (healthy bool, err error)
+	CheckRegistryServer(catalogSource *operatorsv1alpha1.CatalogSource) (healthy bool, err error)
 }
 
 // RegistryReconciler knows how to reconcile a registry.
@@ -51,7 +51,7 @@ type RegistryReconciler interface {
 
 // RegistryReconcilerFactory describes factory methods for RegistryReconcilers.
 type RegistryReconcilerFactory interface {
-	ReconcilerForSource(source *v1alpha1.CatalogSource) RegistryReconciler
+	ReconcilerForSource(source *operatorsv1alpha1.CatalogSource) RegistryReconciler
 }
 
 // RegistryReconcilerFactory is a factory for RegistryReconcilers.
@@ -64,17 +64,17 @@ type registryReconcilerFactory struct {
 }
 
 // ReconcilerForSource returns a RegistryReconciler based on the configuration of the given CatalogSource.
-func (r *registryReconcilerFactory) ReconcilerForSource(source *v1alpha1.CatalogSource) RegistryReconciler {
+func (r *registryReconcilerFactory) ReconcilerForSource(source *operatorsv1alpha1.CatalogSource) RegistryReconciler {
 	// TODO: add memoization by source type
 	switch source.Spec.SourceType {
-	case v1alpha1.SourceTypeInternal, v1alpha1.SourceTypeConfigmap:
+	case operatorsv1alpha1.SourceTypeInternal, operatorsv1alpha1.SourceTypeConfigmap:
 		return &ConfigMapRegistryReconciler{
 			now:      r.now,
 			Lister:   r.Lister,
 			OpClient: r.OpClient,
 			Image:    r.ConfigMapServerImage,
 		}
-	case v1alpha1.SourceTypeGrpc:
+	case operatorsv1alpha1.SourceTypeGrpc:
 		if source.Spec.Image != "" {
 			return &GrpcRegistryReconciler{
 				now:       r.now,
@@ -102,15 +102,15 @@ func NewRegistryReconcilerFactory(lister operatorlister.OperatorLister, opClient
 	}
 }
 
-func Pod(source *v1alpha1.CatalogSource, name string, image string, saName string, labels map[string]string, annotations map[string]string, readinessDelay int32, livenessDelay int32) *v1.Pod {
+func Pod(source *operatorsv1alpha1.CatalogSource, name string, image string, saName string, labels map[string]string, annotations map[string]string, readinessDelay int32, livenessDelay int32) *corev1.Pod {
 	// Ensure the catalog image is always pulled if the image is not based on a digest, measured by whether an "@" is included.
 	// See https://github.com/docker/distribution/blob/master/reference/reference.go for more info.
 	// This means recreating non-digest based catalog pods will result in the latest version of the catalog content being delivered on-cluster.
-	var pullPolicy v1.PullPolicy
+	var pullPolicy corev1.PullPolicy
 	if strings.Contains(image, "@") {
-		pullPolicy = v1.PullIfNotPresent
+		pullPolicy = corev1.PullIfNotPresent
 	} else {
-		pullPolicy = v1.PullAlways
+		pullPolicy = corev1.PullAlways
 	}
 
 	// make a copy of the labels and annotations to avoid mutating the input parameters
@@ -127,62 +127,62 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, saName strin
 
 	readOnlyRootFilesystem := false
 
-	pod := &v1.Pod{
+	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: source.GetName() + "-",
 			Namespace:    source.GetNamespace(),
 			Labels:       podLabels,
 			Annotations:  podAnnotations,
 		},
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
 				{
 					Name:  name,
 					Image: image,
-					Ports: []v1.ContainerPort{
+					Ports: []corev1.ContainerPort{
 						{
 							Name:          "grpc",
 							ContainerPort: 50051,
 						},
 					},
-					ReadinessProbe: &v1.Probe{
-						Handler: v1.Handler{
-							Exec: &v1.ExecAction{
+					ReadinessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							Exec: &corev1.ExecAction{
 								Command: []string{"grpc_health_probe", "-addr=:50051"},
 							},
 						},
 						InitialDelaySeconds: readinessDelay,
 						TimeoutSeconds:      5,
 					},
-					LivenessProbe: &v1.Probe{
-						Handler: v1.Handler{
-							Exec: &v1.ExecAction{
+					LivenessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							Exec: &corev1.ExecAction{
 								Command: []string{"grpc_health_probe", "-addr=:50051"},
 							},
 						},
 						InitialDelaySeconds: livenessDelay,
 						TimeoutSeconds:      5,
 					},
-					StartupProbe: &v1.Probe{
-						Handler: v1.Handler{
-							Exec: &v1.ExecAction{
+					StartupProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							Exec: &corev1.ExecAction{
 								Command: []string{"grpc_health_probe", "-addr=:50051"},
 							},
 						},
 						FailureThreshold: 15,
 						PeriodSeconds:    10,
 					},
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceCPU:    resource.MustParse("10m"),
-							v1.ResourceMemory: resource.MustParse("50Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("10m"),
+							corev1.ResourceMemory: resource.MustParse("50Mi"),
 						},
 					},
-					SecurityContext: &v1.SecurityContext{
+					SecurityContext: &corev1.SecurityContext{
 						ReadOnlyRootFilesystem: &readOnlyRootFilesystem,
 					},
 					ImagePullPolicy:          pullPolicy,
-					TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 				},
 			},
 			NodeSelector: map[string]string{
@@ -211,7 +211,7 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, saName strin
 
 		// Override tolerations
 		if grpcPodConfig.Tolerations != nil {
-			pod.Spec.Tolerations = make([]v1.Toleration, len(grpcPodConfig.Tolerations))
+			pod.Spec.Tolerations = make([]corev1.Toleration, len(grpcPodConfig.Tolerations))
 			for index, toleration := range grpcPodConfig.Tolerations {
 				pod.Spec.Tolerations[index] = *toleration.DeepCopy()
 			}
@@ -235,7 +235,7 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, saName strin
 }
 
 // hashPodSpec calculates a hash given a copy of the pod spec
-func hashPodSpec(spec v1.PodSpec) string {
+func hashPodSpec(spec corev1.PodSpec) string {
 	hasher := fnv.New32a()
 	hashutil.DeepHashObject(hasher, &spec)
 	return rand.SafeEncodeString(fmt.Sprint(hasher.Sum32()))

--- a/staging/operator-lifecycle-manager/pkg/fakes/fake_strategy_installer.go
+++ b/staging/operator-lifecycle-manager/pkg/fakes/fake_strategy_installer.go
@@ -3,11 +3,32 @@ package fakes
 
 import (
 	"sync"
+	"time"
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
 )
 
 type FakeStrategyInstaller struct {
+	CertsRotateAtStub        func() time.Time
+	certsRotateAtMutex       sync.RWMutex
+	certsRotateAtArgsForCall []struct {
+	}
+	certsRotateAtReturns struct {
+		result1 time.Time
+	}
+	certsRotateAtReturnsOnCall map[int]struct {
+		result1 time.Time
+	}
+	CertsRotatedStub        func() bool
+	certsRotatedMutex       sync.RWMutex
+	certsRotatedArgsForCall []struct {
+	}
+	certsRotatedReturns struct {
+		result1 bool
+	}
+	certsRotatedReturnsOnCall map[int]struct {
+		result1 bool
+	}
 	CheckInstalledStub        func(install.Strategy) (bool, error)
 	checkInstalledMutex       sync.RWMutex
 	checkInstalledArgsForCall []struct {
@@ -34,6 +55,110 @@ type FakeStrategyInstaller struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeStrategyInstaller) CertsRotateAt() time.Time {
+	fake.certsRotateAtMutex.Lock()
+	ret, specificReturn := fake.certsRotateAtReturnsOnCall[len(fake.certsRotateAtArgsForCall)]
+	fake.certsRotateAtArgsForCall = append(fake.certsRotateAtArgsForCall, struct {
+	}{})
+	fake.recordInvocation("CertsRotateAt", []interface{}{})
+	fake.certsRotateAtMutex.Unlock()
+	if fake.CertsRotateAtStub != nil {
+		return fake.CertsRotateAtStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.certsRotateAtReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeStrategyInstaller) CertsRotateAtCallCount() int {
+	fake.certsRotateAtMutex.RLock()
+	defer fake.certsRotateAtMutex.RUnlock()
+	return len(fake.certsRotateAtArgsForCall)
+}
+
+func (fake *FakeStrategyInstaller) CertsRotateAtCalls(stub func() time.Time) {
+	fake.certsRotateAtMutex.Lock()
+	defer fake.certsRotateAtMutex.Unlock()
+	fake.CertsRotateAtStub = stub
+}
+
+func (fake *FakeStrategyInstaller) CertsRotateAtReturns(result1 time.Time) {
+	fake.certsRotateAtMutex.Lock()
+	defer fake.certsRotateAtMutex.Unlock()
+	fake.CertsRotateAtStub = nil
+	fake.certsRotateAtReturns = struct {
+		result1 time.Time
+	}{result1}
+}
+
+func (fake *FakeStrategyInstaller) CertsRotateAtReturnsOnCall(i int, result1 time.Time) {
+	fake.certsRotateAtMutex.Lock()
+	defer fake.certsRotateAtMutex.Unlock()
+	fake.CertsRotateAtStub = nil
+	if fake.certsRotateAtReturnsOnCall == nil {
+		fake.certsRotateAtReturnsOnCall = make(map[int]struct {
+			result1 time.Time
+		})
+	}
+	fake.certsRotateAtReturnsOnCall[i] = struct {
+		result1 time.Time
+	}{result1}
+}
+
+func (fake *FakeStrategyInstaller) CertsRotated() bool {
+	fake.certsRotatedMutex.Lock()
+	ret, specificReturn := fake.certsRotatedReturnsOnCall[len(fake.certsRotatedArgsForCall)]
+	fake.certsRotatedArgsForCall = append(fake.certsRotatedArgsForCall, struct {
+	}{})
+	fake.recordInvocation("CertsRotated", []interface{}{})
+	fake.certsRotatedMutex.Unlock()
+	if fake.CertsRotatedStub != nil {
+		return fake.CertsRotatedStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.certsRotatedReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeStrategyInstaller) CertsRotatedCallCount() int {
+	fake.certsRotatedMutex.RLock()
+	defer fake.certsRotatedMutex.RUnlock()
+	return len(fake.certsRotatedArgsForCall)
+}
+
+func (fake *FakeStrategyInstaller) CertsRotatedCalls(stub func() bool) {
+	fake.certsRotatedMutex.Lock()
+	defer fake.certsRotatedMutex.Unlock()
+	fake.CertsRotatedStub = stub
+}
+
+func (fake *FakeStrategyInstaller) CertsRotatedReturns(result1 bool) {
+	fake.certsRotatedMutex.Lock()
+	defer fake.certsRotatedMutex.Unlock()
+	fake.CertsRotatedStub = nil
+	fake.certsRotatedReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeStrategyInstaller) CertsRotatedReturnsOnCall(i int, result1 bool) {
+	fake.certsRotatedMutex.Lock()
+	defer fake.certsRotatedMutex.Unlock()
+	fake.CertsRotatedStub = nil
+	if fake.certsRotatedReturnsOnCall == nil {
+		fake.certsRotatedReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.certsRotatedReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
 }
 
 func (fake *FakeStrategyInstaller) CheckInstalled(arg1 install.Strategy) (bool, error) {
@@ -162,6 +287,10 @@ func (fake *FakeStrategyInstaller) InstallReturnsOnCall(i int, result1 error) {
 func (fake *FakeStrategyInstaller) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.certsRotateAtMutex.RLock()
+	defer fake.certsRotateAtMutex.RUnlock()
+	fake.certsRotatedMutex.RLock()
+	defer fake.certsRotatedMutex.RUnlock()
 	fake.checkInstalledMutex.RLock()
 	defer fake.checkInstalledMutex.RUnlock()
 	fake.installMutex.RLock()

--- a/staging/operator-lifecycle-manager/pkg/lib/operatorstatus/clusteroperatorwriter.go
+++ b/staging/operator-lifecycle-manager/pkg/lib/operatorstatus/clusteroperatorwriter.go
@@ -7,7 +7,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -36,7 +36,7 @@ func (w *Writer) EnsureExists(name string) (existing *configv1.ClusterOperator, 
 		return
 	}
 
-	if !k8serrors.IsNotFound(err) {
+	if !apierrors.IsNotFound(err) {
 		return
 	}
 

--- a/staging/operator-lifecycle-manager/pkg/lib/operatorstatus/status.go
+++ b/staging/operator-lifecycle-manager/pkg/lib/operatorstatus/status.go
@@ -12,7 +12,7 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/diff"
@@ -87,7 +87,7 @@ func MonitorClusterStatus(name string, syncCh <-chan error, stopCh <-chan struct
 
 		// create the cluster operator in an initial state if it does not exist
 		existing, err := configClient.ClusterOperators().Get(context.TODO(), name, metav1.GetOptions{})
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.Info("Existing operator status not found, creating")
 			created, createErr := configClient.ClusterOperators().Create(context.TODO(), &configv1.ClusterOperator{
 				ObjectMeta: metav1.ObjectMeta{

--- a/staging/operator-lifecycle-manager/pkg/lib/proxy/syncer.go
+++ b/staging/operator-lifecycle-manager/pkg/lib/proxy/syncer.go
@@ -11,7 +11,7 @@ import (
 	listers "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/discovery"
 )
 
@@ -49,7 +49,7 @@ type Syncer struct {
 func (w *Syncer) QueryProxyConfig() (proxy []corev1.EnvVar, err error) {
 	global, getErr := w.lister.Get(globalProxyName)
 	if getErr != nil {
-		if !k8serrors.IsNotFound(getErr) {
+		if !apierrors.IsNotFound(getErr) {
 			err = getErr
 			return
 		}

--- a/staging/operator-lifecycle-manager/pkg/lib/scoped/syncer.go
+++ b/staging/operator-lifecycle-manager/pkg/lib/scoped/syncer.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -79,7 +79,7 @@ func (s *UserDefinedServiceAccountSyncer) SyncOperatorGroup(in *v1.OperatorGroup
 	// A service account has been specified, we need to update the status.
 	sa, err := s.client.KubernetesInterface().CoreV1().ServiceAccounts(namespace).Get(context.TODO(), serviceAccountName, metav1.GetOptions{})
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			// Set OG's status condition to indicate SA is not found
 			cond := metav1.Condition{
 				Type:    v1.OperatorGroupServiceAccountCondition,

--- a/staging/operator-lifecycle-manager/pkg/lib/scoped/token_retriever.go
+++ b/staging/operator-lifecycle-manager/pkg/lib/scoped/token_retriever.go
@@ -7,7 +7,7 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -54,7 +54,7 @@ func getAPISecret(logger logrus.FieldLogger, kubeclient operatorclient.ClientInt
 		// corev1.ObjectReference only has Name populated.
 		secret, getErr := kubeclient.KubernetesInterface().CoreV1().Secrets(sa.GetNamespace()).Get(context.TODO(), ref.Name, metav1.GetOptions{})
 		if getErr != nil {
-			if k8serrors.IsNotFound(getErr) {
+			if apierrors.IsNotFound(getErr) {
 				logger.Warnf("skipping secret %s - %v", ref.Name, getErr)
 				continue
 			}

--- a/staging/operator-lifecycle-manager/pkg/metrics/metrics.go
+++ b/staging/operator-lifecycle-manager/pkg/metrics/metrics.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
-	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	v1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
 )
 
@@ -247,19 +247,19 @@ func DeleteCatalogSourceStateMetric(name, namespace string) {
 	catalogSourceReady.DeleteLabelValues(namespace, name)
 }
 
-func DeleteCSVMetric(oldCSV *olmv1alpha1.ClusterServiceVersion) {
+func DeleteCSVMetric(oldCSV *operatorsv1alpha1.ClusterServiceVersion) {
 	// Delete the old CSV metrics
 	csvAbnormal.DeleteLabelValues(oldCSV.Namespace, oldCSV.Name, oldCSV.Spec.Version.String(), string(oldCSV.Status.Phase), string(oldCSV.Status.Reason))
 	csvSucceeded.DeleteLabelValues(oldCSV.Namespace, oldCSV.Name, oldCSV.Spec.Version.String())
 }
 
-func EmitCSVMetric(oldCSV *olmv1alpha1.ClusterServiceVersion, newCSV *olmv1alpha1.ClusterServiceVersion) {
+func EmitCSVMetric(oldCSV *operatorsv1alpha1.ClusterServiceVersion, newCSV *operatorsv1alpha1.ClusterServiceVersion) {
 	if oldCSV == nil || newCSV == nil {
 		return
 	}
 
 	// Don't update the metric for copies
-	if newCSV.Status.Reason == olmv1alpha1.CSVReasonCopied {
+	if newCSV.Status.Reason == operatorsv1alpha1.CSVReasonCopied {
 		return
 	}
 
@@ -269,7 +269,7 @@ func EmitCSVMetric(oldCSV *olmv1alpha1.ClusterServiceVersion, newCSV *olmv1alpha
 	// Get the phase of the new CSV
 	newCSVPhase := string(newCSV.Status.Phase)
 	csvSucceededGauge := csvSucceeded.WithLabelValues(newCSV.Namespace, newCSV.Name, newCSV.Spec.Version.String())
-	if newCSVPhase == string(olmv1alpha1.CSVPhaseSucceeded) {
+	if newCSVPhase == string(operatorsv1alpha1.CSVPhaseSucceeded) {
 		csvSucceededGauge.Set(1)
 	} else {
 		csvSucceededGauge.Set(0)
@@ -277,7 +277,7 @@ func EmitCSVMetric(oldCSV *olmv1alpha1.ClusterServiceVersion, newCSV *olmv1alpha
 	}
 }
 
-func EmitSubMetric(sub *olmv1alpha1.Subscription) {
+func EmitSubMetric(sub *operatorsv1alpha1.Subscription) {
 	if sub.Spec == nil {
 		return
 	}
@@ -292,14 +292,14 @@ func EmitSubMetric(sub *olmv1alpha1.Subscription) {
 	}
 }
 
-func DeleteSubsMetric(sub *olmv1alpha1.Subscription) {
+func DeleteSubsMetric(sub *operatorsv1alpha1.Subscription) {
 	if sub.Spec == nil {
 		return
 	}
 	SubscriptionSyncCount.DeleteLabelValues(sub.GetName(), sub.Status.InstalledCSV, sub.Spec.Channel, sub.Spec.Package, string(sub.Spec.InstallPlanApproval))
 }
 
-func UpdateSubsSyncCounterStorage(sub *olmv1alpha1.Subscription) {
+func UpdateSubsSyncCounterStorage(sub *operatorsv1alpha1.Subscription) {
 	if sub.Spec == nil {
 		return
 	}

--- a/staging/operator-lifecycle-manager/pkg/package-server/storage/reststorage.go
+++ b/staging/operator-lifecycle-manager/pkg/package-server/storage/reststorage.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/printers"
 	printerstorage "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/printers/storage"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -76,7 +76,7 @@ func (m *PackageManifestStorage) List(ctx context.Context, options *metainternal
 
 	res, err := m.prov.List(namespace, labelSelector)
 	if err != nil {
-		return nil, k8serrors.NewInternalError(err)
+		return nil, apierrors.NewInternalError(err)
 	}
 
 	filtered := []operators.PackageManifest{}
@@ -101,7 +101,7 @@ func (m *PackageManifestStorage) Get(ctx context.Context, name string, opts *met
 	namespace := genericreq.NamespaceValue(ctx)
 	manifest, err := m.prov.Get(namespace, name)
 	if err != nil || manifest == nil {
-		return nil, k8serrors.NewNotFound(m.groupResource, name)
+		return nil, apierrors.NewNotFound(m.groupResource, name)
 	}
 	// Strip logo icons
 	for i := range manifest.Status.Channels {

--- a/staging/operator-lifecycle-manager/test/e2e/bundle_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/bundle_e2e_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ghodss/yaml"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	. "github.com/onsi/ginkgo"
@@ -73,7 +73,7 @@ var _ = Describe("Installing bundles with new object types", func() {
 			Eventually(func() error {
 				err := ctx.Ctx().Client().Create(context.Background(), &vpaCRD)
 				if err != nil {
-					if !k8serrors.IsAlreadyExists(err) {
+					if !apierrors.IsAlreadyExists(err) {
 						return err
 					}
 				}
@@ -167,7 +167,7 @@ var _ = Describe("Installing bundles with new object types", func() {
 			By("Deleting the VPA CRD")
 			Eventually(func() error {
 				err := ctx.Ctx().Client().Delete(context.Background(), &vpaCRD)
-				if k8serrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					return nil
 				}
 				return err

--- a/staging/operator-lifecycle-manager/test/e2e/crd_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/crd_e2e_test.go
@@ -14,7 +14,7 @@ import (
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -459,7 +459,7 @@ var _ = Describe("CRD Versions", func() {
 		Eventually(func() bool {
 			sub, _ := crc.OperatorsV1alpha1().Subscriptions(testNamespace).Get(context.TODO(), subscription.GetName(), metav1.GetOptions{})
 			ip, err := crc.OperatorsV1alpha1().InstallPlans(testNamespace).Get(context.TODO(), sub.Status.InstallPlanRef.Name, metav1.GetOptions{})
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				return false
 			}
 			GinkgoT().Logf("waiting for installplan to succeed...currently %s", ip.Status.Phase)

--- a/staging/operator-lifecycle-manager/test/e2e/csv_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/csv_e2e_test.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
@@ -126,11 +126,11 @@ var _ = Describe("ClusterServiceVersion", func() {
 		AfterEach(func() {
 			Eventually(func() error {
 				return ctx.Ctx().Client().Delete(context.Background(), &ns)
-			}).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
+			}).Should(WithTransform(apierrors.IsNotFound, BeTrue()))
 
 			Eventually(func() error {
 				return ctx.Ctx().Client().Delete(context.Background(), &crd)
-			}).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
+			}).Should(WithTransform(apierrors.IsNotFound, BeTrue()))
 		})
 
 		It("can satisfy an associated ClusterServiceVersion's ownership requirement", func() {
@@ -239,7 +239,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 
 			Eventually(func() error {
 				return ctx.Ctx().Client().Get(context.Background(), client.ObjectKeyFromObject(&unassociated), &unassociated)
-			}).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
+			}).Should(WithTransform(apierrors.IsNotFound, BeTrue()))
 		})
 
 		It("can satisfy an unassociated ClusterServiceVersion's non-ownership requirement", func() {
@@ -321,7 +321,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			AfterEach(func() {
 				Eventually(func() error {
 					return ctx.Ctx().Client().Delete(context.Background(), &ns)
-				}).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
+				}).Should(WithTransform(apierrors.IsNotFound, BeTrue()))
 			})
 
 			It("can satisfy the unassociated ClusterServiceVersion's ownership requirement", func() {
@@ -745,7 +745,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 		// Shouldn't create deployment
 		Consistently(func() bool {
 			_, err := c.GetDeployment(testNamespace, depName)
-			return k8serrors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}).Should(BeTrue())
 	})
 	// TODO: same test but missing serviceaccount instead
@@ -805,7 +805,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 		// Shouldn't create deployment
 		Consistently(func() bool {
 			_, err := c.GetDeployment(testNamespace, depName)
-			return k8serrors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}).Should(BeTrue())
 	})
 
@@ -925,7 +925,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 		// Shouldn't create deployment
 		Consistently(func() bool {
 			_, err := c.GetDeployment(testNamespace, depName)
-			return k8serrors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}).Should(BeTrue())
 	})
 	It("create with unmet requirements API service", func() {
@@ -984,7 +984,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 		// Shouldn't create deployment
 		Consistently(func() bool {
 			_, err := c.GetDeployment(testNamespace, depName)
-			return k8serrors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}).Should(BeTrue())
 	})
 	It("create with unmet permissions API service", func() {
@@ -1071,7 +1071,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 		// Shouldn't create deployment
 		Consistently(func() bool {
 			_, err := c.GetDeployment(testNamespace, depName)
-			return k8serrors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}).Should(BeTrue())
 	})
 	It("create with unmet requirements native API", func() {
@@ -1120,7 +1120,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 		// Shouldn't create deployment
 		Consistently(func() bool {
 			_, err := c.GetDeployment(testNamespace, depName)
-			return k8serrors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}).Should(BeTrue())
 	})
 	// TODO: same test but create serviceaccount instead
@@ -1363,7 +1363,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 		// Poll for deployment to be ready
 		Eventually(func() (bool, error) {
 			dep, err := c.GetDeployment(testNamespace, depName)
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				ctx.Ctx().Logf("deployment %s not found\n", depName)
 				return false, nil
 			} else if err != nil {
@@ -4208,17 +4208,17 @@ var _ = Describe("Disabling copied CSVs", func() {
 	When("an operator is installed in AllNamespace mode", func() {
 		BeforeEach(func() {
 			Eventually(func() error {
-				if err := ctx.Ctx().Client().Create(context.TODO(), ns); err != nil && !k8serrors.IsAlreadyExists(err) {
+				if err := ctx.Ctx().Client().Create(context.TODO(), ns); err != nil && !apierrors.IsAlreadyExists(err) {
 					ctx.Ctx().Logf("Unable to create ns: %v", err)
 					return err
 				}
 
-				if err := ctx.Ctx().Client().Create(context.TODO(), &operatorGroup); err != nil && !k8serrors.IsAlreadyExists(err) {
+				if err := ctx.Ctx().Client().Create(context.TODO(), &operatorGroup); err != nil && !apierrors.IsAlreadyExists(err) {
 					ctx.Ctx().Logf("Unable to create og: %v", err)
 					return err
 				}
 
-				if err := ctx.Ctx().Client().Create(context.TODO(), &csv); err != nil && !k8serrors.IsAlreadyExists(err) {
+				if err := ctx.Ctx().Client().Create(context.TODO(), &csv); err != nil && !apierrors.IsAlreadyExists(err) {
 					ctx.Ctx().Logf("Unable to create csv: %v", err)
 					return err
 				}
@@ -4694,7 +4694,7 @@ func awaitCSV(c versioned.Interface, namespace, name string, checker csvConditio
 	Eventually(func() (bool, error) {
 		fetched, err = c.OperatorsV1alpha1().ClusterServiceVersions(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				return false, nil
 			}
 			return false, err
@@ -4713,7 +4713,7 @@ func waitForDeployment(c operatorclient.ClientInterface, name string) error {
 	return wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 		_, err := c.GetDeployment(testNamespace, name)
 		if err != nil {
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				return false, nil
 			}
 			return false, err
@@ -4728,7 +4728,7 @@ func waitForDeploymentToDelete(c operatorclient.ClientInterface, name string) er
 	Eventually(func() (bool, error) {
 		ctx.Ctx().Logf("waiting for deployment %s to delete", name)
 		_, err := c.GetDeployment(testNamespace, name)
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			ctx.Ctx().Logf("deleted %s", name)
 			return true, nil
 		}
@@ -4744,7 +4744,7 @@ func waitForDeploymentToDelete(c operatorclient.ClientInterface, name string) er
 func csvExists(c versioned.Interface, name string) bool {
 
 	fetched, err := c.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Get(context.TODO(), name, metav1.GetOptions{})
-	if k8serrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		return false
 	}
 	ctx.Ctx().Logf("%s (%s): %s", fetched.Status.Phase, fetched.Status.Reason, fetched.Status.Message)
@@ -4806,7 +4806,7 @@ func createLegacyAPIResources(csv *operatorsv1alpha1.ClusterServiceVersion, desc
 	}
 
 	_, err = c.CreateSecret(&secret)
-	if err != nil && !k8serrors.IsAlreadyExists(err) {
+	if err != nil && !apierrors.IsAlreadyExists(err) {
 		Expect(err).ShouldNot(HaveOccurred())
 	}
 
@@ -4871,25 +4871,25 @@ func checkLegacyAPIResources(desc operatorsv1alpha1.APIServiceDescription, expec
 
 	// Attempt to create the legacy service
 	_, err := c.GetService(testNamespace, strings.Replace(apiServiceName, ".", "-", -1))
-	Expect(k8serrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
+	Expect(apierrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy secret
 	_, err = c.GetSecret(testNamespace, apiServiceName+"-cert")
-	Expect(k8serrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
+	Expect(apierrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy secret role
 	_, err = c.GetRole(testNamespace, apiServiceName+"-cert")
-	Expect(k8serrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
+	Expect(apierrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy secret role binding
 	_, err = c.GetRoleBinding(testNamespace, apiServiceName+"-cert")
-	Expect(k8serrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
+	Expect(apierrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy authDelegatorClusterRoleBinding
 	_, err = c.GetClusterRoleBinding(apiServiceName + "-system:auth-delegator")
-	Expect(k8serrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
+	Expect(apierrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 
 	// Attempt to create the legacy authReadingRoleBinding
 	_, err = c.GetRoleBinding("kube-system", apiServiceName+"-auth-reader")
-	Expect(k8serrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
+	Expect(apierrors.IsNotFound(err)).Should(Equal(expectedIsNotFound))
 }

--- a/staging/operator-lifecycle-manager/test/e2e/gc_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/gc_e2e_test.go
@@ -11,7 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
@@ -109,14 +109,14 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 				// Delete CRD
 				Eventually(func() bool {
 					err := kubeClient.ApiextensionsInterface().ApiextensionsV1().CustomResourceDefinitions().Delete(context.Background(), crd.GetName(), metav1.DeleteOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 			})
 
 			It("should delete the associated ClusterRole", func() {
 				Eventually(func() bool {
 					_, err := kubeClient.GetClusterRole(cr.GetName())
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue(), "get cluster role should eventually return \"not found\"")
 			})
 
@@ -179,14 +179,14 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 				// Delete API service
 				Eventually(func() bool {
 					err := kubeClient.DeleteAPIService(apiService.GetName(), &metav1.DeleteOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 			})
 
 			It("should delete the associated ClusterRole", func() {
 				Eventually(func() bool {
 					_, err := kubeClient.GetClusterRole(cr.GetName())
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue(), "get cluster role should eventually return \"not found\"")
 			})
 
@@ -256,13 +256,13 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 				// delete ownerA in the foreground (to ensure any "blocking" dependents are deleted before ownerA)
 				Eventually(func() bool {
 					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Delete(context.Background(), fetchedA.GetName(), options)
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// wait for deletion of ownerA
 				Eventually(func() bool {
 					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Get(context.Background(), ownerA.GetName(), metav1.GetOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 			})
 
@@ -281,32 +281,32 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 				// delete ownerA in the foreground (to ensure any "blocking" dependents are deleted before ownerA)
 				Eventually(func() bool {
 					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Delete(context.Background(), fetchedA.GetName(), options)
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// wait for deletion of ownerA
 				Eventually(func() bool {
 					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Get(context.Background(), ownerA.GetName(), metav1.GetOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// delete ownerB in the foreground (to ensure any "blocking" dependents are deleted before ownerB)
 				Eventually(func() bool {
 					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Delete(context.Background(), fetchedB.GetName(), options)
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// wait for deletion of ownerB
 				Eventually(func() bool {
 					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Get(context.Background(), ownerB.GetName(), metav1.GetOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 			})
 
 			It("should have deleted the dependent since both the owners were deleted", func() {
 				Eventually(func() bool {
 					_, err := kubeClient.KubernetesInterface().CoreV1().ConfigMaps(testNamespace).Get(context.Background(), dependent.GetName(), metav1.GetOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue(), "expected dependency configmap would be properly garabage collected")
 				ctx.Ctx().Logf("dependent successfully garbage collected after both owners were deleted")
 			})
@@ -396,25 +396,25 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 				// Delete subscription first
 				Eventually(func() bool {
 					err := operatorClient.OperatorsV1alpha1().Subscriptions(testNamespace).Delete(context.Background(), subName, metav1.DeleteOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// wait for deletion
 				Eventually(func() bool {
 					_, err := operatorClient.OperatorsV1alpha1().Subscriptions(testNamespace).Get(context.Background(), subName, metav1.GetOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// Delete CSV
 				Eventually(func() bool {
 					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Delete(context.Background(), csvName, metav1.DeleteOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// wait for deletion
 				Eventually(func() bool {
 					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(testNamespace).Get(context.Background(), csvName, metav1.GetOptions{})
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 			})
 
@@ -422,12 +422,12 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 				// confirm extra bundle objects (secret and configmap) are no longer installed on the cluster
 				Eventually(func() bool {
 					_, err := kubeClient.GetSecret(testNamespace, secretName)
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				Eventually(func() bool {
 					_, err := kubeClient.GetConfigMap(testNamespace, configmapName)
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 				ctx.Ctx().Logf("dependent successfully garbage collected after csv owner was deleted")
 			})
@@ -649,7 +649,7 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 			It("should have removed the old configmap and put the new configmap in place", func() {
 				Eventually(func() bool {
 					_, err := kubeClient.GetConfigMap(testNamespace, configmapName)
-					return k8serrors.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				Eventually(func() error {

--- a/staging/operator-lifecycle-manager/test/e2e/installplan_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/installplan_e2e_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -275,7 +275,7 @@ var _ = Describe("Install Plan", func() {
 		AfterEach(func() {
 			Eventually(func() error {
 				return ctx.Ctx().Client().Delete(context.Background(), &crd)
-			}).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
+			}).Should(WithTransform(apierrors.IsNotFound, BeTrue()))
 		})
 
 		It("is annotated with a reference to its associated ClusterServiceVersion", func() {
@@ -416,7 +416,7 @@ var _ = Describe("Install Plan", func() {
 		AfterEach(func() {
 			Expect(ctx.Ctx().Client().Delete(context.Background(), owned)).To(Or(
 				Succeed(),
-				WithTransform(k8serrors.IsNotFound, BeTrue()),
+				WithTransform(apierrors.IsNotFound, BeTrue()),
 			))
 		})
 
@@ -517,7 +517,7 @@ var _ = Describe("Install Plan", func() {
 		AfterEach(func() {
 			Expect(ctx.Ctx().Client().Delete(context.TODO(), &sa)).To(Or(
 				Succeed(),
-				WithTransform(k8serrors.IsNotFound, BeTrue()),
+				WithTransform(apierrors.IsNotFound, BeTrue()),
 			))
 		})
 
@@ -2712,7 +2712,7 @@ var _ = Describe("Install Plan", func() {
 				err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 					_, err = c.GetClusterRole(step.Resource.Name)
 					if err != nil {
-						if k8serrors.IsNotFound(err) {
+						if apierrors.IsNotFound(err) {
 							return false, nil
 						}
 						return false, err
@@ -2725,7 +2725,7 @@ var _ = Describe("Install Plan", func() {
 				err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 					_, err = c.GetClusterRoleBinding(step.Resource.Name)
 					if err != nil {
-						if k8serrors.IsNotFound(err) {
+						if apierrors.IsNotFound(err) {
 							return false, nil
 						}
 						return false, err
@@ -2820,7 +2820,7 @@ var _ = Describe("Install Plan", func() {
 			if err == nil {
 				return fmt.Errorf("The %v/%v ServiceAccount should have been deleted", testNamespace, serviceAccountName)
 			}
-			if !k8serrors.IsNotFound(err) {
+			if !apierrors.IsNotFound(err) {
 				return err
 			}
 			return nil
@@ -4106,7 +4106,7 @@ func waitForInstallPlan(c versioned.Interface, name string, namespace string, ch
 
 	err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 		fetchedInstallPlan, err = c.OperatorsV1alpha1().InstallPlans(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return false, err
 		}
 

--- a/staging/operator-lifecycle-manager/test/e2e/operator_groups_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/operator_groups_e2e_test.go
@@ -14,7 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -218,7 +218,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(opGroupNamespace).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if k8serrors.IsNotFound(fetchErr) {
+				if apierrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				log(fmt.Sprintf("Error (in %v): %v", testNamespace, fetchErr.Error()))
@@ -235,7 +235,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if k8serrors.IsNotFound(fetchErr) {
+				if apierrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				log(fmt.Sprintf("Error (in %v): %v", otherNamespaceName, fetchErr.Error()))
@@ -252,7 +252,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if k8serrors.IsNotFound(fetchErr) {
+				if apierrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", otherNamespaceName, fetchErr.Error())
@@ -269,7 +269,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			createdDeployment, err := c.GetDeployment(opGroupNamespace, deploymentName)
 			if err != nil {
-				if k8serrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					return false, nil
 				}
 				return false, err
@@ -388,7 +388,7 @@ var _ = Describe("Operator Group", func() {
 			}
 			return true, err
 		})
-		require.True(GinkgoT(), k8serrors.IsNotFound(err))
+		require.True(GinkgoT(), apierrors.IsNotFound(err))
 
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			_, err := c.KubernetesInterface().RbacV1().ClusterRoles().Get(context.TODO(), operatorGroup.Name+"-edit", metav1.GetOptions{})
@@ -397,7 +397,7 @@ var _ = Describe("Operator Group", func() {
 			}
 			return true, err
 		})
-		require.True(GinkgoT(), k8serrors.IsNotFound(err))
+		require.True(GinkgoT(), apierrors.IsNotFound(err))
 
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			_, err := c.KubernetesInterface().RbacV1().ClusterRoles().Get(context.TODO(), operatorGroup.Name+"-view", metav1.GetOptions{})
@@ -406,7 +406,7 @@ var _ = Describe("Operator Group", func() {
 			}
 			return true, err
 		})
-		require.True(GinkgoT(), k8serrors.IsNotFound(err))
+		require.True(GinkgoT(), apierrors.IsNotFound(err))
 	})
 	It("role aggregation", func() {
 
@@ -1441,7 +1441,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedRole, err = c.GetClusterRole(role.GetName())
 			if err != nil {
-				if k8serrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					return false, nil
 				}
 				return false, err
@@ -1457,7 +1457,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedRoleBinding, err = c.GetClusterRoleBinding(roleBinding.GetName())
 			if err != nil {
-				if k8serrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					return false, nil
 				}
 				return false, err
@@ -1486,7 +1486,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(opGroupNamespace).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if k8serrors.IsNotFound(fetchErr) {
+				if apierrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", testNamespace, fetchErr.Error())
@@ -1519,7 +1519,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if k8serrors.IsNotFound(fetchErr) {
+				if apierrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", otherNamespaceName, fetchErr.Error())
@@ -1550,7 +1550,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, 2*pollDuration, func() (bool, error) {
 			_, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if k8serrors.IsNotFound(fetchErr) {
+				if apierrors.IsNotFound(fetchErr) {
 					return true, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", opGroupNamespace, fetchErr.Error())
@@ -1921,7 +1921,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedRole, err = c.GetClusterRole(role.GetName())
 			if err != nil {
-				if k8serrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					return false, nil
 				}
 				return false, err
@@ -1937,7 +1937,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedRoleBinding, err = c.GetClusterRoleBinding(roleBinding.GetName())
 			if err != nil {
-				if k8serrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					return false, nil
 				}
 				return false, err
@@ -1966,7 +1966,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(opGroupNamespace).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if k8serrors.IsNotFound(fetchErr) {
+				if apierrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", testNamespace, fetchErr.Error())
@@ -1999,7 +1999,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 			fetchedCSV, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if k8serrors.IsNotFound(fetchErr) {
+				if apierrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", otherNamespaceName, fetchErr.Error())
@@ -2026,7 +2026,7 @@ var _ = Describe("Operator Group", func() {
 		err = wait.Poll(pollInterval, 2*pollDuration, func() (bool, error) {
 			csv, fetchErr := crc.OperatorsV1alpha1().ClusterServiceVersions(otherNamespaceName).Get(context.TODO(), csvName, metav1.GetOptions{})
 			if fetchErr != nil {
-				if k8serrors.IsNotFound(fetchErr) {
+				if apierrors.IsNotFound(fetchErr) {
 					return true, nil
 				}
 				GinkgoT().Logf("Error (in %v): %v", opGroupNamespace, fetchErr.Error())

--- a/staging/operator-lifecycle-manager/test/e2e/scoped_client_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/scoped_client_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
@@ -55,7 +55,7 @@ var _ = Describe("Scoped Client bound to a service account can be used to make A
 			// We expect the get api call to return 'Forbidden' error due to
 			// lack of permission.
 			assertFunc: func(errGot error) {
-				Expect(k8serrors.IsForbidden(errGot)).To(BeTrue())
+				Expect(apierrors.IsForbidden(errGot)).To(BeTrue())
 			},
 		}),
 		table.Entry("successfully allows API calls to be made when ServiceAccount has permission", testParameter{
@@ -66,7 +66,7 @@ var _ = Describe("Scoped Client bound to a service account can be used to make A
 				return
 			},
 			assertFunc: func(errGot error) {
-				Expect(k8serrors.IsNotFound(errGot)).To(BeTrue())
+				Expect(apierrors.IsNotFound(errGot)).To(BeTrue())
 			},
 		}),
 	}

--- a/staging/operator-lifecycle-manager/test/e2e/setup_bare_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/setup_bare_test.go
@@ -1,3 +1,4 @@
+//go:build bare
 // +build bare
 
 package e2e
@@ -18,7 +19,7 @@ import (
 	utilclock "k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/client-go/tools/clientcmd"
 
-	v1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm"

--- a/staging/operator-lifecycle-manager/test/e2e/subscription_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/subscription_e2e_test.go
@@ -19,7 +19,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -1189,7 +1189,7 @@ var _ = Describe("Subscription", func() {
 			}
 
 			proxy, getErr := client.Proxies().Get(context.Background(), "cluster", metav1.GetOptions{})
-			if k8serrors.IsNotFound(getErr) {
+			if apierrors.IsNotFound(getErr) {
 				return nil
 			}
 			require.NoError(GinkgoT(), getErr)
@@ -2537,7 +2537,7 @@ func initCatalog(t GinkgoTInterface, namespace string, c operatorclient.ClientIn
 
 	dummyCatalogConfigMap.SetNamespace(namespace)
 	if _, err := c.KubernetesInterface().CoreV1().ConfigMaps(namespace).Create(context.Background(), dummyCatalogConfigMap, metav1.CreateOptions{}); err != nil {
-		if k8serrors.IsAlreadyExists(err) {
+		if apierrors.IsAlreadyExists(err) {
 			return fmt.Errorf("E2E bug detected: %v", err)
 		}
 		return err
@@ -2545,7 +2545,7 @@ func initCatalog(t GinkgoTInterface, namespace string, c operatorclient.ClientIn
 
 	dummyCatalogSource.SetNamespace(namespace)
 	if _, err := crc.OperatorsV1alpha1().CatalogSources(namespace).Create(context.Background(), &dummyCatalogSource, metav1.CreateOptions{}); err != nil {
-		if k8serrors.IsAlreadyExists(err) {
+		if apierrors.IsAlreadyExists(err) {
 			return fmt.Errorf("E2E bug detected: %v", err)
 		}
 		return err

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/cmd/olm/main.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/cmd/olm/main.go
@@ -13,7 +13,7 @@ import (
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -103,8 +103,8 @@ func main() {
 	// the empty string, the resulting array will be `[]string{""}`.
 	namespaces := strings.Split(*watchedNamespaces, ",")
 	for _, ns := range namespaces {
-		if ns == v1.NamespaceAll {
-			namespaces = []string{v1.NamespaceAll}
+		if ns == corev1.NamespaceAll {
+			namespaces = []string{corev1.NamespaceAll}
 			break
 		}
 	}

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install/apiservice.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install/apiservice.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 
@@ -26,7 +26,7 @@ func (i *StrategyDeploymentInstaller) createOrUpdateAPIService(caPEM []byte, des
 	exists := true
 	apiService, err := i.strategyClient.GetOpLister().APIRegistrationV1().APIServiceLister().Get(apiServiceName)
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 
@@ -120,14 +120,14 @@ func IsAPIServiceAdoptable(opLister operatorlister.OperatorLister, target *v1alp
 
 	// Get the CSV that target replaces
 	replacing, replaceGetErr := opLister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(target.GetNamespace()).Get(target.Spec.Replaces)
-	if replaceGetErr != nil && !k8serrors.IsNotFound(replaceGetErr) && !k8serrors.IsGone(replaceGetErr) {
+	if replaceGetErr != nil && !apierrors.IsNotFound(replaceGetErr) && !apierrors.IsGone(replaceGetErr) {
 		err = replaceGetErr
 		return
 	}
 
 	// Get the current owner CSV of the APIService
 	currentOwnerCSV, ownerGetErr := opLister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(ownerNamespace).Get(ownerName)
-	if ownerGetErr != nil && !k8serrors.IsNotFound(ownerGetErr) && !k8serrors.IsGone(ownerGetErr) {
+	if ownerGetErr != nil && !apierrors.IsNotFound(ownerGetErr) && !apierrors.IsGone(ownerGetErr) {
 		err = ownerGetErr
 		return
 	}
@@ -179,13 +179,13 @@ func (i *StrategyDeploymentInstaller) deleteLegacyAPIServiceResources(desc apiSe
 		// Attempt to delete the legacy Service.
 		existingService, err := i.strategyClient.GetOpClient().GetService(namespace, legacyServiceName)
 		if err != nil {
-			if !k8serrors.IsNotFound(err) {
+			if !apierrors.IsNotFound(err) {
 				return err
 			}
 		} else if ownerutil.AdoptableLabels(existingService.GetLabels(), true, i.owner) {
 			logger.Infof("Deleting Service with legacy APIService name %s", existingService.Name)
 			err = i.strategyClient.GetOpClient().DeleteService(namespace, legacyServiceName, &metav1.DeleteOptions{})
-			if err != nil && !k8serrors.IsNotFound(err) {
+			if err != nil && !apierrors.IsNotFound(err) {
 				return err
 			}
 		} else {
@@ -198,13 +198,13 @@ func (i *StrategyDeploymentInstaller) deleteLegacyAPIServiceResources(desc apiSe
 	// Attempt to delete the legacy Secret.
 	existingSecret, err := i.strategyClient.GetOpClient().GetSecret(namespace, SecretName(apiServiceName))
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else if ownerutil.AdoptableLabels(existingSecret.GetLabels(), true, i.owner) {
 		logger.Infof("Deleting Secret with legacy APIService name %s", existingSecret.Name)
 		err = i.strategyClient.GetOpClient().DeleteSecret(namespace, SecretName(apiServiceName), &metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else {
@@ -214,13 +214,13 @@ func (i *StrategyDeploymentInstaller) deleteLegacyAPIServiceResources(desc apiSe
 	// Attempt to delete the legacy Role.
 	existingRole, err := i.strategyClient.GetOpClient().GetRole(namespace, SecretName(apiServiceName))
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else if ownerutil.AdoptableLabels(existingRole.GetLabels(), true, i.owner) {
 		logger.Infof("Deleting Role with legacy APIService name %s", existingRole.Name)
 		err = i.strategyClient.GetOpClient().DeleteRole(namespace, SecretName(apiServiceName), &metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else {
@@ -230,13 +230,13 @@ func (i *StrategyDeploymentInstaller) deleteLegacyAPIServiceResources(desc apiSe
 	// Attempt to delete the legacy secret RoleBinding.
 	existingRoleBinding, err := i.strategyClient.GetOpClient().GetRoleBinding(namespace, SecretName(apiServiceName))
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else if ownerutil.AdoptableLabels(existingRoleBinding.GetLabels(), true, i.owner) {
 		logger.Infof("Deleting RoleBinding with legacy APIService name %s", existingRoleBinding.Name)
 		err = i.strategyClient.GetOpClient().DeleteRoleBinding(namespace, SecretName(apiServiceName), &metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else {
@@ -246,13 +246,13 @@ func (i *StrategyDeploymentInstaller) deleteLegacyAPIServiceResources(desc apiSe
 	// Attempt to delete the legacy ClusterRoleBinding.
 	existingClusterRoleBinding, err := i.strategyClient.GetOpClient().GetClusterRoleBinding(apiServiceName + "-system:auth-delegator")
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else if ownerutil.AdoptableLabels(existingClusterRoleBinding.GetLabels(), true, i.owner) {
 		logger.Infof("Deleting ClusterRoleBinding with legacy APIService name %s", existingClusterRoleBinding.Name)
 		err = i.strategyClient.GetOpClient().DeleteClusterRoleBinding(apiServiceName+"-system:auth-delegator", &metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else {
@@ -262,13 +262,13 @@ func (i *StrategyDeploymentInstaller) deleteLegacyAPIServiceResources(desc apiSe
 	// Attempt to delete the legacy AuthReadingRoleBinding.
 	existingRoleBinding, err = i.strategyClient.GetOpClient().GetRoleBinding(KubeSystem, apiServiceName+"-auth-reader")
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else if ownerutil.AdoptableLabels(existingRoleBinding.GetLabels(), true, i.owner) {
 		logger.Infof("Deleting RoleBinding with legacy APIService name %s", existingRoleBinding.Name)
 		err = i.strategyClient.GetOpClient().DeleteRoleBinding(KubeSystem, apiServiceName+"-auth-reader", &metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	} else {

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install/certresources.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install/certresources.go
@@ -160,7 +160,7 @@ func (i *StrategyDeploymentInstaller) getCertResources() []certResource {
 }
 
 func (i *StrategyDeploymentInstaller) certResourcesForDeployment(deploymentName string) []certResource {
-	result := []certResource{}
+	var result []certResource
 	for _, desc := range i.getCertResources() {
 		if desc.getDeploymentName() == deploymentName {
 			result = append(result, desc)
@@ -185,8 +185,8 @@ func (i *StrategyDeploymentInstaller) installCertRequirements(strategy Strategy)
 	}
 
 	// Create the CA
-	expiration, _ := CalculateCertExpirationAndRotateAt()
-	ca, err := certs.GenerateCA(expiration, Organization)
+	i.certificateExpirationTime = CalculateCertExpiration(time.Now())
+	ca, err := certs.GenerateCA(i.certificateExpirationTime, Organization)
 	if err != nil {
 		logger.Debug("failed to generate CA")
 		return nil, err
@@ -201,7 +201,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirements(strategy Strategy)
 		}
 
 		// Update the deployment for each certResource
-		newDepSpec, caPEM, err := i.installCertRequirementsForDeployment(sddSpec.Name, ca, expiration, sddSpec.Spec, getServicePorts(certResources))
+		newDepSpec, caPEM, err := i.installCertRequirementsForDeployment(sddSpec.Name, ca, i.certificateExpirationTime, sddSpec.Spec, getServicePorts(certResources))
 		if err != nil {
 			return nil, err
 		}
@@ -213,6 +213,14 @@ func (i *StrategyDeploymentInstaller) installCertRequirements(strategy Strategy)
 	return strategyDetailsDeployment, nil
 }
 
+func (i *StrategyDeploymentInstaller) CertsRotateAt() time.Time {
+	return CalculateCertRotatesAt(i.certificateExpirationTime)
+}
+
+func (i *StrategyDeploymentInstaller) CertsRotated() bool {
+	return i.certificatesRotated
+}
+
 func ShouldRotateCerts(csv *v1alpha1.ClusterServiceVersion) bool {
 	now := metav1.Now()
 	if !csv.Status.CertsRotateAt.IsZero() && csv.Status.CertsRotateAt.Before(&now) {
@@ -222,10 +230,12 @@ func ShouldRotateCerts(csv *v1alpha1.ClusterServiceVersion) bool {
 	return false
 }
 
-func CalculateCertExpirationAndRotateAt() (expiration time.Time, rotateAt time.Time) {
-	expiration = time.Now().Add(DefaultCertValidFor)
-	rotateAt = expiration.Add(-1 * DefaultCertMinFresh)
-	return
+func CalculateCertExpiration(startingFrom time.Time) time.Time {
+	return startingFrom.Add(DefaultCertValidFor)
+}
+
+func CalculateCertRotatesAt(certExpirationTime time.Time) time.Time {
+	return certExpirationTime.Add(-1 * DefaultCertMinFresh)
 }
 
 func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deploymentName string, ca *certs.KeyPair, expiration time.Time, depSpec appsv1.DeploymentSpec, ports []corev1.ServicePort) (*appsv1.DeploymentSpec, []byte, error) {
@@ -316,9 +326,12 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 			secret = existingSecret
 			caPEM = existingCAPEM
 			caHash = certs.PEMSHA256(caPEM)
-		} else if _, err := i.strategyClient.GetOpClient().UpdateSecret(secret); err != nil {
-			logger.Warnf("could not update secret %s", secret.GetName())
-			return nil, nil, err
+		} else {
+			if _, err := i.strategyClient.GetOpClient().UpdateSecret(secret); err != nil {
+				logger.Warnf("could not update secret %s", secret.GetName())
+				return nil, nil, err
+			}
+			i.certificatesRotated = true
 		}
 	} else if apierrors.IsNotFound(err) {
 		// Create the secret
@@ -335,6 +348,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 				return nil, nil, err
 			}
 		}
+		i.certificatesRotated = true
 	} else {
 		return nil, nil, err
 	}

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install/certresources.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install/certresources.go
@@ -9,7 +9,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -246,7 +246,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 
 		// Delete the Service to replace
 		deleteErr := i.strategyClient.GetOpClient().DeleteService(service.GetNamespace(), service.GetName(), &metav1.DeleteOptions{})
-		if deleteErr != nil && !k8serrors.IsNotFound(deleteErr) {
+		if deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
 			return nil, nil, fmt.Errorf("could not delete existing service %s", service.GetName())
 		}
 	}
@@ -315,12 +315,11 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 			logger.Warnf("could not update secret %s", secret.GetName())
 			return nil, nil, err
 		}
-
-	} else if k8serrors.IsNotFound(err) {
+	} else if apierrors.IsNotFound(err) {
 		// Create the secret
 		ownerutil.AddNonBlockingOwner(secret, i.owner)
 		if _, err := i.strategyClient.GetOpClient().CreateSecret(secret); err != nil {
-			if !k8serrors.IsAlreadyExists(err) {
+			if !apierrors.IsAlreadyExists(err) {
 				log.Warnf("could not create secret %s: %v", secret.GetName(), err)
 				return nil, nil, err
 			}
@@ -361,7 +360,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 			logger.Warnf("could not update secret role %s", secretRole.GetName())
 			return nil, nil, err
 		}
-	} else if k8serrors.IsNotFound(err) {
+	} else if apierrors.IsNotFound(err) {
 		// Create the role
 		ownerutil.AddNonBlockingOwner(secretRole, i.owner)
 		_, err = i.strategyClient.GetOpClient().CreateRole(secretRole)
@@ -407,7 +406,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 			logger.Warnf("could not update secret rolebinding %s", secretRoleBinding.GetName())
 			return nil, nil, err
 		}
-	} else if k8serrors.IsNotFound(err) {
+	} else if apierrors.IsNotFound(err) {
 		// Create the role
 		ownerutil.AddNonBlockingOwner(secretRoleBinding, i.owner)
 		_, err = i.strategyClient.GetOpClient().CreateRoleBinding(secretRoleBinding)
@@ -452,7 +451,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 			logger.Warnf("could not update auth delegator clusterrolebinding %s", authDelegatorClusterRoleBinding.GetName())
 			return nil, nil, err
 		}
-	} else if k8serrors.IsNotFound(err) {
+	} else if apierrors.IsNotFound(err) {
 		// Create the role.
 		if err := ownerutil.AddOwnerLabels(authDelegatorClusterRoleBinding, i.owner); err != nil {
 			return nil, nil, err
@@ -499,7 +498,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 			logger.Warnf("could not update auth reader role binding %s", authReaderRoleBinding.GetName())
 			return nil, nil, err
 		}
-	} else if k8serrors.IsNotFound(err) {
+	} else if apierrors.IsNotFound(err) {
 		// Create the role.
 		if err := ownerutil.AddOwnerLabels(authReaderRoleBinding, i.owner); err != nil {
 			return nil, nil, err

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install/deployment.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install/deployment.go
@@ -3,6 +3,7 @@ package install
 import (
 	"fmt"
 	"hash/fnv"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
@@ -22,13 +23,15 @@ import (
 const DeploymentSpecHashLabelKey = "olm.deployment-spec-hash"
 
 type StrategyDeploymentInstaller struct {
-	strategyClient         wrappers.InstallStrategyDeploymentInterface
-	owner                  ownerutil.Owner
-	previousStrategy       Strategy
-	templateAnnotations    map[string]string
-	initializers           DeploymentInitializerFuncChain
-	apiServiceDescriptions []certResource
-	webhookDescriptions    []certResource
+	strategyClient            wrappers.InstallStrategyDeploymentInterface
+	owner                     ownerutil.Owner
+	previousStrategy          Strategy
+	templateAnnotations       map[string]string
+	initializers              DeploymentInitializerFuncChain
+	apiServiceDescriptions    []certResource
+	webhookDescriptions       []certResource
+	certificateExpirationTime time.Time
+	certificatesRotated       bool
 }
 
 var _ Strategy = &v1alpha1.StrategyDetailsDeployment{}
@@ -77,13 +80,15 @@ func NewStrategyDeploymentInstaller(strategyClient wrappers.InstallStrategyDeplo
 	}
 
 	return &StrategyDeploymentInstaller{
-		strategyClient:         strategyClient,
-		owner:                  owner,
-		previousStrategy:       previousStrategy,
-		templateAnnotations:    templateAnnotations,
-		initializers:           initializers,
-		apiServiceDescriptions: apiDescs,
-		webhookDescriptions:    webhookDescs,
+		strategyClient:            strategyClient,
+		owner:                     owner,
+		previousStrategy:          previousStrategy,
+		templateAnnotations:       templateAnnotations,
+		initializers:              initializers,
+		apiServiceDescriptions:    apiDescs,
+		webhookDescriptions:       webhookDescs,
+		certificatesRotated:       false,
+		certificateExpirationTime: time.Time{},
 	}
 }
 

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install/deployment.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install/deployment.go
@@ -7,7 +7,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/utils/pointer"
@@ -209,7 +209,7 @@ func (i *StrategyDeploymentInstaller) Install(s Strategy) error {
 	}
 
 	if err := i.installDeployments(updatedStrategy.DeploymentSpecs); err != nil {
-		if k8serrors.IsForbidden(err) {
+		if apierrors.IsForbidden(err) {
 			return StrategyError{Reason: StrategyErrInsufficientPermissions, Message: fmt.Sprintf("install strategy failed: %s", err)}
 		}
 		return err

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install/resolver.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install/resolver.go
@@ -5,6 +5,7 @@ package install
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/wrappers"
@@ -20,6 +21,8 @@ type Strategy interface {
 type StrategyInstaller interface {
 	Install(strategy Strategy) error
 	CheckInstalled(strategy Strategy) (bool, error)
+	CertsRotateAt() time.Time
+	CertsRotated() bool
 }
 
 type StrategyResolverInterface interface {
@@ -67,4 +70,12 @@ func (i *NullStrategyInstaller) Install(s Strategy) error {
 
 func (i *NullStrategyInstaller) CheckInstalled(s Strategy) (bool, error) {
 	return true, nil
+}
+
+func (i *NullStrategyInstaller) CertsRotateAt() time.Time {
+	return time.Time{}
+}
+
+func (i *NullStrategyInstaller) CertsRotated() bool {
+	return false
 }

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
@@ -21,7 +21,7 @@ import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
 	extinf "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -628,7 +628,7 @@ func (o *Operator) syncConfigMap(logger *logrus.Entry, in *v1alpha1.CatalogSourc
 	// Get the catalog source's config map
 	configMap, err := o.lister.CoreV1().ConfigMapLister().ConfigMaps(in.GetNamespace()).Get(in.Spec.ConfigMap)
 	// Attempt to look up the CM via api call if there is a cache miss
-	if k8serrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		configMap, err = o.opClient.KubernetesInterface().CoreV1().ConfigMaps(in.GetNamespace()).Get(context.TODO(), in.Spec.ConfigMap, metav1.GetOptions{})
 		// Found cm in the cluster, add managed label to configmap
 		if err == nil {
@@ -2306,7 +2306,7 @@ func (o *Operator) ExecutePlan(plan *v1alpha1.InstallPlan) error {
 			}
 			return nil
 		}(i, step); err != nil {
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				// Check for APIVersions present in the installplan steps that are not available on the server.
 				// The check is made via discovery per step in the plan. Transient communication failures to the api-server are handled by the plan retry logic.
 				notFoundErr := discoveryQuerier.WithStepResource(step.Resource).QueryForGVK()

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/step.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/step.go
@@ -10,7 +10,7 @@ import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsv1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	apiextensionsv1beta1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/util/retry"
@@ -100,7 +100,7 @@ func (b *builder) NewCRDV1Step(client apiextensionsv1client.ApiextensionsV1Inter
 		case v1alpha1.StepStatusWaitingForAPI:
 			crd, err := client.CustomResourceDefinitions().Get(context.TODO(), step.Resource.Name, metav1.GetOptions{})
 			if err != nil {
-				if k8serrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					return v1alpha1.StepStatusNotPresent, nil
 				} else {
 					return v1alpha1.StepStatusNotPresent, errors.Wrapf(err, "error finding the %s CRD", crd.Name)
@@ -131,7 +131,7 @@ func (b *builder) NewCRDV1Step(client apiextensionsv1client.ApiextensionsV1Inter
 			setInstalledAlongsideAnnotation(b.annotator, crd, b.plan.GetNamespace(), step.Resolving, b.csvLister, crd)
 
 			_, createError := client.CustomResourceDefinitions().Create(context.TODO(), crd, metav1.CreateOptions{})
-			if k8serrors.IsAlreadyExists(createError) {
+			if apierrors.IsAlreadyExists(createError) {
 				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 					currentCRD, _ := client.CustomResourceDefinitions().Get(context.TODO(), crd.GetName(), metav1.GetOptions{})
 					crd.SetResourceVersion(currentCRD.GetResourceVersion())
@@ -184,7 +184,7 @@ func (b *builder) NewCRDV1Beta1Step(client apiextensionsv1beta1client.Apiextensi
 		case v1alpha1.StepStatusWaitingForAPI:
 			crd, err := client.CustomResourceDefinitions().Get(context.TODO(), step.Resource.Name, metav1.GetOptions{})
 			if err != nil {
-				if k8serrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					return v1alpha1.StepStatusNotPresent, nil
 				} else {
 					return v1alpha1.StepStatusNotPresent, fmt.Errorf("error finding the %q CRD: %w", crd.Name, err)
@@ -215,7 +215,7 @@ func (b *builder) NewCRDV1Beta1Step(client apiextensionsv1beta1client.Apiextensi
 			setInstalledAlongsideAnnotation(b.annotator, crd, b.plan.GetNamespace(), step.Resolving, b.csvLister, crd)
 
 			_, createError := client.CustomResourceDefinitions().Create(context.TODO(), crd, metav1.CreateOptions{})
-			if k8serrors.IsAlreadyExists(createError) {
+			if apierrors.IsAlreadyExists(createError) {
 				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 					currentCRD, _ := client.CustomResourceDefinitions().Get(context.TODO(), crd.GetName(), metav1.GetOptions{})
 					crd.SetResourceVersion(currentCRD.GetResourceVersion())
@@ -272,7 +272,7 @@ func setInstalledAlongsideAnnotation(a alongside.Annotator, dst metav1.Object, n
 				continue
 			}
 
-			if csv, err := lister.ClusterServiceVersions(nn.Namespace).Get(nn.Name); k8serrors.IsNotFound(err) {
+			if csv, err := lister.ClusterServiceVersions(nn.Namespace).Get(nn.Name); apierrors.IsNotFound(err) {
 				continue
 			} else if err == nil && csv.IsCopied() {
 				continue

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/step_ensurer.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/step_ensurer.go
@@ -8,7 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
@@ -43,7 +43,7 @@ func (o *StepEnsurer) EnsureClusterServiceVersion(csv *v1alpha1.ClusterServiceVe
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating csv %s", csv.GetName())
 		return
 	}
@@ -60,7 +60,7 @@ func (o *StepEnsurer) EnsureSubscription(subscription *v1alpha1.Subscription) (s
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating subscription %s", subscription.GetName())
 		return
 	}
@@ -74,7 +74,7 @@ func (o *StepEnsurer) EnsureSubscription(subscription *v1alpha1.Subscription) (s
 func (o *StepEnsurer) EnsureSecret(operatorNamespace, planNamespace, name string) (status v1alpha1.StepStatus, err error) {
 	secret, getError := o.kubeClient.KubernetesInterface().CoreV1().Secrets(operatorNamespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if getError != nil {
-		if k8serrors.IsNotFound(getError) {
+		if apierrors.IsNotFound(getError) {
 			err = fmt.Errorf("secret %s does not exist - %v", name, getError)
 			return
 		}
@@ -97,7 +97,7 @@ func (o *StepEnsurer) EnsureSecret(operatorNamespace, planNamespace, name string
 	}
 
 	if _, createError := o.kubeClient.KubernetesInterface().CoreV1().Secrets(planNamespace).Create(context.TODO(), newSecret, metav1.CreateOptions{}); createError != nil {
-		if k8serrors.IsAlreadyExists(createError) {
+		if apierrors.IsAlreadyExists(createError) {
 			status = v1alpha1.StepStatusPresent
 			return
 		}
@@ -118,7 +118,7 @@ func (o *StepEnsurer) EnsureBundleSecret(namespace string, secret *corev1.Secret
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error updating secret: %s", secret.GetName())
 		return
 	}
@@ -142,7 +142,7 @@ func (o *StepEnsurer) EnsureServiceAccount(namespace string, sa *corev1.ServiceA
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating service account: %s", sa.GetName())
 		return
 	}
@@ -180,7 +180,7 @@ func (o *StepEnsurer) EnsureService(namespace string, service *corev1.Service) (
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error updating service: %s", service.GetName())
 		return
 	}
@@ -203,7 +203,7 @@ func (o *StepEnsurer) EnsureClusterRole(cr *rbacv1.ClusterRole, step *v1alpha1.S
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating clusterrole %s", cr.GetName())
 		return
 	}
@@ -230,7 +230,7 @@ func (o *StepEnsurer) EnsureClusterRoleBinding(crb *rbacv1.ClusterRoleBinding, s
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating clusterrolebinding %s", crb.GetName())
 		return
 	}
@@ -257,7 +257,7 @@ func (o *StepEnsurer) EnsureRole(namespace string, role *rbacv1.Role) (status v1
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating role %s", role.GetName())
 		return
 	}
@@ -281,7 +281,7 @@ func (o *StepEnsurer) EnsureRoleBinding(namespace string, rb *rbacv1.RoleBinding
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating rolebinding %s", rb.GetName())
 		return
 	}
@@ -304,7 +304,7 @@ func (o *StepEnsurer) EnsureUnstructuredObject(client dynamic.ResourceInterface,
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error creating unstructured object %s", obj.GetName())
 		return
 	}
@@ -336,7 +336,7 @@ func (o *StepEnsurer) EnsureConfigMap(namespace string, configmap *corev1.Config
 		return
 	}
 
-	if !k8serrors.IsAlreadyExists(createErr) {
+	if !apierrors.IsAlreadyExists(createErr) {
 		err = errorwrap.Wrapf(createErr, "error updating configmap: %s", configmap.GetName())
 		return
 	}

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/apiservices.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/apiservices.go
@@ -7,7 +7,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -148,7 +148,7 @@ func (a *Operator) checkAPIServiceResources(csv *v1alpha1.ClusterServiceVersion,
 
 		// Ensure the existing Deployment has a matching CA hash annotation
 		deployment, err := a.lister.AppsV1().DeploymentLister().Deployments(csv.GetNamespace()).Get(desc.DeploymentName)
-		if k8serrors.IsNotFound(err) || err != nil {
+		if apierrors.IsNotFound(err) || err != nil {
 			logger.WithField("deployment", desc.DeploymentName).Warnf("expected Deployment could not be retrieved")
 			errs = append(errs, err)
 			continue
@@ -227,7 +227,7 @@ func (a *Operator) checkAPIServiceResources(csv *v1alpha1.ClusterServiceVersion,
 func (a *Operator) areAPIServicesAvailable(csv *v1alpha1.ClusterServiceVersion) (bool, error) {
 	for _, desc := range csv.Spec.APIServiceDefinitions.Owned {
 		apiService, err := a.lister.APIRegistrationV1().APIServiceLister().Get(desc.GetName())
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return false, nil
 		}
 
@@ -410,7 +410,7 @@ func (a *Operator) cleanUpRemovedWebhooks(csv *v1alpha1.ClusterServiceVersion) e
 		}
 		if _, ok := csvWebhookGenerateNames[webhookGenerateNameLabel]; !ok {
 			err = a.opClient.KubernetesInterface().AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(context.TODO(), webhook.Name, metav1.DeleteOptions{})
-			if err != nil && k8serrors.IsNotFound(err) {
+			if err != nil && apierrors.IsNotFound(err) {
 				return err
 			}
 		}
@@ -428,7 +428,7 @@ func (a *Operator) cleanUpRemovedWebhooks(csv *v1alpha1.ClusterServiceVersion) e
 		}
 		if _, ok := csvWebhookGenerateNames[webhookGenerateNameLabel]; !ok {
 			err = a.opClient.KubernetesInterface().AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(context.TODO(), webhook.Name, metav1.DeleteOptions{})
-			if err != nil && k8serrors.IsNotFound(err) {
+			if err != nil && apierrors.IsNotFound(err) {
 				return err
 			}
 		}

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/groups.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/groups.go
@@ -3,7 +3,7 @@ package olm
 import (
 	"strings"
 
-	v1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 )
 
@@ -106,14 +106,14 @@ type OperatorGroup struct {
 	providedAPIs cache.APISet
 }
 
-func NewOperatorGroup(group *v1.OperatorGroup) *OperatorGroup {
+func NewOperatorGroup(group *operatorsv1.OperatorGroup) *OperatorGroup {
 	// Add operatorgroup namespace if not NamespaceAll
 	namespaces := group.Status.Namespaces
 	if len(namespaces) >= 1 && namespaces[0] != "" {
 		namespaces = append(namespaces, group.GetNamespace())
 	}
 	// TODO: Sanitize OperatorGroup if len(namespaces) > 1 and contains ""
-	gvksStr := group.GetAnnotations()[v1.OperatorGroupProvidedAPIsAnnotationKey]
+	gvksStr := group.GetAnnotations()[operatorsv1.OperatorGroupProvidedAPIsAnnotationKey]
 
 	return &OperatorGroup{
 		namespace:    group.GetNamespace(),
@@ -123,7 +123,7 @@ func NewOperatorGroup(group *v1.OperatorGroup) *OperatorGroup {
 	}
 }
 
-func NewOperatorGroupSurfaces(groups ...v1.OperatorGroup) []OperatorGroupSurface {
+func NewOperatorGroupSurfaces(groups ...operatorsv1.OperatorGroup) []OperatorGroupSurface {
 	operatorGroups := make([]OperatorGroupSurface, len(groups))
 	for i, group := range groups {
 		operatorGroups[i] = NewOperatorGroup(&group)

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
@@ -1893,10 +1893,19 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 			return
 		}
 
-		if out.HasCAResources() {
+		// Only update certificate status if:
+		//  - the CSV has CAResources; and
+		//  - the certificate lastUpdated and rotateAt timestamps have not already been set, or the certificate should be rotated
+		// Note: the code here is a bit wonky and it wasn't clear how to clean it up without some major refactoring:
+		// the installer is in charge of generating and rotating the certificates. It detects whether a certificate should be rotated by
+		// looking at the csv.status.RotateAt value. But, it does not update this value or surface
+		// the certificate expiry information. So, the rotatedAt value is to be re-calculated here. This is bad because you have
+		// two different components doing the same thing (installer and operator are both calculating RotateAt). If we're not careful
+		// there could be skew
+		// See pkg/controller/install/certresources.go
+		if shouldUpdateCertificateDates(out) {
 			now := metav1.Now()
-			expiration := now.Add(install.DefaultCertValidFor)
-			rotateAt := expiration.Add(-1 * install.DefaultCertMinFresh)
+			_, rotateAt := install.CalculateCertExpirationAndRotateAt()
 			rotateTime := metav1.NewTime(rotateAt)
 			out.Status.CertsLastUpdated = &now
 			out.Status.CertsRotateAt = &rotateTime
@@ -2490,4 +2499,12 @@ func (a *Operator) ensureLabels(in *v1alpha1.ClusterServiceVersion, labelSets ..
 	out.SetLabels(merged)
 	out, err := a.client.OperatorsV1alpha1().ClusterServiceVersions(out.GetNamespace()).Update(context.TODO(), out, metav1.UpdateOptions{})
 	return out, err
+}
+
+// shouldUpdateCertificateDates checks the csv status to decide whether
+// status.CertsLastUpdated and status.CertsRotateAt should be updated
+// returns true if the CSV has CAResources and status.RotatedAt is not set OR its time to rotate the certificates
+func shouldUpdateCertificateDates(csv *v1alpha1.ClusterServiceVersion) bool {
+	isNotSet := csv.Status.CertsRotateAt == nil || csv.Status.CertsRotateAt.IsZero()
+	return csv.HasCAResources() && (isNotSet || install.ShouldRotateCerts(csv))
 }

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
@@ -7,13 +7,12 @@ import (
 	"strings"
 	"time"
 
-	v1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/sirupsen/logrus"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	extinf "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -30,6 +29,7 @@ import (
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	kagg "k8s.io/kube-aggregator/pkg/client/informers/externalversions"
 
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/informers/externalversions"
@@ -636,14 +636,14 @@ func (a *Operator) syncAPIService(obj interface{}) (syncError error) {
 
 	if name, ns, ok := ownerutil.GetOwnerByKindLabel(apiService, v1alpha1.ClusterServiceVersionKind); ok {
 		_, err := a.lister.CoreV1().NamespaceLister().Get(ns)
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			logger.Debug("Deleting api service since owning namespace is not found")
 			syncError = a.opClient.DeleteAPIService(apiService.GetName(), &metav1.DeleteOptions{})
 			return
 		}
 
 		_, err = a.lister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(ns).Get(name)
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			logger.Debug("Deleting api service since owning CSV is not found")
 			syncError = a.opClient.DeleteAPIService(apiService.GetName(), &metav1.DeleteOptions{})
 			return
@@ -714,7 +714,7 @@ func (a *Operator) syncGCObject(obj interface{}) (syncError error) {
 				logger.Debugf("CSV still present, must wait until it is deleted (owners=%v/%v)", ns, name)
 				syncError = fmt.Errorf("cleanup must wait")
 				return
-			} else if !k8serrors.IsNotFound(err) {
+			} else if !apierrors.IsNotFound(err) {
 				syncError = err
 				return
 			}
@@ -732,7 +732,7 @@ func (a *Operator) syncGCObject(obj interface{}) (syncError error) {
 				logger.Debugf("CSV still present, must wait until it is deleted (owners=%v)", name)
 				syncError = fmt.Errorf("cleanup must wait")
 				return
-			} else if !k8serrors.IsNotFound(err) {
+			} else if !apierrors.IsNotFound(err) {
 				syncError = err
 				return
 			}
@@ -750,7 +750,7 @@ func (a *Operator) syncGCObject(obj interface{}) (syncError error) {
 				logger.Debugf("CSV still present, must wait until it is deleted (owners=%v)", name)
 				syncError = fmt.Errorf("cleanup must wait")
 				return
-			} else if !k8serrors.IsNotFound(err) {
+			} else if !apierrors.IsNotFound(err) {
 				logger.Infof("error CSV retrieval error")
 				syncError = err
 				return
@@ -769,7 +769,7 @@ func (a *Operator) syncGCObject(obj interface{}) (syncError error) {
 				logger.Debugf("CSV still present, must wait until it is deleted (owners=%v)", name)
 				syncError = fmt.Errorf("cleanup must wait")
 				return
-			} else if !k8serrors.IsNotFound(err) {
+			} else if !apierrors.IsNotFound(err) {
 				logger.Infof("Error CSV retrieval error")
 				syncError = err
 				return
@@ -807,7 +807,7 @@ func (a *Operator) syncObject(obj interface{}) (syncError error) {
 			logger.Error("unexpected owner label retrieval failure")
 		}
 		_, err := a.lister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(ns).Get(name)
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			logger.Debug("requeueing owner csvs from owner label")
 			a.requeueOwnerCSVs(metaObj)
 		} else {
@@ -908,7 +908,7 @@ func (a *Operator) syncNamespace(obj interface{}) error {
 
 	// Remove existing OperatorGroup labels
 	for label := range namespace.GetLabels() {
-		if v1.IsOperatorGroupLabel(label) {
+		if operatorsv1.IsOperatorGroupLabel(label) {
 			delete(namespace.Labels, label)
 		}
 	}
@@ -998,19 +998,19 @@ func (a *Operator) handleClusterServiceVersionDeletion(obj interface{}) {
 		}
 	}(*clusterServiceVersion)
 
-	targetNamespaces, ok := clusterServiceVersion.Annotations[v1.OperatorGroupTargetsAnnotationKey]
+	targetNamespaces, ok := clusterServiceVersion.Annotations[operatorsv1.OperatorGroupTargetsAnnotationKey]
 	if !ok {
 		logger.Debug("missing target namespaces annotation on csv")
 		return
 	}
 
-	operatorNamespace, ok := clusterServiceVersion.Annotations[v1.OperatorGroupNamespaceAnnotationKey]
+	operatorNamespace, ok := clusterServiceVersion.Annotations[operatorsv1.OperatorGroupNamespaceAnnotationKey]
 	if !ok {
 		logger.Debug("missing operator namespace annotation on csv")
 		return
 	}
 
-	if _, ok = clusterServiceVersion.Annotations[v1.OperatorGroupAnnotationKey]; !ok {
+	if _, ok = clusterServiceVersion.Annotations[operatorsv1.OperatorGroupAnnotationKey]; !ok {
 		logger.Debug("missing operatorgroup name annotation on csv")
 		return
 	}
@@ -1041,7 +1041,7 @@ func (a *Operator) handleClusterServiceVersionDeletion(obj interface{}) {
 	for _, desc := range clusterServiceVersion.Spec.APIServiceDefinitions.Owned {
 		apiServiceName := fmt.Sprintf("%s.%s", desc.Version, desc.Group)
 		fetched, err := a.lister.APIRegistrationV1().APIServiceLister().Get(apiServiceName)
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			continue
 		}
 		if err != nil {
@@ -1118,7 +1118,7 @@ func (a *Operator) removeDanglingChildCSVs(csv *v1alpha1.ClusterServiceVersion) 
 		return nil
 	}
 
-	operatorNamespace, ok := csv.Annotations[v1.OperatorGroupNamespaceAnnotationKey]
+	operatorNamespace, ok := csv.Annotations[operatorsv1.OperatorGroupNamespaceAnnotationKey]
 	if !ok {
 		logger.Debug("missing operator namespace annotation on copied CSV")
 		return a.deleteChild(csv, logger)
@@ -1126,7 +1126,7 @@ func (a *Operator) removeDanglingChildCSVs(csv *v1alpha1.ClusterServiceVersion) 
 
 	logger = logger.WithField("parentNamespace", operatorNamespace)
 	parent, err := a.lister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(operatorNamespace).Get(csv.GetName())
-	if k8serrors.IsNotFound(err) || k8serrors.IsGone(err) || parent == nil {
+	if apierrors.IsNotFound(err) || apierrors.IsGone(err) || parent == nil {
 		logger.Debug("deleting copied CSV since parent is missing")
 		return a.deleteChild(csv, logger)
 	}
@@ -1137,8 +1137,8 @@ func (a *Operator) removeDanglingChildCSVs(csv *v1alpha1.ClusterServiceVersion) 
 	}
 
 	if annotations := parent.GetAnnotations(); annotations != nil {
-		if !NewNamespaceSetFromString(annotations[v1.OperatorGroupTargetsAnnotationKey]).Contains(csv.GetNamespace()) {
-			logger.WithField("parentTargets", annotations[v1.OperatorGroupTargetsAnnotationKey]).
+		if !NewNamespaceSetFromString(annotations[operatorsv1.OperatorGroupTargetsAnnotationKey]).Contains(csv.GetNamespace()) {
+			logger.WithField("parentTargets", annotations[operatorsv1.OperatorGroupTargetsAnnotationKey]).
 				Debug("deleting copied CSV since parent no longer lists this as a target namespace")
 			return a.deleteChild(csv, logger)
 		}
@@ -1236,13 +1236,13 @@ func (a *Operator) syncClusterServiceVersion(obj interface{}) (syncError error) 
 	return
 }
 
-func (a *Operator) allNamespaceOperatorGroups() ([]*v1.OperatorGroup, error) {
+func (a *Operator) allNamespaceOperatorGroups() ([]*operatorsv1.OperatorGroup, error) {
 	operatorGroups, err := a.lister.OperatorsV1().OperatorGroupLister().List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
 
-	result := []*v1.OperatorGroup{}
+	result := []*operatorsv1.OperatorGroup{}
 	for _, operatorGroup := range operatorGroups {
 		if NewNamespaceSet(operatorGroup.Status.Namespaces).IsAllNamespaces() {
 			result = append(result, operatorGroup.DeepCopy())
@@ -1252,8 +1252,8 @@ func (a *Operator) allNamespaceOperatorGroups() ([]*v1.OperatorGroup, error) {
 }
 
 func (a *Operator) syncOLMConfig(obj interface{}) (syncError error) {
-	a.logger.Info("Processing olmConfig")
-	olmConfig, ok := obj.(*v1.OLMConfig)
+	a.logger.Debug("Processing olmConfig")
+	olmConfig, ok := obj.(*operatorsv1.OLMConfig)
 	if !ok {
 		return fmt.Errorf("casting OLMConfig failed")
 	}
@@ -1331,7 +1331,7 @@ func isStatusConditionPresentAndAreTypeReasonMessageStatusEqual(conditions []met
 
 func getCopiedCSVsCondition(isDisabled, csvIsRequeued bool) metav1.Condition {
 	condition := metav1.Condition{
-		Type:               v1.DisabledCopiedCSVsConditionType,
+		Type:               operatorsv1.DisabledCopiedCSVsConditionType,
 		LastTransitionTime: metav1.Now(),
 		Status:             metav1.ConditionFalse,
 	}
@@ -1365,7 +1365,7 @@ func (a *Operator) syncCopyCSV(obj interface{}) (syncError error) {
 	}
 
 	olmConfig, err := a.client.OperatorsV1().OLMConfigs().Get(context.TODO(), "cluster", metav1.GetOptions{})
-	if err != nil && !k8serrors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
 
@@ -1429,7 +1429,7 @@ func (a *Operator) syncCopyCSV(obj interface{}) (syncError error) {
 
 	for _, copiedCSV := range copiedCSVs {
 		err := a.client.OperatorsV1alpha1().ClusterServiceVersions(copiedCSV.Namespace).Delete(context.TODO(), copiedCSV.Name, metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	}
@@ -1457,7 +1457,7 @@ func (a *Operator) copiedCSVsAreEnabled() (bool, error) {
 	olmConfig, err := a.client.OperatorsV1().OLMConfigs().Get(context.TODO(), "cluster", metav1.GetOptions{})
 	if err != nil {
 		// Default to true if olmConfig singleton cannot be found
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return true, nil
 		}
 		// If there was an error that wasn't an IsNotFound, return the error
@@ -1483,7 +1483,7 @@ func (a *Operator) getCopiedCSVDisabledEventsForCSV(csv *v1alpha1.ClusterService
 		if event.InvolvedObject.Namespace == csv.GetNamespace() &&
 			event.InvolvedObject.Name == csv.GetName() &&
 			event.InvolvedObject.UID == csv.GetUID() &&
-			event.Reason == v1.DisabledCopiedCSVsConditionType {
+			event.Reason == operatorsv1.DisabledCopiedCSVsConditionType {
 			result = append(result, *event.DeepCopy())
 		}
 	}
@@ -1504,7 +1504,7 @@ func (a *Operator) deleteCSVCopyingDisabledEvent(csv *v1alpha1.ClusterServiceVer
 func (a *Operator) deleteEvents(events []corev1.Event) error {
 	for _, event := range events {
 		err := a.opClient.KubernetesInterface().EventsV1().Events(event.GetNamespace()).Delete(context.TODO(), event.GetName(), metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	}
@@ -1528,7 +1528,7 @@ func (a *Operator) createCSVCopyingDisabledEvent(csv *v1alpha1.ClusterServiceVer
 		}
 	}
 
-	a.recorder.Eventf(csv, corev1.EventTypeWarning, v1.DisabledCopiedCSVsConditionType, "CSV copying disabled for %s/%s", csv.GetNamespace(), csv.GetName())
+	a.recorder.Eventf(csv, corev1.EventTypeWarning, operatorsv1.DisabledCopiedCSVsConditionType, "CSV copying disabled for %s/%s", csv.GetNamespace(), csv.GetName())
 
 	return nil
 }
@@ -1547,7 +1547,7 @@ func (a *Operator) syncGcCsv(obj interface{}) (syncError error) {
 }
 
 // operatorGroupFromAnnotations returns the OperatorGroup for the CSV only if the CSV is active one in the group
-func (a *Operator) operatorGroupFromAnnotations(logger *logrus.Entry, csv *v1alpha1.ClusterServiceVersion) *v1.OperatorGroup {
+func (a *Operator) operatorGroupFromAnnotations(logger *logrus.Entry, csv *v1alpha1.ClusterServiceVersion) *operatorsv1.OperatorGroup {
 	annotations := csv.GetAnnotations()
 
 	// Not part of a group yet
@@ -1557,12 +1557,12 @@ func (a *Operator) operatorGroupFromAnnotations(logger *logrus.Entry, csv *v1alp
 	}
 
 	// Not in the OperatorGroup namespace
-	if annotations[v1.OperatorGroupNamespaceAnnotationKey] != csv.GetNamespace() {
+	if annotations[operatorsv1.OperatorGroupNamespaceAnnotationKey] != csv.GetNamespace() {
 		logger.Info("not in operatorgroup namespace")
 		return nil
 	}
 
-	operatorGroupName, ok := annotations[v1.OperatorGroupAnnotationKey]
+	operatorGroupName, ok := annotations[operatorsv1.OperatorGroupAnnotationKey]
 
 	// No OperatorGroup annotation
 	if !ok {
@@ -1579,7 +1579,7 @@ func (a *Operator) operatorGroupFromAnnotations(logger *logrus.Entry, csv *v1alp
 		return nil
 	}
 
-	targets, ok := annotations[v1.OperatorGroupTargetsAnnotationKey]
+	targets, ok := annotations[operatorsv1.OperatorGroupTargetsAnnotationKey]
 
 	// No target annotation
 	if !ok {
@@ -1596,7 +1596,7 @@ func (a *Operator) operatorGroupFromAnnotations(logger *logrus.Entry, csv *v1alp
 	return operatorGroup.DeepCopy()
 }
 
-func (a *Operator) operatorGroupForCSV(csv *v1alpha1.ClusterServiceVersion, logger *logrus.Entry) (*v1.OperatorGroup, error) {
+func (a *Operator) operatorGroupForCSV(csv *v1alpha1.ClusterServiceVersion, logger *logrus.Entry) (*operatorsv1.OperatorGroup, error) {
 	now := a.now()
 
 	// Attempt to associate an OperatorGroup with the CSV.
@@ -1605,7 +1605,7 @@ func (a *Operator) operatorGroupForCSV(csv *v1alpha1.ClusterServiceVersion, logg
 		logger.Errorf("error occurred while attempting to associate csv with operatorgroup")
 		return nil, err
 	}
-	var operatorGroup *v1.OperatorGroup
+	var operatorGroup *operatorsv1.OperatorGroup
 
 	switch len(operatorGroups) {
 	case 0:
@@ -1702,7 +1702,7 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 	}
 
 	// Check if the CSV supports its operatorgroup's selected namespaces
-	targets, ok := out.GetAnnotations()[v1.OperatorGroupTargetsAnnotationKey]
+	targets, ok := out.GetAnnotations()[operatorsv1.OperatorGroupTargetsAnnotationKey]
 	if ok {
 		namespaces := strings.Split(targets, ",")
 
@@ -1719,7 +1719,11 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 
 	// Check for intersecting provided APIs in intersecting OperatorGroups
 	allGroups, err := a.lister.OperatorsV1().OperatorGroupLister().List(labels.Everything())
-	otherGroups := make([]v1.OperatorGroup, 0, len(allGroups))
+	if err != nil {
+		logger.WithError(err).Warn("failed to list operatorgroups")
+		return
+	}
+	otherGroups := make([]operatorsv1.OperatorGroup, 0, len(allGroups))
 	for _, g := range allGroups {
 		if g.GetName() != operatorGroup.GetName() || g.GetNamespace() != operatorGroup.GetNamespace() {
 			otherGroups = append(otherGroups, *g)
@@ -1755,16 +1759,16 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 		if unionedAnnotations == nil {
 			unionedAnnotations = make(map[string]string)
 		}
-		if unionedAnnotations[v1.OperatorGroupProvidedAPIsAnnotationKey] == union.String() {
+		if unionedAnnotations[operatorsv1.OperatorGroupProvidedAPIsAnnotationKey] == union.String() {
 			// resolver may think apis need adding with invalid input, so continue when there's no work
 			// to be done so that the CSV can progress far enough to get requirements checked
 			a.logger.Debug("operator group annotations up to date, continuing")
 			break
 		}
-		unionedAnnotations[v1.OperatorGroupProvidedAPIsAnnotationKey] = union.String()
+		unionedAnnotations[operatorsv1.OperatorGroupProvidedAPIsAnnotationKey] = union.String()
 		operatorGroup.SetAnnotations(unionedAnnotations)
-		if _, err := a.client.OperatorsV1().OperatorGroups(operatorGroup.GetNamespace()).Update(context.TODO(), operatorGroup, metav1.UpdateOptions{}); err != nil && !k8serrors.IsNotFound(err) {
-			syncError = fmt.Errorf("could not update operatorgroups %s annotation: %v", v1.OperatorGroupProvidedAPIsAnnotationKey, err)
+		if _, err := a.client.OperatorsV1().OperatorGroups(operatorGroup.GetNamespace()).Update(context.TODO(), operatorGroup, metav1.UpdateOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			syncError = fmt.Errorf("could not update operatorgroups %s annotation: %v", operatorsv1.OperatorGroupProvidedAPIsAnnotationKey, err)
 		}
 		if err := a.csvQueueSet.Requeue(out.GetNamespace(), out.GetName()); err != nil {
 			a.logger.WithError(err).Warn("unable to requeue")
@@ -1775,10 +1779,10 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 		logger.WithField("apis", providedAPIs).Debug("removing csv provided apis from operatorgroup")
 		difference := groupSurface.ProvidedAPIs().Difference(providedAPIs)
 		if diffedAnnotations := operatorGroup.GetAnnotations(); diffedAnnotations != nil {
-			diffedAnnotations[v1.OperatorGroupProvidedAPIsAnnotationKey] = difference.String()
+			diffedAnnotations[operatorsv1.OperatorGroupProvidedAPIsAnnotationKey] = difference.String()
 			operatorGroup.SetAnnotations(diffedAnnotations)
-			if _, err := a.client.OperatorsV1().OperatorGroups(operatorGroup.GetNamespace()).Update(context.TODO(), operatorGroup, metav1.UpdateOptions{}); err != nil && !k8serrors.IsNotFound(err) {
-				syncError = fmt.Errorf("could not update operatorgroups %s annotation: %v", v1.OperatorGroupProvidedAPIsAnnotationKey, err)
+			if _, err := a.client.OperatorsV1().OperatorGroups(operatorGroup.GetNamespace()).Update(context.TODO(), operatorGroup, metav1.UpdateOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				syncError = fmt.Errorf("could not update operatorgroups %s annotation: %v", operatorsv1.OperatorGroupProvidedAPIsAnnotationKey, err)
 			}
 		}
 		if err := a.csvQueueSet.Requeue(out.GetNamespace(), out.GetName()); err != nil {
@@ -1919,7 +1923,7 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 		}
 		if installErr := a.updateInstallStatus(out, installer, strategy, v1alpha1.CSVPhaseInstalling, v1alpha1.CSVReasonWaiting); installErr != nil {
 			// Re-sync if kube-apiserver was unavailable
-			if k8serrors.IsServiceUnavailable(installErr) {
+			if apierrors.IsServiceUnavailable(installErr) {
 				logger.WithError(installErr).Info("could not update install status")
 				syncError = installErr
 				return
@@ -1981,7 +1985,7 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 		}
 		if installErr := a.updateInstallStatus(out, installer, strategy, v1alpha1.CSVPhaseFailed, v1alpha1.CSVReasonComponentUnhealthy); installErr != nil {
 			// Re-sync if kube-apiserver was unavailable
-			if k8serrors.IsServiceUnavailable(installErr) {
+			if apierrors.IsServiceUnavailable(installErr) {
 				logger.WithError(installErr).Info("could not update install status")
 				syncError = installErr
 				return
@@ -2069,7 +2073,7 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 		}
 		if installErr := a.updateInstallStatus(out, installer, strategy, v1alpha1.CSVPhasePending, v1alpha1.CSVReasonNeedsReinstall); installErr != nil {
 			// Re-sync if kube-apiserver was unavailable
-			if k8serrors.IsServiceUnavailable(installErr) {
+			if apierrors.IsServiceUnavailable(installErr) {
 				logger.WithError(installErr).Info("could not update install status")
 				syncError = installErr
 				return
@@ -2152,7 +2156,7 @@ func (a *Operator) updateInstallStatus(csv *v1alpha1.ClusterServiceVersion, inst
 		return nil
 	}
 
-	if err := findFirstError(k8serrors.IsServiceUnavailable, strategyErr, apiServiceErr, webhookErr); err != nil {
+	if err := findFirstError(apierrors.IsServiceUnavailable, strategyErr, apiServiceErr, webhookErr); err != nil {
 		return err
 	}
 
@@ -2324,7 +2328,7 @@ func (a *Operator) apiServiceOwnerConflicts(csv *v1alpha1.ClusterServiceVersion)
 	for _, desc := range csv.GetOwnedAPIServiceDescriptions() {
 		// Check if the APIService exists
 		apiService, err := a.lister.APIRegistrationV1().APIServiceLister().Get(desc.GetName())
-		if err != nil && !k8serrors.IsNotFound(err) && !k8serrors.IsGone(err) {
+		if err != nil && !apierrors.IsNotFound(err) && !apierrors.IsGone(err) {
 			return err
 		}
 
@@ -2415,7 +2419,7 @@ func (a *Operator) requeueOwnerCSVs(ownee metav1.Object) {
 	if len(owners) > 0 && ownee.GetNamespace() != metav1.NamespaceAll {
 		for _, ownerCSV := range owners {
 			_, err := a.lister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(ownee.GetNamespace()).Get(ownerCSV.Name)
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				logger.Debugf("skipping requeue since CSV %v is not in cache", ownerCSV.Name)
 				continue
 			}
@@ -2431,7 +2435,7 @@ func (a *Operator) requeueOwnerCSVs(ownee metav1.Object) {
 	// Requeue owners based on labels
 	if name, ns, ok := ownerutil.GetOwnerByKindLabel(ownee, v1alpha1.ClusterServiceVersionKind); ok {
 		_, err := a.lister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(ns).Get(name)
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			logger.Debugf("skipping requeue since CSV %v is not in cache", name)
 			return
 		}

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
@@ -1893,20 +1893,9 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 			return
 		}
 
-		// Only update certificate status if:
-		//  - the CSV has CAResources; and
-		//  - the certificate lastUpdated and rotateAt timestamps have not already been set, or the certificate should be rotated
-		// Note: the code here is a bit wonky and it wasn't clear how to clean it up without some major refactoring:
-		// the installer is in charge of generating and rotating the certificates. It detects whether a certificate should be rotated by
-		// looking at the csv.status.RotateAt value. But, it does not update this value or surface
-		// the certificate expiry information. So, the rotatedAt value is to be re-calculated here. This is bad because you have
-		// two different components doing the same thing (installer and operator are both calculating RotateAt). If we're not careful
-		// there could be skew
-		// See pkg/controller/install/certresources.go
-		if shouldUpdateCertificateDates(out) {
+		if installer.CertsRotated() {
 			now := metav1.Now()
-			_, rotateAt := install.CalculateCertExpirationAndRotateAt()
-			rotateTime := metav1.NewTime(rotateAt)
+			rotateTime := metav1.NewTime(installer.CertsRotateAt())
 			out.Status.CertsLastUpdated = &now
 			out.Status.CertsRotateAt = &rotateTime
 		}
@@ -2499,12 +2488,4 @@ func (a *Operator) ensureLabels(in *v1alpha1.ClusterServiceVersion, labelSets ..
 	out.SetLabels(merged)
 	out, err := a.client.OperatorsV1alpha1().ClusterServiceVersions(out.GetNamespace()).Update(context.TODO(), out, metav1.UpdateOptions{})
 	return out, err
-}
-
-// shouldUpdateCertificateDates checks the csv status to decide whether
-// status.CertsLastUpdated and status.CertsRotateAt should be updated
-// returns true if the CSV has CAResources and status.RotatedAt is not set OR its time to rotate the certificates
-func shouldUpdateCertificateDates(csv *v1alpha1.ClusterServiceVersion) bool {
-	isNotSet := csv.Status.CertsRotateAt == nil || csv.Status.CertsRotateAt.IsZero()
-	return csv.HasCAResources() && (isNotSet || install.ShouldRotateCerts(csv))
 }

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/operatorconditions.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/operatorconditions.go
@@ -3,7 +3,7 @@ package olm
 import (
 	"fmt"
 
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -19,7 +19,7 @@ func (a *Operator) isOperatorUpgradeable(csv *v1alpha1.ClusterServiceVersion) (b
 
 	cond, err := a.lister.OperatorsV2().OperatorConditionLister().OperatorConditions(csv.GetNamespace()).Get(csv.GetName())
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return true, nil
 		}
 		return false, err

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/operatorgroup.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/operatorgroup.go
@@ -7,17 +7,17 @@ import (
 	"reflect"
 	"strings"
 
-	v1 "github.com/operator-framework/api/pkg/operators/v1"
 	utillabels "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/util/labels"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/errors"
 
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/decorators"
@@ -54,7 +54,7 @@ func aggregationLabelFromAPIKey(k opregistry.APIKey, suffix string) (string, err
 }
 
 func (a *Operator) syncOperatorGroups(obj interface{}) error {
-	op, ok := obj.(*v1.OperatorGroup)
+	op, ok := obj.(*operatorsv1.OperatorGroup)
 	if !ok {
 		a.logger.Debugf("wrong type: %#v\n", obj)
 		return fmt.Errorf("casting OperatorGroup failed")
@@ -74,10 +74,10 @@ func (a *Operator) syncOperatorGroups(obj interface{}) error {
 	// Check if there is a stale multiple OG condition and clear it if existed.
 	if len(groups) == 1 {
 		og := groups[0].DeepCopy()
-		if c := meta.FindStatusCondition(og.Status.Conditions, v1.MutlipleOperatorGroupCondition); c != nil {
-			meta.RemoveStatusCondition(&og.Status.Conditions, v1.MutlipleOperatorGroupCondition)
+		if c := meta.FindStatusCondition(og.Status.Conditions, operatorsv1.MutlipleOperatorGroupCondition); c != nil {
+			meta.RemoveStatusCondition(&og.Status.Conditions, operatorsv1.MutlipleOperatorGroupCondition)
 			if og.GetName() == op.GetName() {
-				meta.RemoveStatusCondition(&op.Status.Conditions, v1.MutlipleOperatorGroupCondition)
+				meta.RemoveStatusCondition(&op.Status.Conditions, operatorsv1.MutlipleOperatorGroupCondition)
 			}
 			_, err = a.client.OperatorsV1().OperatorGroups(op.GetNamespace()).UpdateStatus(context.TODO(), og, metav1.UpdateOptions{})
 			if err != nil {
@@ -88,14 +88,14 @@ func (a *Operator) syncOperatorGroups(obj interface{}) error {
 		// Add to all OG's status conditions to indicate they're multiple OGs in the
 		// same namespace which is not allowed.
 		cond := metav1.Condition{
-			Type:    v1.MutlipleOperatorGroupCondition,
+			Type:    operatorsv1.MutlipleOperatorGroupCondition,
 			Status:  metav1.ConditionTrue,
-			Reason:  v1.MultipleOperatorGroupsReason,
+			Reason:  operatorsv1.MultipleOperatorGroupsReason,
 			Message: "Multiple OperatorGroup found in the same namespace",
 		}
 		for i := range groups {
 			og := groups[i].DeepCopy()
-			if c := meta.FindStatusCondition(og.Status.Conditions, v1.MutlipleOperatorGroupCondition); c != nil {
+			if c := meta.FindStatusCondition(og.Status.Conditions, operatorsv1.MutlipleOperatorGroupCondition); c != nil {
 				continue
 			}
 			meta.SetStatusCondition(&og.Status.Conditions, cond)
@@ -122,7 +122,7 @@ func (a *Operator) syncOperatorGroups(obj interface{}) error {
 		}
 		for i := range csvList {
 			csv := csvList[i].DeepCopy()
-			if group, ok := csv.GetAnnotations()[v1.OperatorGroupAnnotationKey]; !ok || group != op.GetName() {
+			if group, ok := csv.GetAnnotations()[operatorsv1.OperatorGroupAnnotationKey]; !ok || group != op.GetName() {
 				continue
 			}
 			if csv.Status.Reason == v1alpha1.CSVReasonComponentFailedNoRetry {
@@ -152,13 +152,13 @@ func (a *Operator) syncOperatorGroups(obj interface{}) error {
 
 		// Update operatorgroup target namespace selection
 		logger.WithField("targets", targetNamespaces).Debug("namespace change detected")
-		op.Status = v1.OperatorGroupStatus{
+		op.Status = operatorsv1.OperatorGroupStatus{
 			Namespaces:  targetNamespaces,
 			LastUpdated: a.now(),
 			Conditions:  op.Status.Conditions,
 		}
 
-		if _, err = a.client.OperatorsV1().OperatorGroups(op.GetNamespace()).UpdateStatus(context.TODO(), op, metav1.UpdateOptions{}); err != nil && !k8serrors.IsNotFound(err) {
+		if _, err = a.client.OperatorsV1().OperatorGroups(op.GetNamespace()).UpdateStatus(context.TODO(), op, metav1.UpdateOptions{}); err != nil && !apierrors.IsNotFound(err) {
 			logger.WithError(err).Warn("operatorgroup update failed")
 			return err
 		}
@@ -223,7 +223,7 @@ func (a *Operator) syncOperatorGroups(obj interface{}) error {
 }
 
 func (a *Operator) operatorGroupDeleted(obj interface{}) {
-	op, ok := obj.(*v1.OperatorGroup)
+	op, ok := obj.(*operatorsv1.OperatorGroup)
 	if !ok {
 		a.logger.Debugf("casting OperatorGroup failed, wrong type: %#v\n", obj)
 		return
@@ -254,7 +254,7 @@ func (a *Operator) operatorGroupDeleted(obj interface{}) {
 	}
 }
 
-func (a *Operator) annotateCSVs(group *v1.OperatorGroup, targetNamespaces []string, logger *logrus.Entry) error {
+func (a *Operator) annotateCSVs(group *operatorsv1.OperatorGroup, targetNamespaces []string, logger *logrus.Entry) error {
 	updateErrs := []error{}
 	targetNamespaceSet := NewNamespaceSet(targetNamespaces)
 
@@ -264,13 +264,13 @@ func (a *Operator) annotateCSVs(group *v1.OperatorGroup, targetNamespaces []stri
 		}
 		logger := logger.WithField("csv", csv.GetName())
 
-		originalNamespacesAnnotation, _ := a.copyOperatorGroupAnnotations(&csv.ObjectMeta)[v1.OperatorGroupTargetsAnnotationKey]
+		originalNamespacesAnnotation, _ := a.copyOperatorGroupAnnotations(&csv.ObjectMeta)[operatorsv1.OperatorGroupTargetsAnnotationKey]
 		originalNamespaceSet := NewNamespaceSetFromString(originalNamespacesAnnotation)
 
 		if a.operatorGroupAnnotationsDiffer(&csv.ObjectMeta, group) {
 			a.setOperatorGroupAnnotations(&csv.ObjectMeta, group, true)
 			// CRDs don't support strategic merge patching, but in the future if they do this should be updated to patch
-			if _, err := a.client.OperatorsV1alpha1().ClusterServiceVersions(csv.GetNamespace()).Update(context.TODO(), csv, metav1.UpdateOptions{}); err != nil && !k8serrors.IsNotFound(err) {
+			if _, err := a.client.OperatorsV1alpha1().ClusterServiceVersions(csv.GetNamespace()).Update(context.TODO(), csv, metav1.UpdateOptions{}); err != nil && !apierrors.IsNotFound(err) {
 				logger.WithError(err).Warnf("error adding operatorgroup annotations")
 				updateErrs = append(updateErrs, err)
 				continue
@@ -298,7 +298,7 @@ func (a *Operator) annotateCSVs(group *v1.OperatorGroup, targetNamespaces []stri
 	return errors.NewAggregate(updateErrs)
 }
 
-func (a *Operator) providedAPIsFromCSVs(group *v1.OperatorGroup, logger *logrus.Entry) map[opregistry.APIKey]*v1alpha1.ClusterServiceVersion {
+func (a *Operator) providedAPIsFromCSVs(group *operatorsv1.OperatorGroup, logger *logrus.Entry) map[opregistry.APIKey]*v1alpha1.ClusterServiceVersion {
 	set := a.csvSet(group.Namespace, v1alpha1.CSVPhaseAny)
 	providedAPIsFromCSVs := make(map[opregistry.APIKey]*v1alpha1.ClusterServiceVersion)
 	for _, csv := range set {
@@ -323,7 +323,7 @@ func (a *Operator) providedAPIsFromCSVs(group *v1.OperatorGroup, logger *logrus.
 	return providedAPIsFromCSVs
 }
 
-func (a *Operator) pruneProvidedAPIs(group *v1.OperatorGroup, groupProvidedAPIs cache.APISet, providedAPIsFromCSVs map[opregistry.APIKey]*v1alpha1.ClusterServiceVersion, logger *logrus.Entry) {
+func (a *Operator) pruneProvidedAPIs(group *operatorsv1.OperatorGroup, groupProvidedAPIs cache.APISet, providedAPIsFromCSVs map[opregistry.APIKey]*v1alpha1.ClusterServiceVersion, logger *logrus.Entry) {
 	// Don't prune providedAPIsFromCSVs if static
 	if group.Spec.StaticProvidedAPIs {
 		a.logger.Debug("group has static provided apis. skipping provided api pruning")
@@ -337,7 +337,7 @@ func (a *Operator) pruneProvidedAPIs(group *v1.OperatorGroup, groupProvidedAPIs 
 		} else {
 			csv := providedAPIsFromCSVs[api]
 			_, err := a.lister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(csv.GetNamespace()).Get(csv.GetName())
-			if k8serrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				continue
 			}
 			if csv.DeletionTimestamp == nil && (csv.Status.Phase == v1alpha1.CSVPhaseNone || csv.Status.Phase == v1alpha1.CSVPhasePending) {
@@ -360,10 +360,10 @@ func (a *Operator) pruneProvidedAPIs(group *v1.OperatorGroup, groupProvidedAPIs 
 
 		// Don't need to check for nil annotations since we already know |annotations| > 0
 		annotations := group.GetAnnotations()
-		annotations[v1.OperatorGroupProvidedAPIsAnnotationKey] = intersection.String()
+		annotations[operatorsv1.OperatorGroupProvidedAPIsAnnotationKey] = intersection.String()
 		group.SetAnnotations(annotations)
 		logger.Debug("removing provided apis from annotation to match cluster state")
-		if _, err := a.client.OperatorsV1().OperatorGroups(group.GetNamespace()).Update(context.TODO(), group, metav1.UpdateOptions{}); err != nil && !k8serrors.IsNotFound(err) {
+		if _, err := a.client.OperatorsV1().OperatorGroups(group.GetNamespace()).Update(context.TODO(), group, metav1.UpdateOptions{}); err != nil && !apierrors.IsNotFound(err) {
 			logger.WithError(err).Warn("could not update provided api annotations")
 		}
 	}
@@ -391,12 +391,15 @@ func (a *Operator) ensureProvidedAPIClusterRole(namePrefix, suffix string, verbs
 	}
 
 	existingCR, err := a.lister.RbacV1().ClusterRoleLister().Get(clusterRole.Name)
-	if existingCR == nil {
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	if apierrors.IsNotFound(err) {
 		existingCR, err = a.opClient.KubernetesInterface().RbacV1().ClusterRoles().Create(context.TODO(), clusterRole, metav1.CreateOptions{})
 		if err == nil {
 			return nil
 		}
-		if !k8serrors.IsAlreadyExists(err) {
+		if !apierrors.IsAlreadyExists(err) {
 			a.logger.WithError(err).Errorf("Create cluster role failed: %v", clusterRole)
 			return err
 		}
@@ -454,7 +457,7 @@ func (a *Operator) ensureClusterRolesForCSV(csv *v1alpha1.ClusterServiceVersion)
 	return nil
 }
 
-func (a *Operator) ensureRBACInTargetNamespace(csv *v1alpha1.ClusterServiceVersion, operatorGroup *v1.OperatorGroup) error {
+func (a *Operator) ensureRBACInTargetNamespace(csv *v1alpha1.ClusterServiceVersion, operatorGroup *operatorsv1.OperatorGroup) error {
 	targetNamespaces := operatorGroup.Status.Namespaces
 	if targetNamespaces == nil {
 		return nil
@@ -535,7 +538,7 @@ func (a *Operator) ensureSingletonRBAC(operatorNamespace string, csv *v1alpha1.C
 			// TODO: this should do something smarter if the cluster role already exists
 			if cr, err := a.opClient.CreateClusterRole(clusterRole); err != nil {
 				// If the CR already exists, but the label is correct, the cache is just behind
-				if k8serrors.IsAlreadyExists(err) && cr != nil && ownerutil.IsOwnedByLabel(cr, csv) {
+				if apierrors.IsAlreadyExists(err) && cr != nil && ownerutil.IsOwnedByLabel(cr, csv) {
 					continue
 				}
 				return err
@@ -574,7 +577,7 @@ func (a *Operator) ensureSingletonRBAC(operatorNamespace string, csv *v1alpha1.C
 			// TODO: this should do something smarter if the cluster role binding already exists
 			if crb, err := a.opClient.CreateClusterRoleBinding(clusterRoleBinding); err != nil {
 				// If the CRB already exists, but the label is correct, the cache is just behind
-				if k8serrors.IsAlreadyExists(err) && crb != nil && ownerutil.IsOwnedByLabel(crb, csv) {
+				if apierrors.IsAlreadyExists(err) && crb != nil && ownerutil.IsOwnedByLabel(crb, csv) {
 					continue
 				}
 				return err
@@ -688,7 +691,7 @@ func (a *Operator) ensureTenantRBAC(operatorNamespace, targetNamespace string, c
 	return nil
 }
 
-func (a *Operator) ensureCSVsInNamespaces(csv *v1alpha1.ClusterServiceVersion, operatorGroup *v1.OperatorGroup, targets NamespaceSet) error {
+func (a *Operator) ensureCSVsInNamespaces(csv *v1alpha1.ClusterServiceVersion, operatorGroup *operatorsv1.OperatorGroup, targets NamespaceSet) error {
 	namespaces, err := a.lister.CoreV1().NamespaceLister().List(labels.Everything())
 	if err != nil {
 		return err
@@ -798,8 +801,8 @@ func (a *Operator) copyToNamespace(prototype *v1alpha1.ClusterServiceVersion, ns
 	prototype.UID = ""
 
 	existing, err := a.copiedCSVLister.ClusterServiceVersions(nsTo).Get(prototype.GetName())
-	if k8serrors.IsNotFound(err) {
 
+	if apierrors.IsNotFound(err) {
 		created, err := a.client.OperatorsV1alpha1().ClusterServiceVersions(nsTo).Create(context.TODO(), prototype, metav1.CreateOptions{})
 		if err != nil {
 			return nil, err
@@ -856,7 +859,7 @@ func (a *Operator) pruneFromNamespace(operatorGroupName, namespace string) error
 	}
 
 	for _, csv := range fetchedCSVs {
-		if csv.IsCopied() && csv.GetAnnotations()[v1.OperatorGroupAnnotationKey] == operatorGroupName {
+		if csv.IsCopied() && csv.GetAnnotations()[operatorsv1.OperatorGroupAnnotationKey] == operatorGroupName {
 			a.logger.Debugf("Found CSV '%v' in namespace %v to delete", csv.GetName(), namespace)
 			if err := a.copiedCSVGCQueueSet.Requeue(csv.GetNamespace(), csv.GetName()); err != nil {
 				return err
@@ -866,36 +869,36 @@ func (a *Operator) pruneFromNamespace(operatorGroupName, namespace string) error
 	return nil
 }
 
-func (a *Operator) setOperatorGroupAnnotations(obj *metav1.ObjectMeta, op *v1.OperatorGroup, addTargets bool) {
-	metav1.SetMetaDataAnnotation(obj, v1.OperatorGroupNamespaceAnnotationKey, op.GetNamespace())
-	metav1.SetMetaDataAnnotation(obj, v1.OperatorGroupAnnotationKey, op.GetName())
+func (a *Operator) setOperatorGroupAnnotations(obj *metav1.ObjectMeta, op *operatorsv1.OperatorGroup, addTargets bool) {
+	metav1.SetMetaDataAnnotation(obj, operatorsv1.OperatorGroupNamespaceAnnotationKey, op.GetNamespace())
+	metav1.SetMetaDataAnnotation(obj, operatorsv1.OperatorGroupAnnotationKey, op.GetName())
 
 	if addTargets && op.Status.Namespaces != nil {
-		metav1.SetMetaDataAnnotation(obj, v1.OperatorGroupTargetsAnnotationKey, op.BuildTargetNamespaces())
+		metav1.SetMetaDataAnnotation(obj, operatorsv1.OperatorGroupTargetsAnnotationKey, op.BuildTargetNamespaces())
 	}
 }
 
-func (a *Operator) operatorGroupAnnotationsDiffer(obj *metav1.ObjectMeta, op *v1.OperatorGroup) bool {
+func (a *Operator) operatorGroupAnnotationsDiffer(obj *metav1.ObjectMeta, op *operatorsv1.OperatorGroup) bool {
 	annotations := obj.GetAnnotations()
 	if annotations == nil {
 		return true
 	}
-	if operatorGroupNamespace, ok := annotations[v1.OperatorGroupNamespaceAnnotationKey]; !ok || operatorGroupNamespace != op.GetNamespace() {
+	if operatorGroupNamespace, ok := annotations[operatorsv1.OperatorGroupNamespaceAnnotationKey]; !ok || operatorGroupNamespace != op.GetNamespace() {
 		return true
 	}
-	if operatorGroup, ok := annotations[v1.OperatorGroupAnnotationKey]; !ok || operatorGroup != op.GetName() {
+	if operatorGroup, ok := annotations[operatorsv1.OperatorGroupAnnotationKey]; !ok || operatorGroup != op.GetName() {
 		return true
 	}
-	if targets, ok := annotations[v1.OperatorGroupTargetsAnnotationKey]; !ok || targets != op.BuildTargetNamespaces() {
+	if targets, ok := annotations[operatorsv1.OperatorGroupTargetsAnnotationKey]; !ok || targets != op.BuildTargetNamespaces() {
 		a.logger.WithFields(logrus.Fields{
-			"annotationTargets": annotations[v1.OperatorGroupTargetsAnnotationKey],
+			"annotationTargets": annotations[operatorsv1.OperatorGroupTargetsAnnotationKey],
 			"opgroupTargets":    op.BuildTargetNamespaces(),
 		}).Debug("annotations different")
 		return true
 	}
 
 	a.logger.WithFields(logrus.Fields{
-		"annotationTargets": annotations[v1.OperatorGroupTargetsAnnotationKey],
+		"annotationTargets": annotations[operatorsv1.OperatorGroupTargetsAnnotationKey],
 		"opgroupTargets":    op.BuildTargetNamespaces(),
 	}).Debug("annotations correct")
 	return false
@@ -905,11 +908,11 @@ func (a *Operator) copyOperatorGroupAnnotations(obj *metav1.ObjectMeta) map[stri
 	copiedAnnotations := make(map[string]string)
 	for k, v := range obj.GetAnnotations() {
 		switch k {
-		case v1.OperatorGroupNamespaceAnnotationKey:
+		case operatorsv1.OperatorGroupNamespaceAnnotationKey:
 			fallthrough
-		case v1.OperatorGroupAnnotationKey:
+		case operatorsv1.OperatorGroupAnnotationKey:
 			fallthrough
-		case v1.OperatorGroupTargetsAnnotationKey:
+		case operatorsv1.OperatorGroupTargetsAnnotationKey:
 			copiedAnnotations[k] = v
 		}
 	}
@@ -933,7 +936,7 @@ func namespacesChanged(clusterNamespaces []string, statusNamespaces []string) bo
 	return false
 }
 
-func (a *Operator) getOperatorGroupTargets(op *v1.OperatorGroup) (map[string]struct{}, error) {
+func (a *Operator) getOperatorGroupTargets(op *operatorsv1.OperatorGroup) (map[string]struct{}, error) {
 	selector, err := metav1.LabelSelectorAsSelector(op.Spec.Selector)
 
 	if err != nil {
@@ -965,7 +968,7 @@ func (a *Operator) getOperatorGroupTargets(op *v1.OperatorGroup) (map[string]str
 	return namespaceSet, nil
 }
 
-func (a *Operator) updateNamespaceList(op *v1.OperatorGroup) ([]string, error) {
+func (a *Operator) updateNamespaceList(op *operatorsv1.OperatorGroup) ([]string, error) {
 	namespaceSet, err := a.getOperatorGroupTargets(op)
 	if err != nil {
 		return nil, err
@@ -978,7 +981,7 @@ func (a *Operator) updateNamespaceList(op *v1.OperatorGroup) ([]string, error) {
 	return namespaceList, nil
 }
 
-func (a *Operator) ensureOpGroupClusterRole(op *v1.OperatorGroup, suffix string, apis cache.APISet) error {
+func (a *Operator) ensureOpGroupClusterRole(op *operatorsv1.OperatorGroup, suffix string, apis cache.APISet) error {
 	clusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: strings.Join([]string{op.GetName(), suffix}, "-"),
@@ -1007,12 +1010,15 @@ func (a *Operator) ensureOpGroupClusterRole(op *v1.OperatorGroup, suffix string,
 	}
 
 	existingRole, err := a.lister.RbacV1().ClusterRoleLister().Get(clusterRole.Name)
-	if existingRole == nil {
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	if apierrors.IsNotFound(err) {
 		existingRole, err = a.opClient.KubernetesInterface().RbacV1().ClusterRoles().Create(context.TODO(), clusterRole, metav1.CreateOptions{})
 		if err == nil {
 			return nil
 		}
-		if !k8serrors.IsAlreadyExists(err) {
+		if !apierrors.IsAlreadyExists(err) {
 			a.logger.WithError(err).Errorf("Create cluster role failed: %v", clusterRole)
 			return err
 		}
@@ -1029,7 +1035,7 @@ func (a *Operator) ensureOpGroupClusterRole(op *v1.OperatorGroup, suffix string,
 	return nil
 }
 
-func (a *Operator) ensureOpGroupClusterRoles(op *v1.OperatorGroup, apis cache.APISet) error {
+func (a *Operator) ensureOpGroupClusterRoles(op *operatorsv1.OperatorGroup, apis cache.APISet) error {
 	for _, suffix := range Suffices {
 		if err := a.ensureOpGroupClusterRole(op, suffix, apis); err != nil {
 			return err
@@ -1105,7 +1111,7 @@ func csvCopyPrototype(src, dst *v1alpha1.ClusterServiceVersion) {
 		Status: src.Status,
 	}
 	for k, v := range src.Annotations {
-		if k == v1.OperatorGroupTargetsAnnotationKey {
+		if k == operatorsv1.OperatorGroupTargetsAnnotationKey {
 			continue
 		}
 		if k == "kubectl.kubernetes.io/last-applied-configuration" {

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/operatorcondition_controller.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/operatorcondition_controller.go
@@ -8,7 +8,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -150,7 +150,7 @@ func (r *OperatorConditionReconciler) ensureOperatorConditionRole(operatorCondit
 	existingRole := &rbacv1.Role{}
 	err := r.Client.Get(context.TODO(), client.ObjectKey{Name: role.GetName(), Namespace: role.GetNamespace()}, existingRole)
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 		return r.Client.Create(context.TODO(), role)
@@ -196,7 +196,7 @@ func (r *OperatorConditionReconciler) ensureOperatorConditionRoleBinding(operato
 	existingRoleBinding := &rbacv1.RoleBinding{}
 	err := r.Client.Get(context.TODO(), client.ObjectKey{Name: roleBinding.GetName(), Namespace: roleBinding.GetNamespace()}, existingRoleBinding)
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 		return r.Client.Create(context.TODO(), roleBinding)

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/operatorconditiongenerator_controller.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/operatorconditiongenerator_controller.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 
 	"github.com/go-logr/logr"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -156,7 +156,7 @@ func (r *OperatorConditionGeneratorReconciler) ensureOperatorCondition(operatorC
 	existingOperatorCondition := &operatorsv2.OperatorCondition{}
 	err := r.Client.Get(context.TODO(), client.ObjectKey{Name: operatorCondition.GetName(), Namespace: operatorCondition.GetNamespace()}, existingOperatorCondition)
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 		return r.Client.Create(context.TODO(), &operatorCondition)

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/grpc.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/grpc.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	k8serror "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -208,7 +208,7 @@ func (c *GrpcRegistryReconciler) EnsureRegistryServer(catalogSource *v1alpha1.Ca
 	// recreate the pod if no existing pod is serving the latest image or correct spec
 	overwritePod := overwrite || len(c.currentPodsWithCorrectImageAndSpec(source, sa.GetName())) == 0
 
-	if err != nil && !k8serror.IsAlreadyExists(err) {
+	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return errors.Wrapf(err, "error ensuring service account: %s", source.GetName())
 	}
 	if err := c.ensurePod(source, sa.GetName(), overwritePod); err != nil {
@@ -261,7 +261,7 @@ func (c *GrpcRegistryReconciler) ensurePod(source grpcCatalogSourceDecorator, sa
 			return nil
 		}
 		for _, p := range currentLivePods {
-			if err := c.OpClient.KubernetesInterface().CoreV1().Pods(source.GetNamespace()).Delete(context.TODO(), p.GetName(), *metav1.NewDeleteOptions(1)); err != nil && !k8serror.IsNotFound(err) {
+			if err := c.OpClient.KubernetesInterface().CoreV1().Pods(source.GetNamespace()).Delete(context.TODO(), p.GetName(), *metav1.NewDeleteOptions(1)); err != nil && !apierrors.IsNotFound(err) {
 				return errors.Wrapf(err, "error deleting old pod: %s", p.GetName())
 			}
 		}
@@ -343,7 +343,7 @@ func (c *GrpcRegistryReconciler) ensureService(source grpcCatalogSourceDecorator
 			return nil
 		}
 		// TODO(tflannag): Do we care about force deleting services?
-		if err := c.OpClient.DeleteService(service.GetNamespace(), service.GetName(), metav1.NewDeleteOptions(0)); err != nil && !k8serror.IsNotFound(err) {
+		if err := c.OpClient.DeleteService(service.GetNamespace(), service.GetName(), metav1.NewDeleteOptions(0)); err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	}
@@ -438,7 +438,7 @@ func imageID(pod *corev1.Pod) string {
 
 func (c *GrpcRegistryReconciler) removePods(pods []*corev1.Pod, namespace string) error {
 	for _, p := range pods {
-		if err := c.OpClient.KubernetesInterface().CoreV1().Pods(namespace).Delete(context.TODO(), p.GetName(), *metav1.NewDeleteOptions(1)); err != nil && !k8serror.IsNotFound(err) {
+		if err := c.OpClient.KubernetesInterface().CoreV1().Pods(namespace).Delete(context.TODO(), p.GetName(), *metav1.NewDeleteOptions(1)); err != nil && !apierrors.IsNotFound(err) {
 			return errors.Wrapf(err, "error deleting pod: %s", p.GetName())
 		}
 	}

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
@@ -6,12 +6,12 @@ import (
 	"hash/fnv"
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	controllerclient "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/controller-runtime/client"
 	hashutil "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/util/hash"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
@@ -34,13 +34,13 @@ const (
 // RegistryEnsurer describes methods for ensuring a registry exists.
 type RegistryEnsurer interface {
 	// EnsureRegistryServer ensures a registry server exists for the given CatalogSource.
-	EnsureRegistryServer(catalogSource *v1alpha1.CatalogSource) error
+	EnsureRegistryServer(catalogSource *operatorsv1alpha1.CatalogSource) error
 }
 
 // RegistryChecker describes methods for checking a registry.
 type RegistryChecker interface {
 	// CheckRegistryServer returns true if the given CatalogSource is considered healthy; false otherwise.
-	CheckRegistryServer(catalogSource *v1alpha1.CatalogSource) (healthy bool, err error)
+	CheckRegistryServer(catalogSource *operatorsv1alpha1.CatalogSource) (healthy bool, err error)
 }
 
 // RegistryReconciler knows how to reconcile a registry.
@@ -51,7 +51,7 @@ type RegistryReconciler interface {
 
 // RegistryReconcilerFactory describes factory methods for RegistryReconcilers.
 type RegistryReconcilerFactory interface {
-	ReconcilerForSource(source *v1alpha1.CatalogSource) RegistryReconciler
+	ReconcilerForSource(source *operatorsv1alpha1.CatalogSource) RegistryReconciler
 }
 
 // RegistryReconcilerFactory is a factory for RegistryReconcilers.
@@ -64,17 +64,17 @@ type registryReconcilerFactory struct {
 }
 
 // ReconcilerForSource returns a RegistryReconciler based on the configuration of the given CatalogSource.
-func (r *registryReconcilerFactory) ReconcilerForSource(source *v1alpha1.CatalogSource) RegistryReconciler {
+func (r *registryReconcilerFactory) ReconcilerForSource(source *operatorsv1alpha1.CatalogSource) RegistryReconciler {
 	// TODO: add memoization by source type
 	switch source.Spec.SourceType {
-	case v1alpha1.SourceTypeInternal, v1alpha1.SourceTypeConfigmap:
+	case operatorsv1alpha1.SourceTypeInternal, operatorsv1alpha1.SourceTypeConfigmap:
 		return &ConfigMapRegistryReconciler{
 			now:      r.now,
 			Lister:   r.Lister,
 			OpClient: r.OpClient,
 			Image:    r.ConfigMapServerImage,
 		}
-	case v1alpha1.SourceTypeGrpc:
+	case operatorsv1alpha1.SourceTypeGrpc:
 		if source.Spec.Image != "" {
 			return &GrpcRegistryReconciler{
 				now:       r.now,
@@ -102,15 +102,15 @@ func NewRegistryReconcilerFactory(lister operatorlister.OperatorLister, opClient
 	}
 }
 
-func Pod(source *v1alpha1.CatalogSource, name string, image string, saName string, labels map[string]string, annotations map[string]string, readinessDelay int32, livenessDelay int32) *v1.Pod {
+func Pod(source *operatorsv1alpha1.CatalogSource, name string, image string, saName string, labels map[string]string, annotations map[string]string, readinessDelay int32, livenessDelay int32) *corev1.Pod {
 	// Ensure the catalog image is always pulled if the image is not based on a digest, measured by whether an "@" is included.
 	// See https://github.com/docker/distribution/blob/master/reference/reference.go for more info.
 	// This means recreating non-digest based catalog pods will result in the latest version of the catalog content being delivered on-cluster.
-	var pullPolicy v1.PullPolicy
+	var pullPolicy corev1.PullPolicy
 	if strings.Contains(image, "@") {
-		pullPolicy = v1.PullIfNotPresent
+		pullPolicy = corev1.PullIfNotPresent
 	} else {
-		pullPolicy = v1.PullAlways
+		pullPolicy = corev1.PullAlways
 	}
 
 	// make a copy of the labels and annotations to avoid mutating the input parameters
@@ -127,62 +127,62 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, saName strin
 
 	readOnlyRootFilesystem := false
 
-	pod := &v1.Pod{
+	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: source.GetName() + "-",
 			Namespace:    source.GetNamespace(),
 			Labels:       podLabels,
 			Annotations:  podAnnotations,
 		},
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
 				{
 					Name:  name,
 					Image: image,
-					Ports: []v1.ContainerPort{
+					Ports: []corev1.ContainerPort{
 						{
 							Name:          "grpc",
 							ContainerPort: 50051,
 						},
 					},
-					ReadinessProbe: &v1.Probe{
-						Handler: v1.Handler{
-							Exec: &v1.ExecAction{
+					ReadinessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							Exec: &corev1.ExecAction{
 								Command: []string{"grpc_health_probe", "-addr=:50051"},
 							},
 						},
 						InitialDelaySeconds: readinessDelay,
 						TimeoutSeconds:      5,
 					},
-					LivenessProbe: &v1.Probe{
-						Handler: v1.Handler{
-							Exec: &v1.ExecAction{
+					LivenessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							Exec: &corev1.ExecAction{
 								Command: []string{"grpc_health_probe", "-addr=:50051"},
 							},
 						},
 						InitialDelaySeconds: livenessDelay,
 						TimeoutSeconds:      5,
 					},
-					StartupProbe: &v1.Probe{
-						Handler: v1.Handler{
-							Exec: &v1.ExecAction{
+					StartupProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							Exec: &corev1.ExecAction{
 								Command: []string{"grpc_health_probe", "-addr=:50051"},
 							},
 						},
 						FailureThreshold: 15,
 						PeriodSeconds:    10,
 					},
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceCPU:    resource.MustParse("10m"),
-							v1.ResourceMemory: resource.MustParse("50Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("10m"),
+							corev1.ResourceMemory: resource.MustParse("50Mi"),
 						},
 					},
-					SecurityContext: &v1.SecurityContext{
+					SecurityContext: &corev1.SecurityContext{
 						ReadOnlyRootFilesystem: &readOnlyRootFilesystem,
 					},
 					ImagePullPolicy:          pullPolicy,
-					TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 				},
 			},
 			NodeSelector: map[string]string{
@@ -211,7 +211,7 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, saName strin
 
 		// Override tolerations
 		if grpcPodConfig.Tolerations != nil {
-			pod.Spec.Tolerations = make([]v1.Toleration, len(grpcPodConfig.Tolerations))
+			pod.Spec.Tolerations = make([]corev1.Toleration, len(grpcPodConfig.Tolerations))
 			for index, toleration := range grpcPodConfig.Tolerations {
 				pod.Spec.Tolerations[index] = *toleration.DeepCopy()
 			}
@@ -235,7 +235,7 @@ func Pod(source *v1alpha1.CatalogSource, name string, image string, saName strin
 }
 
 // hashPodSpec calculates a hash given a copy of the pod spec
-func hashPodSpec(spec v1.PodSpec) string {
+func hashPodSpec(spec corev1.PodSpec) string {
 	hasher := fnv.New32a()
 	hashutil.DeepHashObject(hasher, &spec)
 	return rand.SafeEncodeString(fmt.Sprint(hasher.Sum32()))

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorstatus/clusteroperatorwriter.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorstatus/clusteroperatorwriter.go
@@ -7,7 +7,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -36,7 +36,7 @@ func (w *Writer) EnsureExists(name string) (existing *configv1.ClusterOperator, 
 		return
 	}
 
-	if !k8serrors.IsNotFound(err) {
+	if !apierrors.IsNotFound(err) {
 		return
 	}
 

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorstatus/status.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorstatus/status.go
@@ -12,7 +12,7 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/diff"
@@ -87,7 +87,7 @@ func MonitorClusterStatus(name string, syncCh <-chan error, stopCh <-chan struct
 
 		// create the cluster operator in an initial state if it does not exist
 		existing, err := configClient.ClusterOperators().Get(context.TODO(), name, metav1.GetOptions{})
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.Info("Existing operator status not found, creating")
 			created, createErr := configClient.ClusterOperators().Create(context.TODO(), &configv1.ClusterOperator{
 				ObjectMeta: metav1.ObjectMeta{

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/lib/proxy/syncer.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/lib/proxy/syncer.go
@@ -11,7 +11,7 @@ import (
 	listers "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/discovery"
 )
 
@@ -49,7 +49,7 @@ type Syncer struct {
 func (w *Syncer) QueryProxyConfig() (proxy []corev1.EnvVar, err error) {
 	global, getErr := w.lister.Get(globalProxyName)
 	if getErr != nil {
-		if !k8serrors.IsNotFound(getErr) {
+		if !apierrors.IsNotFound(getErr) {
 			err = getErr
 			return
 		}

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/lib/scoped/syncer.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/lib/scoped/syncer.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -79,7 +79,7 @@ func (s *UserDefinedServiceAccountSyncer) SyncOperatorGroup(in *v1.OperatorGroup
 	// A service account has been specified, we need to update the status.
 	sa, err := s.client.KubernetesInterface().CoreV1().ServiceAccounts(namespace).Get(context.TODO(), serviceAccountName, metav1.GetOptions{})
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			// Set OG's status condition to indicate SA is not found
 			cond := metav1.Condition{
 				Type:    v1.OperatorGroupServiceAccountCondition,

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/lib/scoped/token_retriever.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/lib/scoped/token_retriever.go
@@ -7,7 +7,7 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -54,7 +54,7 @@ func getAPISecret(logger logrus.FieldLogger, kubeclient operatorclient.ClientInt
 		// corev1.ObjectReference only has Name populated.
 		secret, getErr := kubeclient.KubernetesInterface().CoreV1().Secrets(sa.GetNamespace()).Get(context.TODO(), ref.Name, metav1.GetOptions{})
 		if getErr != nil {
-			if k8serrors.IsNotFound(getErr) {
+			if apierrors.IsNotFound(getErr) {
 				logger.Warnf("skipping secret %s - %v", ref.Name, getErr)
 				continue
 			}

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/metrics/metrics.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/metrics/metrics.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
-	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	v1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
 )
 
@@ -247,19 +247,19 @@ func DeleteCatalogSourceStateMetric(name, namespace string) {
 	catalogSourceReady.DeleteLabelValues(namespace, name)
 }
 
-func DeleteCSVMetric(oldCSV *olmv1alpha1.ClusterServiceVersion) {
+func DeleteCSVMetric(oldCSV *operatorsv1alpha1.ClusterServiceVersion) {
 	// Delete the old CSV metrics
 	csvAbnormal.DeleteLabelValues(oldCSV.Namespace, oldCSV.Name, oldCSV.Spec.Version.String(), string(oldCSV.Status.Phase), string(oldCSV.Status.Reason))
 	csvSucceeded.DeleteLabelValues(oldCSV.Namespace, oldCSV.Name, oldCSV.Spec.Version.String())
 }
 
-func EmitCSVMetric(oldCSV *olmv1alpha1.ClusterServiceVersion, newCSV *olmv1alpha1.ClusterServiceVersion) {
+func EmitCSVMetric(oldCSV *operatorsv1alpha1.ClusterServiceVersion, newCSV *operatorsv1alpha1.ClusterServiceVersion) {
 	if oldCSV == nil || newCSV == nil {
 		return
 	}
 
 	// Don't update the metric for copies
-	if newCSV.Status.Reason == olmv1alpha1.CSVReasonCopied {
+	if newCSV.Status.Reason == operatorsv1alpha1.CSVReasonCopied {
 		return
 	}
 
@@ -269,7 +269,7 @@ func EmitCSVMetric(oldCSV *olmv1alpha1.ClusterServiceVersion, newCSV *olmv1alpha
 	// Get the phase of the new CSV
 	newCSVPhase := string(newCSV.Status.Phase)
 	csvSucceededGauge := csvSucceeded.WithLabelValues(newCSV.Namespace, newCSV.Name, newCSV.Spec.Version.String())
-	if newCSVPhase == string(olmv1alpha1.CSVPhaseSucceeded) {
+	if newCSVPhase == string(operatorsv1alpha1.CSVPhaseSucceeded) {
 		csvSucceededGauge.Set(1)
 	} else {
 		csvSucceededGauge.Set(0)
@@ -277,7 +277,7 @@ func EmitCSVMetric(oldCSV *olmv1alpha1.ClusterServiceVersion, newCSV *olmv1alpha
 	}
 }
 
-func EmitSubMetric(sub *olmv1alpha1.Subscription) {
+func EmitSubMetric(sub *operatorsv1alpha1.Subscription) {
 	if sub.Spec == nil {
 		return
 	}
@@ -292,14 +292,14 @@ func EmitSubMetric(sub *olmv1alpha1.Subscription) {
 	}
 }
 
-func DeleteSubsMetric(sub *olmv1alpha1.Subscription) {
+func DeleteSubsMetric(sub *operatorsv1alpha1.Subscription) {
 	if sub.Spec == nil {
 		return
 	}
 	SubscriptionSyncCount.DeleteLabelValues(sub.GetName(), sub.Status.InstalledCSV, sub.Spec.Channel, sub.Spec.Package, string(sub.Spec.InstallPlanApproval))
 }
 
-func UpdateSubsSyncCounterStorage(sub *olmv1alpha1.Subscription) {
+func UpdateSubsSyncCounterStorage(sub *operatorsv1alpha1.Subscription) {
 	if sub.Spec == nil {
 		return
 	}

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/storage/reststorage.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/storage/reststorage.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/printers"
 	printerstorage "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/printers/storage"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -76,7 +76,7 @@ func (m *PackageManifestStorage) List(ctx context.Context, options *metainternal
 
 	res, err := m.prov.List(namespace, labelSelector)
 	if err != nil {
-		return nil, k8serrors.NewInternalError(err)
+		return nil, apierrors.NewInternalError(err)
 	}
 
 	filtered := []operators.PackageManifest{}
@@ -101,7 +101,7 @@ func (m *PackageManifestStorage) Get(ctx context.Context, name string, opts *met
 	namespace := genericreq.NamespaceValue(ctx)
 	manifest, err := m.prov.Get(namespace, name)
 	if err != nil || manifest == nil {
-		return nil, k8serrors.NewNotFound(m.groupResource, name)
+		return nil, apierrors.NewNotFound(m.groupResource, name)
 	}
 	// Strip logo icons
 	for i := range manifest.Status.Channels {


### PR DESCRIPTION
Problem: There was a bug in fixed in 4.11 where the operator service certificates were not being rotated properly. The current bug asks use to backport those fixed to 4.10

The backported commits are:
- https://github.com/openshift/operator-framework-olm/pull/300/commits/8b6a36b4c771be2d247b7b3167f4c477e1301471
- https://github.com/openshift/operator-framework-olm/pull/306