### PR TITLE
OCPBUGS-7102: make plugin e2e tests skippable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,12 @@ e2e/operator-registry: ## Run e2e registry tests
 e2e/olm: ## Run e2e olm tests
 	$(MAKE) e2e WHAT=operator-lifecycle-manager E2E_CATALOG_NS=openshift-marketplace E2E_INSTALL_NS=openshift-operator-lifecycle-manager E2E_TEST_NS=openshift-operators E2E_TIMEOUT=120m KUBECTL=oc
 
+.PHONY: update-plugin-deps
+update-plugin-deps:
+	./scripts/update_plugin_deps.sh
+
 .PHONY: vendor
-vendor:
+vendor: update-plugin-deps
 	go mod tidy
 	go mod vendor
 	go mod verify

--- a/go.mod
+++ b/go.mod
@@ -177,7 +177,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799 // indirect
 	github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a // indirect
-	github.com/openshift/cluster-policy-controller v0.0.0-20220825134653-523e4104074f // indirect
+	github.com/openshift/cluster-policy-controller v0.0.0-20230112143856-3f8efde27bb6 // indirect
 	github.com/otiai10/copy v1.2.0 // indirect
 	github.com/pbnjay/strptime v0.0.0-20140226051138-5c05b0d668c9 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -983,8 +983,8 @@ github.com/openshift/api v0.0.0-20210517065120-b325f58df679/go.mod h1:dZ4kytOo3s
 github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0 h1:kMiuiZXH1GdfbiMwsuAQOqGaMxlo9NCUk0wT4XAdfNM=
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0/go.mod h1:uUQ4LClRO+fg5MF/P6QxjMCb1C9f7Oh4RKepftDnEJE=
-github.com/openshift/cluster-policy-controller v0.0.0-20220825134653-523e4104074f h1:ll0eE7rgGHsFlrI6ksr6nXL2ur8GYBe8Jj0GwNQ/1+o=
-github.com/openshift/cluster-policy-controller v0.0.0-20220825134653-523e4104074f/go.mod h1:r9ZZT5wjwoS2heBfYR26uJhhkGYwgmFqomu9ww0y9Qw=
+github.com/openshift/cluster-policy-controller v0.0.0-20230112143856-3f8efde27bb6 h1:JJ8cHS+mXYwaYjpDnmnEWNj/KPvlVhed1dFLsz3zJ3g=
+github.com/openshift/cluster-policy-controller v0.0.0-20230112143856-3f8efde27bb6/go.mod h1:mxj0Tg1YG9PpVJDOBLsAkjZNVvQTNu1LJkw9fSAkOE4=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=

