### PR TITLE
OPECO-2646: exclude bundles with `olm.deprecated` property when rendering

### DIFF
--- a/staging/operator-registry/pkg/sqlite/conversion.go
+++ b/staging/operator-registry/pkg/sqlite/conversion.go
@@ -76,7 +76,16 @@ func populateModelChannels(ctx context.Context, pkgs model.Model, q *SQLQuerier)
 	if err != nil {
 		return err
 	}
+
+ConvertBundles:
 	for _, bundle := range bundles {
+		for _, prop := range bundle.Properties {
+			if prop.Type == registry.DeprecatedType {
+				// bundle contains `olm.Deprecated` property
+				// exclude this bundle from being rendered
+				continue ConvertBundles
+			}
+		}
 		pkg, ok := pkgs[bundle.PackageName]
 		if !ok {
 			return fmt.Errorf("unknown package %q for bundle %q", bundle.PackageName, bundle.CsvName)

--- a/vendor/github.com/operator-framework/operator-registry/pkg/sqlite/conversion.go
+++ b/vendor/github.com/operator-framework/operator-registry/pkg/sqlite/conversion.go
@@ -76,7 +76,16 @@ func populateModelChannels(ctx context.Context, pkgs model.Model, q *SQLQuerier)
 	if err != nil {
 		return err
 	}
+
+ConvertBundles:
 	for _, bundle := range bundles {
+		for _, prop := range bundle.Properties {
+			if prop.Type == registry.DeprecatedType {
+				// bundle contains `olm.Deprecated` property
+				// exclude this bundle from being rendered
+				continue ConvertBundles
+			}
+		}
 		pkg, ok := pkgs[bundle.PackageName]
 		if !ok {
 			return fmt.Errorf("unknown package %q for bundle %q", bundle.PackageName, bundle.CsvName)


### PR DESCRIPTION
* exclude bundles with `olm.deprecated` property when rendering
* Exclude bundles based on the property type and not value
