### PR TITLE
Fix pop candidate script

### DIFF
--- a/pkg/manifests/csv.yaml
+++ b/pkg/manifests/csv.yaml
@@ -5,7 +5,7 @@ metadata:
   name: packageserver
   namespace: openshift-operator-lifecycle-manager
   labels:
-    olm.version: 0.19.0
+    olm.version: 0.0.0-862d58ed7d505d334e3b7218dee303bcafb1a212
     olm.clusteroperator.name: operator-lifecycle-manager-packageserver
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
@@ -159,7 +159,7 @@ spec:
                                 - packageserver
                         topologyKey: "kubernetes.io/hostname"
   maturity: alpha
-  version: 0.19.0
+  version: 0.0.0-862d58ed7d505d334e3b7218dee303bcafb1a212
   apiservicedefinitions:
     owned:
       - group: packages.operators.coreos.com

--- a/scripts/sync_pop_candidate.sh
+++ b/scripts/sync_pop_candidate.sh
@@ -7,19 +7,17 @@ ROOT_DIR=$(dirname "${BASH_SOURCE[@]}")/..
 # shellcheck disable=SC1091
 source "${ROOT_DIR}/scripts/common.sh"
 
-pop_all=true
+pop_all=false
 
-set +u
-while getopts 'a:' flag; do
+while getopts ':a' flag; do
   case "${flag}" in
-    a) pop_all=true; shift ;;
+    a) pop_all=true ;;
     \?) exit 1 ;;
     *) echo "unexpected option ${flag}"; exit 1 ;;
   esac
-
-  shift
 done
-set -u
+# Shift to non-option arguments
+shift $((OPTIND-1))
 
 remote="${1:-api}"
 subtree_dir="staging/${2:-${remote}}"

--- a/staging/operator-registry/pkg/sqlite/conversion.go
+++ b/staging/operator-registry/pkg/sqlite/conversion.go
@@ -76,7 +76,16 @@ func populateModelChannels(ctx context.Context, pkgs model.Model, q *SQLQuerier)
 	if err != nil {
 		return err
 	}
+
+ConvertBundles:
 	for _, bundle := range bundles {
+		for _, prop := range bundle.Properties {
+			if prop.Type == registry.DeprecatedType {
+				// bundle contains `olm.Deprecated` property
+				// exclude this bundle from being rendered
+				continue ConvertBundles
+			}
+		}
 		pkg, ok := pkgs[bundle.PackageName]
 		if !ok {
 			return fmt.Errorf("unknown package %q for bundle %q", bundle.PackageName, bundle.CsvName)

--- a/vendor/github.com/operator-framework/operator-registry/pkg/sqlite/conversion.go
+++ b/vendor/github.com/operator-framework/operator-registry/pkg/sqlite/conversion.go
@@ -76,7 +76,16 @@ func populateModelChannels(ctx context.Context, pkgs model.Model, q *SQLQuerier)
 	if err != nil {
 		return err
 	}
+
+ConvertBundles:
 	for _, bundle := range bundles {
+		for _, prop := range bundle.Properties {
+			if prop.Type == registry.DeprecatedType {
+				// bundle contains `olm.Deprecated` property
+				// exclude this bundle from being rendered
+				continue ConvertBundles
+			}
+		}
 		pkg, ok := pkgs[bundle.PackageName]
 		if !ok {
 			return fmt.Errorf("unknown package %q for bundle %q", bundle.PackageName, bundle.CsvName)


### PR DESCRIPTION
The pop_candidate_script wasn't handling the command line flags (-a) properly, which was causing the script to fail.