### PR TITLE
OCPBUGS-672: Catalog Pod Startup Probe Timeout

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
@@ -162,8 +162,9 @@ func Pod(source *operatorsv1alpha1.CatalogSource, name string, img string, saNam
 								Command: []string{"grpc_health_probe", "-addr=:50051"},
 							},
 						},
-						FailureThreshold: 15,
+						FailureThreshold: 10,
 						PeriodSeconds:    10,
+						TimeoutSeconds:   5,
 					},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
@@ -162,8 +162,9 @@ func Pod(source *operatorsv1alpha1.CatalogSource, name string, img string, saNam
 								Command: []string{"grpc_health_probe", "-addr=:50051"},
 							},
 						},
-						FailureThreshold: 15,
+						FailureThreshold: 10,
 						PeriodSeconds:    10,
+						TimeoutSeconds:   5,
 					},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{


### PR DESCRIPTION
Updates the Startup Probe timeoutSeconds for catalog pods to be consistent with the timeouts in the readiness and liveness probes. Also adjusted the failure threshold in order to maintain the ~150s startup time failure as originally designed.

Upstream-repository: operator-lifecycle-manager
Upstream-commit: 401bfff4df20c97bef08db2dc9fc75bc1879be7a

OCPBUGS-672