### PR TITLE
METAL-575: Revert "Mutate service monitor manifests to include tlsConfig cert an…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -177,7 +177,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799 // indirect
 	github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a // indirect
-	github.com/openshift/cluster-policy-controller v0.0.0-20230217170320-ac01e3463245 // indirect
+	github.com/openshift/cluster-policy-controller v0.0.0-20230329210054-1a5f0ca08be7 // indirect
 	github.com/otiai10/copy v1.2.0 // indirect
 	github.com/pbnjay/strptime v0.0.0-20140226051138-5c05b0d668c9 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -983,8 +983,8 @@ github.com/openshift/api v0.0.0-20210517065120-b325f58df679/go.mod h1:dZ4kytOo3s
 github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0 h1:kMiuiZXH1GdfbiMwsuAQOqGaMxlo9NCUk0wT4XAdfNM=
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0/go.mod h1:uUQ4LClRO+fg5MF/P6QxjMCb1C9f7Oh4RKepftDnEJE=
-github.com/openshift/cluster-policy-controller v0.0.0-20230217170320-ac01e3463245 h1:BoNt9Hemwyc32xX+CZZaNGegWEiN7bGTVk4XaRboO8k=
-github.com/openshift/cluster-policy-controller v0.0.0-20230217170320-ac01e3463245/go.mod h1:vlkRuwyRueLOQ/ZRRle+rCrh+YNoh+pzJm9WaN9e6mU=
+github.com/openshift/cluster-policy-controller v0.0.0-20230329210054-1a5f0ca08be7 h1:0rJWfuAuSChNKF8Dq1JjX1Yfzixj1PX6ocKYIhvyuZU=
+github.com/openshift/cluster-policy-controller v0.0.0-20230329210054-1a5f0ca08be7/go.mod h1:vlkRuwyRueLOQ/ZRRle+rCrh+YNoh+pzJm9WaN9e6mU=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=

--- a/manifests/0000_90_olm_00-service-monitor.yaml
+++ b/manifests/0000_90_olm_00-service-monitor.yaml
@@ -59,8 +59,6 @@ spec:
       tlsConfig:
         caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
         serverName: olm-operator-metrics.openshift-operator-lifecycle-manager.svc
-        keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
-        certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
   jobLabel: component
   namespaceSelector:
     matchNames:
@@ -94,8 +92,6 @@ spec:
       tlsConfig:
         caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
         serverName: catalog-operator-metrics.openshift-operator-lifecycle-manager.svc
-        keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
-        certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
   jobLabel: component
   namespaceSelector:
     matchNames:

--- a/scripts/generate_crds_manifests.sh
+++ b/scripts/generate_crds_manifests.sh
@@ -90,8 +90,6 @@ ${YQ} write --inplace -s scripts/olm-deployment.patch.yaml manifests/0000_50_olm
 ${YQ} write --inplace -s scripts/catalog-deployment.patch.yaml manifests/0000_50_olm_08-catalog-operator.deployment.yaml
 ${YQ} write --inplace -s scripts/packageserver-deployment.patch.yaml manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml
 ${YQ} merge --inplace manifests/0000_50_olm_02-olmconfig.yaml scripts/cluster-olmconfig.patch.yaml
-${YQ} write --inplace -d'2' -s scripts/service-monitor.patch.yaml manifests/0000_90_olm_00-service-monitor.yaml
-${YQ} write --inplace -d'3' -s scripts/service-monitor.patch.yaml manifests/0000_90_olm_00-service-monitor.yaml
 mv manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml pkg/manifests/csv.yaml
 cp scripts/packageserver-pdb.yaml manifests/0000_50_olm_00-packageserver.pdb.yaml
 

--- a/scripts/service-monitor.patch.yaml
+++ b/scripts/service-monitor.patch.yaml
@@ -1,6 +1,0 @@
-- command: update
-  path: spec.endpoints[*].tlsConfig.keyFile
-  value: /etc/prometheus/secrets/metrics-client-certs/tls.key
-- command: update
-  path: spec.endpoints[*].tlsConfig.certFile
-  value: /etc/prometheus/secrets/metrics-client-certs/tls.crt

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -632,7 +632,7 @@ github.com/openshift/client-go/config/informers/externalversions/config
 github.com/openshift/client-go/config/informers/externalversions/config/v1
 github.com/openshift/client-go/config/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/config/listers/config/v1
-# github.com/openshift/cluster-policy-controller v0.0.0-20230217170320-ac01e3463245
+# github.com/openshift/cluster-policy-controller v0.0.0-20230329210054-1a5f0ca08be7
 ## explicit; go 1.19
 github.com/openshift/cluster-policy-controller/pkg/psalabelsyncer/nsexemptions
 # github.com/operator-framework/api v0.17.3 => ./staging/api


### PR DESCRIPTION
…d key file"

This reverts commit 4af508d7546a2060f7734651c8770d32394ce893.

Testing if this cause tls errors that started in metal-ipi jobs yesterday