### PR TITLE
Set GO_COMPLIANCE_EXCLUDE to match Makefile

### DIFF
--- a/operator-lifecycle-manager.Dockerfile
+++ b/operator-lifecycle-manager.Dockerfile
@@ -6,7 +6,7 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 # Permit the cpb binary to be compiled statically. The Red Hat compiler
 # provided by ART will otherwise force FIPS compliant dynamic compilation.
-ENV GO_COMPLIANCE_EXCLUDE="build.*operator-lifecycle-manager/util/cpb"
+ENV GO_COMPLIANCE_EXCLUDE="*util/cpb"
 
 WORKDIR /build
 


### PR DESCRIPTION
https://github.com/openshift/operator-framework-olm/pull/516 overrode the tweak in
https://github.com/openshift-eng/ocp-build-data/pull/3174. This should set the record straight.