### PR TITLE
OCPBUGS-13128: Retry initialization error conditions (#2979)

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/lib/operatorstatus/monitor.go
+++ b/staging/operator-lifecycle-manager/pkg/lib/operatorstatus/monitor.go
@@ -129,9 +129,18 @@ func (m *monitor) Run(stopCh <-chan struct{}) {
 	m.logger.Infof("initializing clusteroperator resource(s) for %s", m.names)
 
 	for _, name := range m.names {
-		if err := m.init(name); err != nil {
-			m.logger.Errorf("initialization error - %v", err)
-			break
+		for {
+			if err := m.init(name); err != nil {
+				m.logger.Errorf("initialization error - %v", err)
+			} else {
+				m.logger.Infof("initialized cluster resource - %s", name)
+				break
+			}
+			select {
+			case <-time.After(defaultProbeInterval):
+			case <-stopCh:
+				return
+			}
 		}
 	}
 

--- a/staging/operator-lifecycle-manager/pkg/lib/queueinformer/queueinformer_operator_test.go
+++ b/staging/operator-lifecycle-manager/pkg/lib/queueinformer/queueinformer_operator_test.go
@@ -78,7 +78,7 @@ func TestOperatorRunChannelClosure(t *testing.T) {
 
 			o.Run(ctx)
 
-			timeout := time.After(time.Second)
+			timeout := time.After(2 * defaultServerVersionInterval)
 			for n, ch := range map[string]<-chan struct{}{
 				"ready": o.Ready(),
 				"done":  o.Done(),

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorstatus/monitor.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorstatus/monitor.go
@@ -129,9 +129,18 @@ func (m *monitor) Run(stopCh <-chan struct{}) {
 	m.logger.Infof("initializing clusteroperator resource(s) for %s", m.names)
 
 	for _, name := range m.names {
-		if err := m.init(name); err != nil {
-			m.logger.Errorf("initialization error - %v", err)
-			break
+		for {
+			if err := m.init(name); err != nil {
+				m.logger.Errorf("initialization error - %v", err)
+			} else {
+				m.logger.Infof("initialized cluster resource - %s", name)
+				break
+			}
+			select {
+			case <-time.After(defaultProbeInterval):
+			case <-stopCh:
+				return
+			}
 		}
 	}
 


### PR DESCRIPTION
When the api server is flakey (e.g. during a cluster install), it is possible for some of the OLM initialization to fail. When this happens, OLM gets into a bad state (e.g. a monitoring go routine terminates) and can't recover without a restart.

There were at least two places I found where a retry mechanism is needed to handle intialization errors. This was as far as I peeled the onion. It's not an exponential backoff retry, but a 1 minute retry interval should be sufficient (no other backoffs are exponential).

The ServerVersion only retries once with a minute in between. This required fixing a unit-test to take the retry into account.


Upstream-repository: operator-lifecycle-manager
Upstream-commit: e908cfc6b