### PR TITLE
Bump go-restful/v3 to v3.10.2 to address PRISMA-2022-0227

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,7 @@ require (
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
-	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
+	github.com/emicklei/go-restful/v3 v3.10.2 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect


### PR DESCRIPTION
Bump go-restful/v3 to v3.10.2 to address PRISMA-2022-0227

Description:
github.com/emicklei/go-restful/v3 module prior to v3.10.0 is vulnerable to Authentication Bypass by Primary Weakness. There is an inconsistency in how go-restful parses URL paths. This inconsistency could lead to several security check bypass in a complex system.

Severity:
High

CVE:
PRISMA-2022-0227