### PR TITLE
OCPBUGS-15737: Re-enable psa plugin

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/downstream_plugins.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/downstream_plugins.go
@@ -8,8 +8,7 @@ func init() {
 	operatorPlugInFactoryFuncs = plugins.OperatorPlugInFactoryMap{
 		// labels unlabeled non-payload openshift-* csv namespaces with
 		// security.openshift.io/scc.podSecurityLabelSync: true
-// TODO: once PSA is enabled downstream, uncomment next line to enable plugin
-//		CsvLabelerPluginId: plugins.NewCsvNamespaceLabelerPluginFunc,
+		CsvLabelerPluginId: plugins.NewCsvNamespaceLabelerPluginFunc,
 	}
 }
 

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/downstream_plugins.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/downstream_plugins.go
@@ -8,8 +8,7 @@ func init() {
 	operatorPlugInFactoryFuncs = plugins.OperatorPlugInFactoryMap{
 		// labels unlabeled non-payload openshift-* csv namespaces with
 		// security.openshift.io/scc.podSecurityLabelSync: true
-// TODO: once PSA is enabled downstream, uncomment next line to enable plugin
-//		CsvLabelerPluginId: plugins.NewCsvNamespaceLabelerPluginFunc,
+		CsvLabelerPluginId: plugins.NewCsvNamespaceLabelerPluginFunc,
 	}
 }
 


### PR DESCRIPTION
Upstream PSA changes were introduced in Kubernetes 1.25 (OpenShift 4.12). Downstream OLM has a plug-in that integrates with the security team's Cluster-Policy-Constroller that helps smooth out the transition and helps avoid stuck workloads for our customers. We had to disable the plug-in in 4.12. It's not ready to be re-enabled.