--- a/scripts/update_plugin_deps.sh
+++ b/scripts/update_plugin_deps.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# This script is used to keep certain dependencies regularly updated
+# against the same OCP branch of the current build.
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+echo "updating olm plugin dependencies"
+if [[ "$BRANCH" =~ ^master$|^release-\d+\.\d+$ ]]; then
+  echo "attempting to update cluster-policy-controller"
+  # needed for staging/operator-lifecycle-manager/pkg/controller/operators/olm/plugins/downstream_csv_namespace_labeler_plugin.go
+  go get "github.com/openshift/cluster-policy-controller@${BRANCH}"
+else
+  echo "skipping dependency update as branch '$BRANCH' is not recognized"
+fi
+echo "finished updating olm plugin dependencies"

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/downstream_csv_labeler.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/downstream_csv_labeler.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/plugins"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const CsvLabelerPluginId plugins.PluginID = "csv-labeler-plugin"
 const labelSyncerLabelKey = ""
 
 func NewCSVLabelSyncerLabeler(client operatorclient.ClientInterface, logger *logrus.Logger) *CSVLabelSyncerLabeler {

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/downstream_plugins.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/downstream_plugins.go
@@ -5,9 +5,14 @@ import (
 )
 
 func init() {
-	operatorPlugInFactoryFuncs = []plugins.OperatorPlugInFactoryFunc{
+	operatorPlugInFactoryFuncs = plugins.OperatorPlugInFactoryMap{
 		// labels unlabeled non-payload openshift-* csv namespaces with
 		// security.openshift.io/scc.podSecurityLabelSync: true
-		plugins.NewCsvNamespaceLabelerPluginFunc,
+		CsvLabelerPluginId: plugins.NewCsvNamespaceLabelerPluginFunc,
 	}
+}
+
+func IsPluginEnabled(pluginID plugins.PluginID) bool {
+	_, ok := operatorPlugInFactoryFuncs[pluginID]
+	return ok
 }

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
@@ -64,7 +64,7 @@ var (
 
 // this unexported operator plugin slice provides an entrypoint for
 // downstream to inject its own plugins to augment the controller behavior
-var operatorPlugInFactoryFuncs []plugins.OperatorPlugInFactoryFunc
+var operatorPlugInFactoryFuncs plugins.OperatorPlugInFactoryMap
 
 type Operator struct {
 	queueinformer.Operator

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/plugins/downstream_csv_namespace_labeler_plugin_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/plugins/downstream_csv_namespace_labeler_plugin_test.go
@@ -3,8 +3,6 @@ package plugins
 import (
 	"context"
 	"errors"
-	"os/exec"
-	"strings"
 	"testing"
 	"time"
 
@@ -297,22 +295,4 @@ func Test_SyncDoesNotLabelNamespacesWithCopiedCSVs(t *testing.T) {
 	ns, err := plugin.kubeClient.KubernetesInterface().CoreV1().Namespaces().Get(context.Background(), namespace.GetName(), metav1.GetOptions{})
 	assert.NoError(t, err)
 	assert.NotContains(t, ns.GetLabels(), NamespaceLabelSyncerLabelKey)
-}
-
-func Test_OCPVersion(t *testing.T) {
-	// This test is a maintenance alert that means the next OCP version is now in active development.
-	// This plugin relies on a list of payload namespaces that comes from the cluster-policy-controller project
-	// https://github.com/openshift/cluster-policy-controller/tree/master/pkg/psalabelsyncer
-	// This list is dependent on the OCP version. Please update the dependency version to correspond to the one
-	// vendored for the new OCP version (or contact the responsible team if it hasn't been updated yet).
-	// Then, bump the OCP version in the `nextOCPUncutBranchName` constant below
-	const nextOCPUncutBranchName = "release-4.14"
-	const errorMessage = "[maintenance alert] new ocp version branch has been cut: please check comments in test for instructions"
-
-	// Get branches
-	branches, err := exec.Command("git", "branch", "-a").Output()
-	assert.NoError(t, err)
-
-	// check if the next uncut branch has been cut and fail if so
-	assert.False(t, strings.Contains(string(branches), nextOCPUncutBranchName), errorMessage)
 }

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/plugins/operator_plugin.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/plugins/operator_plugin.go
@@ -10,6 +10,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type PluginID string
+type OperatorPlugInFactoryMap map[PluginID]OperatorPlugInFactoryFunc
+
 // HostOperator is an extensible and observable operator that hosts the plug-in, i.e. which the plug-in is extending
 type HostOperator interface {
 	queueinformer.ObservableOperator

--- a/staging/operator-lifecycle-manager/test/e2e/downstream_csv_namespace_labeler_plugin_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/downstream_csv_namespace_labeler_plugin_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/plugins"
 	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/ctx"
 	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/util"
@@ -31,6 +32,10 @@ var _ = Describe("CSV Namespace Labeler Plugin", func() {
 	})
 
 	It("should not label non openshift- namespaces", func() {
+		if !olm.IsPluginEnabled(olm.CsvLabelerPluginId) {
+			Skip("csv labeler plugin is disabled")
+		}
+
 		// create namespace with operator group
 		testNamespace = SetupGeneratedTestNamespace(genName("csv-ns-labeler-"))
 
@@ -46,6 +51,10 @@ var _ = Describe("CSV Namespace Labeler Plugin", func() {
 	})
 
 	It("should label a non-payload openshift- namespace", func() {
+		if !olm.IsPluginEnabled(olm.CsvLabelerPluginId) {
+			Skip("csv labeler plugin is disabled")
+		}
+
 		// create namespace with operator group
 		testNamespace = SetupGeneratedTestNamespace(genName("openshift-csv-ns-labeler-"))
 
@@ -61,6 +70,10 @@ var _ = Describe("CSV Namespace Labeler Plugin", func() {
 	})
 
 	It("should relabel a non-payload openshift- namespace containing csvs if the label is deleted", func() {
+		if !olm.IsPluginEnabled(olm.CsvLabelerPluginId) {
+			Skip("csv labeler plugin is disabled")
+		}
+
 		// create namespace with operator group
 		testNamespace = SetupGeneratedTestNamespace(genName("openshift-csv-ns-labeler-"))
 

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/downstream_csv_labeler.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/downstream_csv_labeler.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/plugins"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const CsvLabelerPluginId plugins.PluginID = "csv-labeler-plugin"
 const labelSyncerLabelKey = ""
 
 func NewCSVLabelSyncerLabeler(client operatorclient.ClientInterface, logger *logrus.Logger) *CSVLabelSyncerLabeler {

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/downstream_plugins.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/downstream_plugins.go
@@ -5,9 +5,14 @@ import (
 )
 
 func init() {
-	operatorPlugInFactoryFuncs = []plugins.OperatorPlugInFactoryFunc{
+	operatorPlugInFactoryFuncs = plugins.OperatorPlugInFactoryMap{
 		// labels unlabeled non-payload openshift-* csv namespaces with
 		// security.openshift.io/scc.podSecurityLabelSync: true
-		plugins.NewCsvNamespaceLabelerPluginFunc,
+		CsvLabelerPluginId: plugins.NewCsvNamespaceLabelerPluginFunc,
 	}
+}
+
+func IsPluginEnabled(pluginID plugins.PluginID) bool {
+	_, ok := operatorPlugInFactoryFuncs[pluginID]
+	return ok
 }

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
@@ -64,7 +64,7 @@ var (
 
 // this unexported operator plugin slice provides an entrypoint for
 // downstream to inject its own plugins to augment the controller behavior
-var operatorPlugInFactoryFuncs []plugins.OperatorPlugInFactoryFunc
+var operatorPlugInFactoryFuncs plugins.OperatorPlugInFactoryMap
 
 type Operator struct {
 	queueinformer.Operator

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/plugins/operator_plugin.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/plugins/operator_plugin.go
@@ -10,6 +10,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type PluginID string
+type OperatorPlugInFactoryMap map[PluginID]OperatorPlugInFactoryFunc
+
 // HostOperator is an extensible and observable operator that hosts the plug-in, i.e. which the plug-in is extending
 type HostOperator interface {
 	queueinformer.ObservableOperator

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -632,8 +632,8 @@ github.com/openshift/client-go/config/informers/externalversions/config
 github.com/openshift/client-go/config/informers/externalversions/config/v1
 github.com/openshift/client-go/config/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/config/listers/config/v1
-# github.com/openshift/cluster-policy-controller v0.0.0-20220825134653-523e4104074f
-## explicit; go 1.18
+# github.com/openshift/cluster-policy-controller v0.0.0-20230112143856-3f8efde27bb6
+## explicit; go 1.19
 github.com/openshift/cluster-policy-controller/pkg/psalabelsyncer/nsexemptions
 # github.com/operator-framework/api v0.17.3 => ./staging/api
 ## explicit; go 1.18


### PR DESCRIPTION
This PR:
* updates the plug-in framework to help make the e2e tests skippable when the plug-in is not enabled
* removes the unit test timebomb
* adds a new make target `make update-plugin-deps`
* make the new target a dependency of the `make vendor` target

The CSV Labeler Plug-in test suite included a timebomb to force us to remember to switch the branch of its dependency on
github.com/openshift/cluster-policy-controller, i.e.

olm@release-master -> cluster-policy-controller@master
olm@release-4.12 -> cluster-policy-controller@release-4.12
olm@release-4.13 -> cluster-policy-controller@release-4.13
...

Instead of this, I've added a new script that go gets the latest dependency at the particular branch and attached it to the make vendor target. If there are changes here, the verify job will fail and we'll have to update the vendor folder and update the PR.

**NOTE** verify job will fail due to the removal of the timebomb test: changes to staging - this can be safely overridden

Signed-off-by: perdasilva <perdasilva@redhat.com>