### PR TITLE
OCPBUGS-1684: Optimize certificate generation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -177,7 +177,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799 // indirect
 	github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a // indirect
-	github.com/openshift/cluster-policy-controller v0.0.0-20230329210054-1a5f0ca08be7 // indirect
+	github.com/openshift/cluster-policy-controller v0.0.0-20230424132259-62adf796a213 // indirect
 	github.com/otiai10/copy v1.2.0 // indirect
 	github.com/pbnjay/strptime v0.0.0-20140226051138-5c05b0d668c9 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -983,8 +983,8 @@ github.com/openshift/api v0.0.0-20210517065120-b325f58df679/go.mod h1:dZ4kytOo3s
 github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0 h1:kMiuiZXH1GdfbiMwsuAQOqGaMxlo9NCUk0wT4XAdfNM=
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0/go.mod h1:uUQ4LClRO+fg5MF/P6QxjMCb1C9f7Oh4RKepftDnEJE=
-github.com/openshift/cluster-policy-controller v0.0.0-20230329210054-1a5f0ca08be7 h1:0rJWfuAuSChNKF8Dq1JjX1Yfzixj1PX6ocKYIhvyuZU=
-github.com/openshift/cluster-policy-controller v0.0.0-20230329210054-1a5f0ca08be7/go.mod h1:vlkRuwyRueLOQ/ZRRle+rCrh+YNoh+pzJm9WaN9e6mU=
+github.com/openshift/cluster-policy-controller v0.0.0-20230424132259-62adf796a213 h1:Fpyt5GHMm1JqRz1xYeBjnzT5VxII+s5d7N9HmyH7iUk=
+github.com/openshift/cluster-policy-controller v0.0.0-20230424132259-62adf796a213/go.mod h1:vlkRuwyRueLOQ/ZRRle+rCrh+YNoh+pzJm9WaN9e6mU=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -632,7 +632,7 @@ github.com/openshift/client-go/config/informers/externalversions/config
 github.com/openshift/client-go/config/informers/externalversions/config/v1
 github.com/openshift/client-go/config/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/config/listers/config/v1
-# github.com/openshift/cluster-policy-controller v0.0.0-20230329210054-1a5f0ca08be7
+# github.com/openshift/cluster-policy-controller v0.0.0-20230424132259-62adf796a213
 ## explicit; go 1.19
 github.com/openshift/cluster-policy-controller/pkg/psalabelsyncer/nsexemptions
 # github.com/operator-framework/api v0.17.3 => ./staging/api


### PR DESCRIPTION
Reduce certificate generation to once-a-day.
Optimize loading of the certificate.
Rename operations to correctly identify what they do.