### PR TITLE
fix the manifests generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ diff:
 verify-vendor: vendor
 	$(MAKE) diff
 
-verify-manifests: OLM_VERSION=0.19.0 # set static version to avoid failing for commit based versioning
+verify-manifests: OLM_VERSION=0.0.1-snapshot
 verify-manifests: manifests
 	$(MAKE) diff
 

--- a/pkg/manifests/csv.yaml
+++ b/pkg/manifests/csv.yaml
@@ -5,7 +5,7 @@ metadata:
   name: packageserver
   namespace: openshift-operator-lifecycle-manager
   labels:
-    olm.version: 0.19.0
+    olm.version: 0.0.1-snapshot
     olm.clusteroperator.name: operator-lifecycle-manager-packageserver
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
@@ -159,7 +159,7 @@ spec:
                                 - packageserver
                         topologyKey: "kubernetes.io/hostname"
   maturity: alpha
-  version: 0.19.0
+  version: 0.0.1-snapshot
   apiservicedefinitions:
     owned:
       - group: packages.operators.coreos.com


### PR DESCRIPTION
manifests: use the CVO-replaced placeholder for version

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

makefile: verify that we use the CVO-based placeholder

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

