### PR TITLE
Correct spelling typo in CSVAnormalOver30Min alert desc

### DIFF
--- a/manifests/0000_90_olm_01-prometheus-rule.yaml
+++ b/manifests/0000_90_olm_01-prometheus-rule.yaml
@@ -31,7 +31,7 @@ spec:
             namespace: "{{ $labels.namespace }}"
           annotations:
             summary: CSV abnormal for over 30 minutes
-            description: Fires whenever a CSV is in the Replacing, Pending, Deleting, or Unkown phase for more than 30 minutes.
+            description: Fires whenever a CSV is in the Replacing, Pending, Deleting, or Unknown phase for more than 30 minutes.
             message: Failed to install Operator {{ $labels.name }} version {{ $labels.version }}. Phase-{{ $labels.phase }} Reason-{{ $labels.reason }}
     - name: olm.installplan.rules
       rules:


### PR DESCRIPTION
This PR just corrects a very minor typo in the description of the `CSVAbnormalOver30Min` alert, which shows up noticably in the console when firing (and was bugging me :sweat_smile: ).