### PR TITLE
OCPBUGS-17157: scripts: add a Go-based bumper, sync upstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,10 @@ vendor:
 manifests: ## Generate manifests
 	OLM_VERSION=$(OLM_VERSION) ./scripts/generate_crds_manifests.sh
 
+.PHONY: generate-manifests
+generate-manifests: OLM_VERSION=0.0.1-snapshot
+generate-manifests: manifests
+
 .PHONY: diff
 diff:
 	git diff --stat HEAD --ignore-submodules --exit-code
@@ -146,8 +150,7 @@ diff:
 verify-vendor: vendor
 	$(MAKE) diff
 
-verify-manifests: OLM_VERSION=0.0.1-snapshot
-verify-manifests: manifests
+verify-manifests: generate-manifests
 	$(MAKE) diff
 
 verify-nested-vendor:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -86,9 +86,12 @@ or amended to the last commit of the branch.
 
 Once `make -k verify` is resolved, create a PR from this working sync branch.
 
-## TODO
+# Long-lived Carry Commits
 
-* Add `make verify` to the `sync_pop_candidate.sh` and/or `sync.sh` scripts.
+It is required at times to write commits that will live in the `vendor/` directory
+on top of upstream code and for those commits to be carried on top for the forseeable
+future. In these cases, prefix your commit message with `[CARRY]` to pass the commit
+verification routines.
 
 ## References
 1. [Downstream to operator-framework-olm](https://spaces.redhat.com/display/OOLM/Downstream+to+operator-framework-olm)

--- a/scripts/bumper/go.mod
+++ b/scripts/bumper/go.mod
@@ -1,0 +1,7 @@
+module github.com/openshift/operator-framework-olm/scripts/bumper
+
+go 1.20
+
+require github.com/sirupsen/logrus v1.9.3
+
+require golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect

--- a/scripts/bumper/go.sum
+++ b/scripts/bumper/go.sum
@@ -1,0 +1,15 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/scripts/bumper/main.go
+++ b/scripts/bumper/main.go
@@ -277,7 +277,7 @@ func cherryPick(ctx context.Context, logger *logrus.Entry, c commit) error {
 			"go", "mod", "verify",
 		), os.Environ()...),
 		withEnv(exec.CommandContext(ctx,
-			"make", "manifests", "OLM_VERSION=0.0.1-snapshot",
+			"make", "generate-manifests",
 		), os.Environ()...),
 		exec.CommandContext(ctx,
 			"git", "add",

--- a/scripts/bumper/main.go
+++ b/scripts/bumper/main.go
@@ -206,7 +206,7 @@ func detectNewCommits(ctx context.Context, logger *logrus.Entry, stagingDir stri
 				infoCmd := exec.CommandContext(ctx,
 					"git", "show",
 					line,
-					"--pretty=format:%H|%cI|%an|%s",
+					"--pretty=format:%H\u00A0%cI\u00A0%an\u00A0%s",
 					"--quiet",
 				)
 				stdout, stderr := bytes.Buffer{}, bytes.Buffer{}
@@ -216,7 +216,7 @@ func detectNewCommits(ctx context.Context, logger *logrus.Entry, stagingDir stri
 				if err := infoCmd.Run(); err != nil {
 					return nil, fmt.Errorf("failed to run command: %s %s: %w", stdout.String(), stderr.String(), err)
 				}
-				parts := strings.Split(stdout.String(), "|")
+				parts := strings.Split(stdout.String(), "\u00A0")
 				if len(parts) != 4 {
 					return nil, fmt.Errorf("incorrect parts from git output: %v", stdout.String())
 				}

--- a/scripts/bumper/main.go
+++ b/scripts/bumper/main.go
@@ -1,0 +1,320 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+type mode string
+
+const (
+	summarize   mode = "summarize"
+	synchronize mode = "synchronize"
+)
+
+type options struct {
+	stagingDir       string
+	commitFileOutput string
+	commitFileInput  string
+	mode             string
+	logLevel         string
+}
+
+func (o *options) Bind(fs *flag.FlagSet) {
+	fs.StringVar(&o.stagingDir, "staging-dir", "staging/", "Directory for staging repositories.")
+	fs.StringVar(&o.mode, "mode", string(summarize), "Operation mode.")
+	fs.StringVar(&o.commitFileOutput, "commits-output", "", "File to write commits data to after resolving what needs to be synced.")
+	fs.StringVar(&o.commitFileInput, "commits-input", "", "File to read commits data from in order to drive sync process.")
+	fs.StringVar(&o.logLevel, "log-level", logrus.InfoLevel.String(), "Logging level.")
+}
+
+func (o *options) Validate() error {
+	switch mode(o.mode) {
+	case summarize, synchronize:
+	default:
+		return fmt.Errorf("--mode must be one of %v", []mode{summarize, synchronize})
+	}
+
+	if _, err := logrus.ParseLevel(o.logLevel); err != nil {
+		return fmt.Errorf("--log-level invalid: %w", err)
+	}
+	return nil
+}
+
+func main() {
+	logger := logrus.New()
+	opts := options{}
+	opts.Bind(flag.CommandLine)
+	flag.Parse()
+
+	if err := opts.Validate(); err != nil {
+		logger.WithError(err).Fatal("invalid options")
+	}
+
+	logLevel, _ := logrus.ParseLevel(opts.logLevel)
+	logger.SetLevel(logLevel)
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	var commits []commit
+	var err error
+	if opts.commitFileInput != "" {
+		rawCommits, err := os.ReadFile(opts.commitFileInput)
+		if err != nil {
+			logrus.WithError(err).Fatal("could not read input file")
+		}
+		if err := json.Unmarshal(rawCommits, &commits); err != nil {
+			logrus.WithError(err).Fatal("could not unmarshal input commits")
+		}
+	} else {
+		commits, err = detectNewCommits(ctx, logger.WithField("phase", "detect"), opts.stagingDir)
+		if err != nil {
+			logger.WithError(err).Fatal("failed to detect commits")
+		}
+	}
+
+	if opts.commitFileOutput != "" {
+		commitsJson, err := json.Marshal(commits)
+		if err != nil {
+			logrus.WithError(err).Fatal("could not marshal commits")
+		}
+		if err := os.WriteFile(opts.commitFileOutput, commitsJson, 0666); err != nil {
+			logrus.WithError(err).Fatal("could not write commits")
+		}
+	}
+
+	switch mode(opts.mode) {
+	case summarize:
+		writer := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+		for _, commit := range commits {
+			if _, err := fmt.Fprintln(writer, commit.Date.Format(time.DateTime)+"\t"+"operator-framework/"+commit.Repo+"\t", commit.Hash+"\t"+commit.Author+"\t"+commit.Message); err != nil {
+				logger.WithError(err).Error("failed to write output")
+			}
+		}
+		if err := writer.Flush(); err != nil {
+			logger.WithError(err).Error("failed to flush output")
+		}
+	case synchronize:
+		for i, commit := range commits {
+			commitLogger := logger.WithField("commit", commit.Hash)
+			commitLogger.Infof("cherry-picking commit %d/%d", i+1, len(commits))
+			if err := cherryPick(ctx, commitLogger, commit); err != nil {
+				logger.WithError(err).Error("failed to cherry-pick commit")
+				break
+			}
+		}
+	}
+}
+
+type commit struct {
+	Date    time.Time `json:"date"`
+	Hash    string    `json:"hash,omitempty"`
+	Author  string    `json:"author,omitempty"`
+	Message string    `json:"message,omitempty"`
+	Repo    string    `json:"repo,omitempty"`
+}
+
+var repoRegex = regexp.MustCompile(`Upstream-repository: ([^ ]+)\n`)
+var commitRegex = regexp.MustCompile(`Upstream-commit: ([a-f0-9]+)\n`)
+
+func detectNewCommits(ctx context.Context, logger *logrus.Entry, stagingDir string) ([]commit, error) {
+	lastCommits := map[string]string{}
+	if err := fs.WalkDir(os.DirFS(stagingDir), ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d == nil || !d.IsDir() {
+			return nil
+		}
+
+		if path == "." {
+			return nil
+		}
+		logger = logger.WithField("repo", path)
+		logger.Debug("detecting commits")
+		output, err := runCommand(logger, exec.CommandContext(ctx,
+			"git", "log",
+			"-n", "1",
+			"--grep", "Upstream-repository: "+path,
+			"--grep", "Upstream-commit",
+			"--all-match",
+			"--pretty=%B",
+			"--",
+			filepath.Join(stagingDir, path),
+		))
+		if err != nil {
+			return err
+		}
+		var lastCommit string
+		commitMatches := commitRegex.FindStringSubmatch(output)
+		if len(commitMatches) > 0 {
+			if len(commitMatches[0]) > 1 {
+				lastCommit = string(commitMatches[1])
+			}
+		}
+		if lastCommit != "" {
+			logger.WithField("commit", lastCommit).Debug("found last commit synchronized with staging")
+			lastCommits[path] = lastCommit
+		}
+
+		if path != "." {
+			return fs.SkipDir
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to walk %s: %w", stagingDir, err)
+	}
+
+	var commits []commit
+	for repo, lastCommit := range lastCommits {
+		if _, err := runCommand(logger, exec.CommandContext(ctx,
+			"git", "fetch",
+			"git@github.com:operator-framework/"+repo,
+			"master",
+		)); err != nil {
+			return nil, err
+		}
+
+		output, err := runCommand(logger, exec.CommandContext(ctx,
+			"git", "log",
+			"--pretty=%H",
+			lastCommit+"...FETCH_HEAD",
+		))
+		if err != nil {
+			return nil, err
+		}
+
+		for _, line := range strings.Split(output, "\n") {
+			line = strings.TrimSpace(line)
+			if line != "" {
+				infoCmd := exec.CommandContext(ctx,
+					"git", "show",
+					line,
+					"--pretty=format:%H|%cI|%an|%s",
+					"--quiet",
+				)
+				stdout, stderr := bytes.Buffer{}, bytes.Buffer{}
+				infoCmd.Stdout = &stdout
+				infoCmd.Stderr = &stderr
+				logger.WithField("command", infoCmd.String()).Debug("running command")
+				if err := infoCmd.Run(); err != nil {
+					return nil, fmt.Errorf("failed to run command: %s %s: %w", stdout.String(), stderr.String(), err)
+				}
+				parts := strings.Split(stdout.String(), "|")
+				if len(parts) != 4 {
+					return nil, fmt.Errorf("incorrect parts from git output: %v", stdout.String())
+				}
+				committedTime, err := time.Parse(time.RFC3339, parts[1])
+				if err != nil {
+					return nil, fmt.Errorf("invalid time %s: %w", parts[1], err)
+				}
+				commits = append(commits, commit{
+					Hash:    parts[0],
+					Date:    committedTime,
+					Author:  parts[2],
+					Message: parts[3],
+					Repo:    repo,
+				})
+			}
+		}
+	}
+	sort.Slice(commits, func(i, j int) bool {
+		return commits[i].Date.Before(commits[j].Date)
+	})
+	return commits, nil
+}
+
+func cherryPick(ctx context.Context, logger *logrus.Entry, c commit) error {
+	{
+		output, err := runCommand(logger, exec.CommandContext(ctx,
+			"git", "cherry-pick",
+			"--allow-empty", "--keep-redundant-commits",
+			"-Xsubtree=staging/"+c.Repo, c.Hash,
+		))
+		if err != nil {
+			if strings.Contains(output, "vendor/modules.txt deleted in HEAD and modified in") {
+				// we remove vendor directories for everything under staging/, but some of the upstream repos have them
+				if _, err := runCommand(logger, exec.CommandContext(ctx,
+					"git", "rm", "--cached", "-r", "--ignore-unmatch", "staging/"+c.Repo+"/vendor",
+				)); err != nil {
+					return err
+				}
+				if _, err := runCommand(logger, exec.CommandContext(ctx,
+					"git", "cherry-pick", "--continue",
+				)); err != nil {
+					return err
+				}
+			} else {
+				return err
+			}
+		}
+	}
+
+	for _, cmd := range []*exec.Cmd{
+		withEnv(exec.CommandContext(ctx,
+			"go", "mod", "tidy",
+		), os.Environ()...),
+		withEnv(exec.CommandContext(ctx,
+			"go", "mod", "vendor",
+		), os.Environ()...),
+		withEnv(exec.CommandContext(ctx,
+			"go", "mod", "verify",
+		), os.Environ()...),
+		withEnv(exec.CommandContext(ctx,
+			"make", "manifests", "OLM_VERSION=0.0.1-snapshot",
+		), os.Environ()...),
+		exec.CommandContext(ctx,
+			"git", "add",
+			"staging/"+c.Repo,
+			"vendor", "go.mod", "go.sum",
+			"manifests", "pkg/manifests",
+		),
+		exec.CommandContext(ctx,
+			"git", "commit",
+			"--amend", "--allow-empty", "--no-edit",
+			"--trailer", "Upstream-repository: "+c.Repo,
+			"--trailer", "Upstream-commit: "+c.Hash,
+			"staging/"+c.Repo,
+			"vendor", "go.mod", "go.sum",
+			"manifests", "pkg/manifests",
+		),
+	} {
+		if _, err := runCommand(logger, cmd); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func runCommand(logger *logrus.Entry, cmd *exec.Cmd) (string, error) {
+	output := bytes.Buffer{}
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	logger.WithField("command", cmd.String()).Debug("running command")
+	if err := cmd.Run(); err != nil {
+		return output.String(), fmt.Errorf("failed to run command: %s: %w", output.String(), err)
+	}
+	return output.String(), nil
+}
+
+func withEnv(command *exec.Cmd, env ...string) *exec.Cmd {
+	command.Env = append(command.Env, env...)
+	return command
+}

--- a/scripts/verify_commits.sh
+++ b/scripts/verify_commits.sh
@@ -37,9 +37,12 @@ function verify_downstream_only() {
     local inside_staging
     inside_staging="$(git show --name-only "${downstream_commit}" -- staging)"
     if [[ -n "${inside_staging}" ]]; then
-        err "downstream non-staging commit ${downstream_commit} changes staging"
+        if git log -n 1 "${downstream_commit}" --pretty=%s | grep -q '[CARRY]'; then
+          return 0
+        fi
+        err "downstream non-staging commit ${downstream_commit} changes staging and is not labeled [CARRY]"
         err "${inside_staging}"
-        err "only staging commits (i.e. from an upstream cherry-pick) may change staging"
+        err "only staging commits (i.e. from an upstream cherry-pick) or commits labeled as downstream carries with [CARRY] may change staging"
         return 1
     fi
 }

--- a/staging/operator-lifecycle-manager/go.mod
+++ b/staging/operator-lifecycle-manager/go.mod
@@ -48,6 +48,7 @@ require (
 	k8s.io/code-generator v0.27.2
 	k8s.io/component-base v0.27.2
 	k8s.io/klog v1.0.0
+	k8s.io/klog/v2 v2.90.1
 	k8s.io/kube-aggregator v0.25.3
 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f
 	k8s.io/utils v0.0.0-20230220204549-a5ecb0141aa5
@@ -224,7 +225,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/cli-runtime v0.27.2 // indirect
 	k8s.io/gengo v0.0.0-20220902162205-c0856e24416d // indirect
-	k8s.io/klog/v2 v2.90.1 // indirect
 	k8s.io/kms v0.27.2 // indirect
 	k8s.io/kubectl v0.27.2 // indirect
 	oras.land/oras-go v1.2.3 // indirect

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/plugins/downstream_csv_namespace_labeler_plugin.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/plugins/downstream_csv_namespace_labeler_plugin.go
@@ -1,26 +1,22 @@
 package plugins
 
 import (
-  "context"
-  "fmt"
-  "strings"
-  "time"
+	"context"
+	"fmt"
+	"strings"
 
-  "github.com/operator-framework/api/pkg/operators/v1alpha1"
-  "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
-  listerv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
-  "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubestate"
-  "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
-  "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
-  "github.com/sirupsen/logrus"
-  v1 "k8s.io/api/core/v1"
-  metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-  "k8s.io/apimachinery/pkg/labels"
-  "k8s.io/apimachinery/pkg/runtime"
-  "k8s.io/apimachinery/pkg/watch"
-  listerv1 "k8s.io/client-go/listers/core/v1"
-  "k8s.io/client-go/tools/cache"
-  "k8s.io/client-go/util/workqueue"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	listerv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubestate"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	listerv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/util/workqueue"
 )
 
 const NamespaceLabelSyncerLabelKey = "security.openshift.io/scc.podSecurityLabelSync"
@@ -38,330 +34,209 @@ const noCopiedCsvSelector = "!" + v1alpha1.CopiedLabelKey
 // if the namespace name is prefixed with 'openshift-', and if the namespace does not contain the label (whatever
 // value it may be set to), it will add the "security.openshift.io/scc.podSecurityLabelSync=true" to the namespace.
 type csvNamespaceLabelerPlugin struct {
-  namespaceLister       listerv1.NamespaceLister
-  nonCopiedCsvListerMap map[string]listerv1alpha1.ClusterServiceVersionLister
-  kubeClient            operatorclient.ClientInterface
-  externalClient        versioned.Interface
-  logger                *logrus.Logger
+	namespaceLister       listerv1.NamespaceLister
+	nonCopiedCsvListerMap map[string]listerv1alpha1.ClusterServiceVersionLister
+	kubeClient            operatorclient.ClientInterface
+	externalClient        versioned.Interface
+	logger                *logrus.Logger
 }
 
 func NewCsvNamespaceLabelerPluginFunc(ctx context.Context, config OperatorConfig, hostOperator HostOperator) (OperatorPlugin, error) {
 
-  if hostOperator == nil {
-    return nil, fmt.Errorf("cannot initialize plugin: operator undefined")
-  }
+	if hostOperator == nil {
+		return nil, fmt.Errorf("cannot initialize plugin: operator undefined")
+	}
 
-  plugin := &csvNamespaceLabelerPlugin{
-    kubeClient:            config.OperatorClient(),
-    externalClient:        config.ExternalClient(),
-    logger:                config.Logger(),
-    namespaceLister:       nil,
-    nonCopiedCsvListerMap: map[string]listerv1alpha1.ClusterServiceVersionLister{},
-  }
+	plugin := &csvNamespaceLabelerPlugin{
+		kubeClient:            config.OperatorClient(),
+		externalClient:        config.ExternalClient(),
+		logger:                config.Logger(),
+		namespaceLister:       nil,
+		nonCopiedCsvListerMap: map[string]listerv1alpha1.ClusterServiceVersionLister{},
+	}
 
-  plugin.log("setting up csv namespace plug-in for namespaces: %s", config.WatchedNamespaces())
+	plugin.log("setting up csv namespace plug-in for namespaces: %s", config.WatchedNamespaces())
 
-  namespaceInformer := newNamespaceInformer(config.OperatorClient(), config.ResyncPeriod()())
+	namespaceInformer := hostOperator.Informers()[metav1.NamespaceAll].NamespaceInformer.Informer()
 
-  plugin.log("registering namespace informer")
+	plugin.log("registering namespace informer")
 
-  plugin.namespaceLister = listerv1.NewNamespaceLister(namespaceInformer.GetIndexer())
+	plugin.namespaceLister = listerv1.NewNamespaceLister(namespaceInformer.GetIndexer())
 
-  namespaceQueue := workqueue.NewNamedRateLimitingQueue(
-    workqueue.DefaultControllerRateLimiter(),
-    "csv-ns-labeler-plugin-ns-queue",
-  )
-  namespaceQueueInformer, err := queueinformer.NewQueueInformer(
-    ctx,
-    queueinformer.WithInformer(namespaceInformer),
-    queueinformer.WithLogger(config.Logger()),
-    queueinformer.WithQueue(namespaceQueue),
-    queueinformer.WithIndexer(namespaceInformer.GetIndexer()),
-    queueinformer.WithSyncer(plugin),
-  )
-  if err != nil {
-    return nil, err
-  }
-  if err := hostOperator.RegisterQueueInformer(namespaceQueueInformer); err != nil {
-    return nil, err
-  }
+	namespaceQueue := workqueue.NewNamedRateLimitingQueue(
+		workqueue.DefaultControllerRateLimiter(),
+		"csv-ns-labeler-plugin-ns-queue",
+	)
+	namespaceQueueInformer, err := queueinformer.NewQueueInformer(
+		ctx,
+		queueinformer.WithInformer(namespaceInformer),
+		queueinformer.WithLogger(config.Logger()),
+		queueinformer.WithQueue(namespaceQueue),
+		queueinformer.WithIndexer(namespaceInformer.GetIndexer()),
+		queueinformer.WithSyncer(plugin),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := hostOperator.RegisterQueueInformer(namespaceQueueInformer); err != nil {
+		return nil, err
+	}
 
-  for _, namespace := range config.WatchedNamespaces() {
-    plugin.log("setting up namespace: %s", namespace)
-    // ignore namespaces that are *NOT* prefixed with openshift- but accept metav1.NamespaceAll
-    if !(hasOpenshiftPrefix(namespace)) && namespace != metav1.NamespaceAll {
-      continue
-    }
+	for _, namespace := range config.WatchedNamespaces() {
+		plugin.log("setting up namespace: %s", namespace)
+		// ignore namespaces that are *NOT* prefixed with openshift- but accept metav1.NamespaceAll
+		if !(hasOpenshiftPrefix(namespace)) && namespace != metav1.NamespaceAll {
+			continue
+		}
 
-    nonCopiedCsvInformer := newNonCopiedCsvInformerForNamespace(namespace, config.ExternalClient(), config.ResyncPeriod()())
+		nonCopiedCsvInformer := hostOperator.Informers()[namespace].CSVInformer.Informer()
 
-    nonCopiedCsvQueue := workqueue.NewNamedRateLimitingQueue(
-      workqueue.DefaultControllerRateLimiter(),
-      fmt.Sprintf("%s/csv-ns-labeler-plugin-csv-queue", namespace),
-    )
-    nonCopiedCsvQueueInformer, err := queueinformer.NewQueueInformer(
-      ctx,
-      queueinformer.WithInformer(nonCopiedCsvInformer),
-      queueinformer.WithLogger(config.Logger()),
-      queueinformer.WithQueue(nonCopiedCsvQueue),
-      queueinformer.WithIndexer(nonCopiedCsvInformer.GetIndexer()),
-      queueinformer.WithSyncer(plugin),
-    )
-    if err != nil {
-      return nil, err
-    }
-    if err := hostOperator.RegisterQueueInformer(nonCopiedCsvQueueInformer); err != nil {
-      return nil, err
-    }
-    plugin.nonCopiedCsvListerMap[namespace] = listerv1alpha1.NewClusterServiceVersionLister(nonCopiedCsvInformer.GetIndexer())
-    plugin.log("registered csv queue informer for: %s", namespace)
-  }
-  plugin.log("finished setting up csv namespace labeler plugin")
+		nonCopiedCsvQueue := workqueue.NewNamedRateLimitingQueue(
+			workqueue.DefaultControllerRateLimiter(),
+			fmt.Sprintf("%s/csv-ns-labeler-plugin-csv-queue", namespace),
+		)
+		nonCopiedCsvQueueInformer, err := queueinformer.NewQueueInformer(
+			ctx,
+			queueinformer.WithInformer(nonCopiedCsvInformer),
+			queueinformer.WithLogger(config.Logger()),
+			queueinformer.WithQueue(nonCopiedCsvQueue),
+			queueinformer.WithIndexer(nonCopiedCsvInformer.GetIndexer()),
+			queueinformer.WithSyncer(plugin),
+		)
+		if err != nil {
+			return nil, err
+		}
+		if err := hostOperator.RegisterQueueInformer(nonCopiedCsvQueueInformer); err != nil {
+			return nil, err
+		}
+		plugin.nonCopiedCsvListerMap[namespace] = listerv1alpha1.NewClusterServiceVersionLister(nonCopiedCsvInformer.GetIndexer())
+		plugin.log("registered csv queue informer for: %s", namespace)
+	}
+	plugin.log("finished setting up csv namespace labeler plugin")
 
-  return plugin, nil
+	return plugin, nil
 }
 
 func (p *csvNamespaceLabelerPlugin) Shutdown() error {
-  return nil
+	return nil
 }
 
 func (p *csvNamespaceLabelerPlugin) Sync(ctx context.Context, event kubestate.ResourceEvent) error {
-  // only act on csv added and updated events
-  if event.Type() != kubestate.ResourceAdded && event.Type() != kubestate.ResourceUpdated {
-    return nil
-  }
+	// only act on csv added and updated events
+	if event.Type() != kubestate.ResourceAdded && event.Type() != kubestate.ResourceUpdated {
+		return nil
+	}
 
-  var namespace *v1.Namespace
-  var err error
+	var namespace *v1.Namespace
+	var err error
 
-  // get namespace from the event resource
-  switch eventResource := event.Resource().(type) {
+	// get namespace from the event resource
+	switch eventResource := event.Resource().(type) {
 
-  // handle csv events
-  case *v1alpha1.ClusterServiceVersion:
-    // ignore copied csvs and namespaces that should be ignored
-    if eventResource.IsCopied() || ignoreNamespace(eventResource.GetNamespace()) {
-      return nil
-    }
+	// handle csv events
+	case *v1alpha1.ClusterServiceVersion:
+		// ignore copied csvs and namespaces that should be ignored
+		if eventResource.IsCopied() || ignoreNamespace(eventResource.GetNamespace()) {
+			return nil
+		}
 
-    namespace, err = p.getNamespace(eventResource.GetNamespace())
-    if err != nil {
-      return fmt.Errorf("error getting csv namespace (%s) for label sync'er labeling", eventResource.GetNamespace())
-    }
+		namespace, err = p.getNamespace(eventResource.GetNamespace())
+		if err != nil {
+			return fmt.Errorf("error getting csv namespace (%s) for label sync'er labeling", eventResource.GetNamespace())
+		}
 
-  // handle namespace events
-  case *v1.Namespace:
-    // ignore namespaces that should be ignored and ones that are already labeled
-    if ignoreNamespace(eventResource.GetName()) || hasLabelSyncerLabel(eventResource) {
-      return nil
-    }
+	// handle namespace events
+	case *v1.Namespace:
+		// ignore namespaces that should be ignored and ones that are already labeled
+		if ignoreNamespace(eventResource.GetName()) || hasLabelSyncerLabel(eventResource) {
+			return nil
+		}
 
-    // get csv count for namespace
-    csvCount, err := p.countClusterServiceVersions(eventResource.GetName())
-    if err != nil {
-      return fmt.Errorf("error counting csvs in namespace=%s: %s", eventResource.GetName(), err)
-    }
+		// get csv count for namespace
+		csvCount, err := p.countClusterServiceVersions(eventResource.GetName())
+		if err != nil {
+			return fmt.Errorf("error counting csvs in namespace=%s: %s", eventResource.GetName(), err)
+		}
 
-    // ignore namespaces with no csvs
-    if csvCount <= 0 {
-      return nil
-    }
+		// ignore namespaces with no csvs
+		if csvCount <= 0 {
+			return nil
+		}
 
-    namespace = eventResource
-  default:
-    return fmt.Errorf("event resource is neither a ClusterServiceVersion or a Namespace")
-  }
+		namespace = eventResource
+	default:
+		return fmt.Errorf("event resource is neither a ClusterServiceVersion or a Namespace")
+	}
 
-  // add label sync'er label if it does not exist
-  if !(hasLabelSyncerLabel(namespace)) {
-    if err := applyLabelSyncerLabel(ctx, p.kubeClient, namespace); err != nil {
-      return fmt.Errorf("error updating csv namespace (%s) with label sync'er label", namespace.GetNamespace())
-    }
-    p.log("applied %s=true label to namespace %s", NamespaceLabelSyncerLabelKey, namespace.GetNamespace())
-  }
+	// add label sync'er label if it does not exist
+	if !(hasLabelSyncerLabel(namespace)) {
+		if err := applyLabelSyncerLabel(ctx, p.kubeClient, namespace); err != nil {
+			return fmt.Errorf("error updating csv namespace (%s) with label sync'er label", namespace.GetNamespace())
+		}
+		p.log("applied %s=true label to namespace %s", NamespaceLabelSyncerLabelKey, namespace.GetNamespace())
+	}
 
-  return nil
+	return nil
 }
 
 func (p *csvNamespaceLabelerPlugin) getNamespace(namespace string) (*v1.Namespace, error) {
-  ns, err := p.namespaceLister.Get(namespace)
-  if err != nil {
-    return nil, err
-  }
-  return ns, nil
+	ns, err := p.namespaceLister.Get(namespace)
+	if err != nil {
+		return nil, err
+	}
+	return ns, nil
 }
 
 func (p *csvNamespaceLabelerPlugin) countClusterServiceVersions(namespace string) (int, error) {
-  lister, ok := p.nonCopiedCsvListerMap[namespace]
-  if !ok {
-    lister, ok = p.nonCopiedCsvListerMap[metav1.NamespaceAll]
-    if !ok {
-      return 0, fmt.Errorf("no csv indexer found for namespace: %s", namespace)
-    }
-  }
-  labelSelector, err := labels.Parse(noCopiedCsvSelector)
-  if err != nil {
-    return 0, err
-  }
+	lister, ok := p.nonCopiedCsvListerMap[namespace]
+	if !ok {
+		lister, ok = p.nonCopiedCsvListerMap[metav1.NamespaceAll]
+		if !ok {
+			return 0, fmt.Errorf("no csv indexer found for namespace: %s", namespace)
+		}
+	}
+	labelSelector, err := labels.Parse(noCopiedCsvSelector)
+	if err != nil {
+		return 0, err
+	}
 
-  csvList, err := lister.ClusterServiceVersions(namespace).List(labelSelector)
-  if err != nil {
-    return 0, err
-  }
-  return len(csvList), nil
+	csvList, err := lister.ClusterServiceVersions(namespace).List(labelSelector)
+	if err != nil {
+		return 0, err
+	}
+	return len(csvList), nil
 }
 
 func (p *csvNamespaceLabelerPlugin) log(format string, args ...interface{}) {
-  if p.logger != nil {
-    p.logger.Infof("[CSV NS Plug-in] "+format, args...)
-  }
-}
-
-// newNamespaceInformer creates a namespace informer that filters namespaces the plug-in is not interested in:
-// payload namespaces (except openshift-operators) and non openshift- prefixed namespaces
-// the informer also prunes the namespace objects to only keep basic type and object metadata and annotations
-func newNamespaceInformer(k8sClient operatorclient.ClientInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-  // create a namespace informer
-  pruneNamespace := func(namespace *v1.Namespace) {
-    namespace = &v1.Namespace{
-      TypeMeta: namespace.TypeMeta,
-      ObjectMeta: metav1.ObjectMeta{
-        Name:        namespace.GetName(),
-        Namespace:   namespace.GetNamespace(),
-        Annotations: namespace.GetAnnotations(),
-      },
-    }
-  }
-
-  return cache.NewSharedIndexInformer(
-    &cache.ListWatch{
-      ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-        list, err := k8sClient.KubernetesInterface().CoreV1().Namespaces().List(context.Background(), options)
-        if err != nil {
-          return list, err
-        }
-
-        // filter and prune namespaces
-        var filteredList []v1.Namespace
-        for i := range list.Items {
-          ns := list.Items[i]
-          if !(ignoreNamespace(ns.GetName())) {
-            pruneNamespace(&ns)
-            filteredList = append(filteredList, ns)
-          }
-        }
-        return &v1.NamespaceList{
-          Items: filteredList,
-        }, nil
-      },
-      WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-        nsWatch, err := k8sClient.KubernetesInterface().CoreV1().Namespaces().Watch(context.Background(), options)
-        if err != nil {
-          return nsWatch, err
-        }
-        return watch.Filter(nsWatch, func(e watch.Event) (watch.Event, bool) {
-          if ns, ok := e.Object.(*v1.Namespace); ok {
-            if !(ignoreNamespace(ns.GetName())) {
-              pruneNamespace(ns)
-              return e, true
-            }
-          }
-          return e, false
-        }), nil
-      },
-    },
-    &v1.Namespace{},
-    resyncPeriod,
-    cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
-  )
-}
-
-// newNonCopiedCsvInformerForNamespace creates a csv-based informer that filters out copied csvs and csv events coming
-// from namespaces the plug-in is not interested in: payload namespaces (except openshift-operators) and
-// non openshift- prefixed namespaces
-// the informer also prunes the csvs to only keep basic type and object metadata and annotations
-func newNonCopiedCsvInformerForNamespace(namespace string, externalClient versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-  // create a new csv informer and prune status to reduce memory footprint
-  pruneCSV := func(csv *v1alpha1.ClusterServiceVersion) {
-    csv = &v1alpha1.ClusterServiceVersion{
-      TypeMeta: csv.TypeMeta,
-      ObjectMeta: metav1.ObjectMeta{
-        Name:        csv.GetName(),
-        Namespace:   csv.GetNamespace(),
-        Annotations: csv.GetAnnotations(),
-      },
-    }
-  }
-
-  return cache.NewSharedIndexInformer(
-    &cache.ListWatch{
-      ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-        options.LabelSelector = noCopiedCsvSelector
-        list, err := externalClient.OperatorsV1alpha1().ClusterServiceVersions(namespace).List(context.Background(), options)
-        if err != nil {
-          return list, err
-        }
-
-        // filter and prune csvs
-        var filteredList []v1alpha1.ClusterServiceVersion
-        for i := range list.Items {
-          csv := list.Items[i]
-          if !(ignoreNamespace(csv.GetNamespace())) {
-            pruneCSV(&csv)
-            filteredList = append(filteredList, csv)
-          }
-        }
-        return &v1alpha1.ClusterServiceVersionList{
-          Items: filteredList,
-        }, nil
-      },
-      WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-        options.LabelSelector = noCopiedCsvSelector
-        csvWatch, err := externalClient.OperatorsV1alpha1().ClusterServiceVersions(namespace).Watch(context.Background(), options)
-        if err != nil {
-          return csvWatch, err
-        }
-        return watch.Filter(csvWatch, func(e watch.Event) (watch.Event, bool) {
-          if csv, ok := e.Object.(*v1alpha1.ClusterServiceVersion); ok {
-            if !(ignoreNamespace(csv.GetNamespace())) && !csv.IsCopied() {
-              pruneCSV(csv)
-              return e, true
-            }
-          }
-          return e, false
-        }), nil
-      },
-    },
-    &v1alpha1.ClusterServiceVersion{},
-    resyncPeriod,
-    cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
-  )
+	if p.logger != nil {
+		p.logger.Infof("[CSV NS Plug-in] "+format, args...)
+	}
 }
 
 func hasOpenshiftPrefix(namespaceName string) bool {
-  return strings.HasPrefix(namespaceName, openshiftPrefix)
+	return strings.HasPrefix(namespaceName, openshiftPrefix)
 }
 
 func ignoreNamespace(namespace string) bool {
-  // ignore non-openshift-* and payload openshift-* namespaces
-  return !hasOpenshiftPrefix(namespace) || IsNamespacePSALabelSyncExemptedInVendoredOCPVersion(namespace)
+	// ignore non-openshift-* and payload openshift-* namespaces
+	return !hasOpenshiftPrefix(namespace) || IsNamespacePSALabelSyncExemptedInVendoredOCPVersion(namespace)
 }
 
 func applyLabelSyncerLabel(ctx context.Context, kubeClient operatorclient.ClientInterface, namespace *v1.Namespace) error {
-  if _, ok := namespace.GetLabels()[NamespaceLabelSyncerLabelKey]; !ok {
-    nsCopy := namespace.DeepCopy()
-    if nsCopy.GetLabels() == nil {
-      nsCopy.SetLabels(map[string]string{})
-    }
-    nsCopy.GetLabels()[NamespaceLabelSyncerLabelKey] = "true"
-    if _, err := kubeClient.KubernetesInterface().CoreV1().Namespaces().Update(ctx, nsCopy, metav1.UpdateOptions{}); err != nil {
-      return err
-    }
-  }
-  return nil
+	if _, ok := namespace.GetLabels()[NamespaceLabelSyncerLabelKey]; !ok {
+		nsCopy := namespace.DeepCopy()
+		if nsCopy.GetLabels() == nil {
+			nsCopy.SetLabels(map[string]string{})
+		}
+		nsCopy.GetLabels()[NamespaceLabelSyncerLabelKey] = "true"
+		if _, err := kubeClient.KubernetesInterface().CoreV1().Namespaces().Update(ctx, nsCopy, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func hasLabelSyncerLabel(namespace *v1.Namespace) bool {
-  _, ok := namespace.GetLabels()[NamespaceLabelSyncerLabelKey]
-  return ok
+	_, ok := namespace.GetLabels()[NamespaceLabelSyncerLabelKey]
+	return ok
 }

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/plugins/operator_plugin.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/plugins/operator_plugin.go
@@ -5,9 +5,19 @@ import (
 	"time"
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	operatorsv1informers "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/informers/externalversions/operators/v1"
+	operatorsv1alpha1informers "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/informers/externalversions/operators/v1alpha1"
+	operatorsv2informers "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/informers/externalversions/operators/v2"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
 	"github.com/sirupsen/logrus"
+	extensionsv1informers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
+	appsv1informers "k8s.io/client-go/informers/apps/v1"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	rbacv1informers "k8s.io/client-go/informers/rbac/v1"
+	"k8s.io/client-go/metadata/metadatalister"
+	"k8s.io/client-go/tools/cache"
+	apiregistrationv1informers "k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1"
 )
 
 type PluginID string
@@ -17,6 +27,29 @@ type OperatorPlugInFactoryMap map[PluginID]OperatorPlugInFactoryFunc
 type HostOperator interface {
 	queueinformer.ObservableOperator
 	queueinformer.ExtensibleOperator
+	Informers() map[string]*Informers
+}
+
+// Informers exposes informer caches that the host operator has already started, for re-use by plugins.
+type Informers struct {
+	CSVInformer                operatorsv1alpha1informers.ClusterServiceVersionInformer
+	CopiedCSVInformer          cache.SharedIndexInformer
+	CopiedCSVLister            metadatalister.Lister
+	OperatorGroupInformer      operatorsv1informers.OperatorGroupInformer
+	OperatorConditionInformer  operatorsv2informers.OperatorConditionInformer
+	SubscriptionInformer       operatorsv1alpha1informers.SubscriptionInformer
+	DeploymentInformer         appsv1informers.DeploymentInformer
+	RoleInformer               rbacv1informers.RoleInformer
+	RoleBindingInformer        rbacv1informers.RoleBindingInformer
+	SecretInformer             corev1informers.SecretInformer
+	ServiceInformer            corev1informers.ServiceInformer
+	ServiceAccountInformer     corev1informers.ServiceAccountInformer
+	OLMConfigInformer          operatorsv1informers.OLMConfigInformer
+	ClusterRoleInformer        rbacv1informers.ClusterRoleInformer
+	ClusterRoleBindingInformer rbacv1informers.ClusterRoleBindingInformer
+	NamespaceInformer          corev1informers.NamespaceInformer
+	APIServiceInformer         apiregistrationv1informers.APIServiceInformer
+	CRDInformer                extensionsv1informers.CustomResourceDefinitionInformer
 }
 
 // OperatorConfig gives access to required configuration from the host operator

--- a/staging/operator-lifecycle-manager/pkg/lib/queueinformer/queueinformer_operator.go
+++ b/staging/operator-lifecycle-manager/pkg/lib/queueinformer/queueinformer_operator.go
@@ -141,6 +141,12 @@ func (o *operator) RegisterInformer(informer cache.SharedIndexInformer) error {
 }
 
 func (o *operator) registerInformer(informer cache.SharedIndexInformer) {
+	// never double-register an informer
+	for i := range o.informers {
+		if o.informers[i] == informer {
+			return
+		}
+	}
 	o.informers = append(o.informers, informer)
 	o.addHasSynced(informer.HasSynced)
 }

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/plugins/downstream_csv_namespace_labeler_plugin.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/plugins/downstream_csv_namespace_labeler_plugin.go
@@ -1,26 +1,22 @@
 package plugins
 
 import (
-  "context"
-  "fmt"
-  "strings"
-  "time"
+	"context"
+	"fmt"
+	"strings"
 
-  "github.com/operator-framework/api/pkg/operators/v1alpha1"
-  "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
-  listerv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
-  "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubestate"
-  "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
-  "github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
-  "github.com/sirupsen/logrus"
-  v1 "k8s.io/api/core/v1"
-  metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-  "k8s.io/apimachinery/pkg/labels"
-  "k8s.io/apimachinery/pkg/runtime"
-  "k8s.io/apimachinery/pkg/watch"
-  listerv1 "k8s.io/client-go/listers/core/v1"
-  "k8s.io/client-go/tools/cache"
-  "k8s.io/client-go/util/workqueue"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	listerv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubestate"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	listerv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/util/workqueue"
 )
 
 const NamespaceLabelSyncerLabelKey = "security.openshift.io/scc.podSecurityLabelSync"
@@ -38,330 +34,209 @@ const noCopiedCsvSelector = "!" + v1alpha1.CopiedLabelKey
 // if the namespace name is prefixed with 'openshift-', and if the namespace does not contain the label (whatever
 // value it may be set to), it will add the "security.openshift.io/scc.podSecurityLabelSync=true" to the namespace.
 type csvNamespaceLabelerPlugin struct {
-  namespaceLister       listerv1.NamespaceLister
-  nonCopiedCsvListerMap map[string]listerv1alpha1.ClusterServiceVersionLister
-  kubeClient            operatorclient.ClientInterface
-  externalClient        versioned.Interface
-  logger                *logrus.Logger
+	namespaceLister       listerv1.NamespaceLister
+	nonCopiedCsvListerMap map[string]listerv1alpha1.ClusterServiceVersionLister
+	kubeClient            operatorclient.ClientInterface
+	externalClient        versioned.Interface
+	logger                *logrus.Logger
 }
 
 func NewCsvNamespaceLabelerPluginFunc(ctx context.Context, config OperatorConfig, hostOperator HostOperator) (OperatorPlugin, error) {
 
-  if hostOperator == nil {
-    return nil, fmt.Errorf("cannot initialize plugin: operator undefined")
-  }
+	if hostOperator == nil {
+		return nil, fmt.Errorf("cannot initialize plugin: operator undefined")
+	}
 
-  plugin := &csvNamespaceLabelerPlugin{
-    kubeClient:            config.OperatorClient(),
-    externalClient:        config.ExternalClient(),
-    logger:                config.Logger(),
-    namespaceLister:       nil,
-    nonCopiedCsvListerMap: map[string]listerv1alpha1.ClusterServiceVersionLister{},
-  }
+	plugin := &csvNamespaceLabelerPlugin{
+		kubeClient:            config.OperatorClient(),
+		externalClient:        config.ExternalClient(),
+		logger:                config.Logger(),
+		namespaceLister:       nil,
+		nonCopiedCsvListerMap: map[string]listerv1alpha1.ClusterServiceVersionLister{},
+	}
 
-  plugin.log("setting up csv namespace plug-in for namespaces: %s", config.WatchedNamespaces())
+	plugin.log("setting up csv namespace plug-in for namespaces: %s", config.WatchedNamespaces())
 
-  namespaceInformer := newNamespaceInformer(config.OperatorClient(), config.ResyncPeriod()())
+	namespaceInformer := hostOperator.Informers()[metav1.NamespaceAll].NamespaceInformer.Informer()
 
-  plugin.log("registering namespace informer")
+	plugin.log("registering namespace informer")
 
-  plugin.namespaceLister = listerv1.NewNamespaceLister(namespaceInformer.GetIndexer())
+	plugin.namespaceLister = listerv1.NewNamespaceLister(namespaceInformer.GetIndexer())
 
-  namespaceQueue := workqueue.NewNamedRateLimitingQueue(
-    workqueue.DefaultControllerRateLimiter(),
-    "csv-ns-labeler-plugin-ns-queue",
-  )
-  namespaceQueueInformer, err := queueinformer.NewQueueInformer(
-    ctx,
-    queueinformer.WithInformer(namespaceInformer),
-    queueinformer.WithLogger(config.Logger()),
-    queueinformer.WithQueue(namespaceQueue),
-    queueinformer.WithIndexer(namespaceInformer.GetIndexer()),
-    queueinformer.WithSyncer(plugin),
-  )
-  if err != nil {
-    return nil, err
-  }
-  if err := hostOperator.RegisterQueueInformer(namespaceQueueInformer); err != nil {
-    return nil, err
-  }
+	namespaceQueue := workqueue.NewNamedRateLimitingQueue(
+		workqueue.DefaultControllerRateLimiter(),
+		"csv-ns-labeler-plugin-ns-queue",
+	)
+	namespaceQueueInformer, err := queueinformer.NewQueueInformer(
+		ctx,
+		queueinformer.WithInformer(namespaceInformer),
+		queueinformer.WithLogger(config.Logger()),
+		queueinformer.WithQueue(namespaceQueue),
+		queueinformer.WithIndexer(namespaceInformer.GetIndexer()),
+		queueinformer.WithSyncer(plugin),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := hostOperator.RegisterQueueInformer(namespaceQueueInformer); err != nil {
+		return nil, err
+	}
 
-  for _, namespace := range config.WatchedNamespaces() {
-    plugin.log("setting up namespace: %s", namespace)
-    // ignore namespaces that are *NOT* prefixed with openshift- but accept metav1.NamespaceAll
-    if !(hasOpenshiftPrefix(namespace)) && namespace != metav1.NamespaceAll {
-      continue
-    }
+	for _, namespace := range config.WatchedNamespaces() {
+		plugin.log("setting up namespace: %s", namespace)
+		// ignore namespaces that are *NOT* prefixed with openshift- but accept metav1.NamespaceAll
+		if !(hasOpenshiftPrefix(namespace)) && namespace != metav1.NamespaceAll {
+			continue
+		}
 
-    nonCopiedCsvInformer := newNonCopiedCsvInformerForNamespace(namespace, config.ExternalClient(), config.ResyncPeriod()())
+		nonCopiedCsvInformer := hostOperator.Informers()[namespace].CSVInformer.Informer()
 
-    nonCopiedCsvQueue := workqueue.NewNamedRateLimitingQueue(
-      workqueue.DefaultControllerRateLimiter(),
-      fmt.Sprintf("%s/csv-ns-labeler-plugin-csv-queue", namespace),
-    )
-    nonCopiedCsvQueueInformer, err := queueinformer.NewQueueInformer(
-      ctx,
-      queueinformer.WithInformer(nonCopiedCsvInformer),
-      queueinformer.WithLogger(config.Logger()),
-      queueinformer.WithQueue(nonCopiedCsvQueue),
-      queueinformer.WithIndexer(nonCopiedCsvInformer.GetIndexer()),
-      queueinformer.WithSyncer(plugin),
-    )
-    if err != nil {
-      return nil, err
-    }
-    if err := hostOperator.RegisterQueueInformer(nonCopiedCsvQueueInformer); err != nil {
-      return nil, err
-    }
-    plugin.nonCopiedCsvListerMap[namespace] = listerv1alpha1.NewClusterServiceVersionLister(nonCopiedCsvInformer.GetIndexer())
-    plugin.log("registered csv queue informer for: %s", namespace)
-  }
-  plugin.log("finished setting up csv namespace labeler plugin")
+		nonCopiedCsvQueue := workqueue.NewNamedRateLimitingQueue(
+			workqueue.DefaultControllerRateLimiter(),
+			fmt.Sprintf("%s/csv-ns-labeler-plugin-csv-queue", namespace),
+		)
+		nonCopiedCsvQueueInformer, err := queueinformer.NewQueueInformer(
+			ctx,
+			queueinformer.WithInformer(nonCopiedCsvInformer),
+			queueinformer.WithLogger(config.Logger()),
+			queueinformer.WithQueue(nonCopiedCsvQueue),
+			queueinformer.WithIndexer(nonCopiedCsvInformer.GetIndexer()),
+			queueinformer.WithSyncer(plugin),
+		)
+		if err != nil {
+			return nil, err
+		}
+		if err := hostOperator.RegisterQueueInformer(nonCopiedCsvQueueInformer); err != nil {
+			return nil, err
+		}
+		plugin.nonCopiedCsvListerMap[namespace] = listerv1alpha1.NewClusterServiceVersionLister(nonCopiedCsvInformer.GetIndexer())
+		plugin.log("registered csv queue informer for: %s", namespace)
+	}
+	plugin.log("finished setting up csv namespace labeler plugin")
 
-  return plugin, nil
+	return plugin, nil
 }
 
 func (p *csvNamespaceLabelerPlugin) Shutdown() error {
-  return nil
+	return nil
 }
 
 func (p *csvNamespaceLabelerPlugin) Sync(ctx context.Context, event kubestate.ResourceEvent) error {
-  // only act on csv added and updated events
-  if event.Type() != kubestate.ResourceAdded && event.Type() != kubestate.ResourceUpdated {
-    return nil
-  }
+	// only act on csv added and updated events
+	if event.Type() != kubestate.ResourceAdded && event.Type() != kubestate.ResourceUpdated {
+		return nil
+	}
 
-  var namespace *v1.Namespace
-  var err error
+	var namespace *v1.Namespace
+	var err error
 
-  // get namespace from the event resource
-  switch eventResource := event.Resource().(type) {
+	// get namespace from the event resource
+	switch eventResource := event.Resource().(type) {
 
-  // handle csv events
-  case *v1alpha1.ClusterServiceVersion:
-    // ignore copied csvs and namespaces that should be ignored
-    if eventResource.IsCopied() || ignoreNamespace(eventResource.GetNamespace()) {
-      return nil
-    }
+	// handle csv events
+	case *v1alpha1.ClusterServiceVersion:
+		// ignore copied csvs and namespaces that should be ignored
+		if eventResource.IsCopied() || ignoreNamespace(eventResource.GetNamespace()) {
+			return nil
+		}
 
-    namespace, err = p.getNamespace(eventResource.GetNamespace())
-    if err != nil {
-      return fmt.Errorf("error getting csv namespace (%s) for label sync'er labeling", eventResource.GetNamespace())
-    }
+		namespace, err = p.getNamespace(eventResource.GetNamespace())
+		if err != nil {
+			return fmt.Errorf("error getting csv namespace (%s) for label sync'er labeling", eventResource.GetNamespace())
+		}
 
-  // handle namespace events
-  case *v1.Namespace:
-    // ignore namespaces that should be ignored and ones that are already labeled
-    if ignoreNamespace(eventResource.GetName()) || hasLabelSyncerLabel(eventResource) {
-      return nil
-    }
+	// handle namespace events
+	case *v1.Namespace:
+		// ignore namespaces that should be ignored and ones that are already labeled
+		if ignoreNamespace(eventResource.GetName()) || hasLabelSyncerLabel(eventResource) {
+			return nil
+		}
 
-    // get csv count for namespace
-    csvCount, err := p.countClusterServiceVersions(eventResource.GetName())
-    if err != nil {
-      return fmt.Errorf("error counting csvs in namespace=%s: %s", eventResource.GetName(), err)
-    }
+		// get csv count for namespace
+		csvCount, err := p.countClusterServiceVersions(eventResource.GetName())
+		if err != nil {
+			return fmt.Errorf("error counting csvs in namespace=%s: %s", eventResource.GetName(), err)
+		}
 
-    // ignore namespaces with no csvs
-    if csvCount <= 0 {
-      return nil
-    }
+		// ignore namespaces with no csvs
+		if csvCount <= 0 {
+			return nil
+		}
 
-    namespace = eventResource
-  default:
-    return fmt.Errorf("event resource is neither a ClusterServiceVersion or a Namespace")
-  }
+		namespace = eventResource
+	default:
+		return fmt.Errorf("event resource is neither a ClusterServiceVersion or a Namespace")
+	}
 
-  // add label sync'er label if it does not exist
-  if !(hasLabelSyncerLabel(namespace)) {
-    if err := applyLabelSyncerLabel(ctx, p.kubeClient, namespace); err != nil {
-      return fmt.Errorf("error updating csv namespace (%s) with label sync'er label", namespace.GetNamespace())
-    }
-    p.log("applied %s=true label to namespace %s", NamespaceLabelSyncerLabelKey, namespace.GetNamespace())
-  }
+	// add label sync'er label if it does not exist
+	if !(hasLabelSyncerLabel(namespace)) {
+		if err := applyLabelSyncerLabel(ctx, p.kubeClient, namespace); err != nil {
+			return fmt.Errorf("error updating csv namespace (%s) with label sync'er label", namespace.GetNamespace())
+		}
+		p.log("applied %s=true label to namespace %s", NamespaceLabelSyncerLabelKey, namespace.GetNamespace())
+	}
 
-  return nil
+	return nil
 }
 
 func (p *csvNamespaceLabelerPlugin) getNamespace(namespace string) (*v1.Namespace, error) {
-  ns, err := p.namespaceLister.Get(namespace)
-  if err != nil {
-    return nil, err
-  }
-  return ns, nil
+	ns, err := p.namespaceLister.Get(namespace)
+	if err != nil {
+		return nil, err
+	}
+	return ns, nil
 }
 
 func (p *csvNamespaceLabelerPlugin) countClusterServiceVersions(namespace string) (int, error) {
-  lister, ok := p.nonCopiedCsvListerMap[namespace]
-  if !ok {
-    lister, ok = p.nonCopiedCsvListerMap[metav1.NamespaceAll]
-    if !ok {
-      return 0, fmt.Errorf("no csv indexer found for namespace: %s", namespace)
-    }
-  }
-  labelSelector, err := labels.Parse(noCopiedCsvSelector)
-  if err != nil {
-    return 0, err
-  }
+	lister, ok := p.nonCopiedCsvListerMap[namespace]
+	if !ok {
+		lister, ok = p.nonCopiedCsvListerMap[metav1.NamespaceAll]
+		if !ok {
+			return 0, fmt.Errorf("no csv indexer found for namespace: %s", namespace)
+		}
+	}
+	labelSelector, err := labels.Parse(noCopiedCsvSelector)
+	if err != nil {
+		return 0, err
+	}
 
-  csvList, err := lister.ClusterServiceVersions(namespace).List(labelSelector)
-  if err != nil {
-    return 0, err
-  }
-  return len(csvList), nil
+	csvList, err := lister.ClusterServiceVersions(namespace).List(labelSelector)
+	if err != nil {
+		return 0, err
+	}
+	return len(csvList), nil
 }
 
 func (p *csvNamespaceLabelerPlugin) log(format string, args ...interface{}) {
-  if p.logger != nil {
-    p.logger.Infof("[CSV NS Plug-in] "+format, args...)
-  }
-}
-
-// newNamespaceInformer creates a namespace informer that filters namespaces the plug-in is not interested in:
-// payload namespaces (except openshift-operators) and non openshift- prefixed namespaces
-// the informer also prunes the namespace objects to only keep basic type and object metadata and annotations
-func newNamespaceInformer(k8sClient operatorclient.ClientInterface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-  // create a namespace informer
-  pruneNamespace := func(namespace *v1.Namespace) {
-    namespace = &v1.Namespace{
-      TypeMeta: namespace.TypeMeta,
-      ObjectMeta: metav1.ObjectMeta{
-        Name:        namespace.GetName(),
-        Namespace:   namespace.GetNamespace(),
-        Annotations: namespace.GetAnnotations(),
-      },
-    }
-  }
-
-  return cache.NewSharedIndexInformer(
-    &cache.ListWatch{
-      ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-        list, err := k8sClient.KubernetesInterface().CoreV1().Namespaces().List(context.Background(), options)
-        if err != nil {
-          return list, err
-        }
-
-        // filter and prune namespaces
-        var filteredList []v1.Namespace
-        for i := range list.Items {
-          ns := list.Items[i]
-          if !(ignoreNamespace(ns.GetName())) {
-            pruneNamespace(&ns)
-            filteredList = append(filteredList, ns)
-          }
-        }
-        return &v1.NamespaceList{
-          Items: filteredList,
-        }, nil
-      },
-      WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-        nsWatch, err := k8sClient.KubernetesInterface().CoreV1().Namespaces().Watch(context.Background(), options)
-        if err != nil {
-          return nsWatch, err
-        }
-        return watch.Filter(nsWatch, func(e watch.Event) (watch.Event, bool) {
-          if ns, ok := e.Object.(*v1.Namespace); ok {
-            if !(ignoreNamespace(ns.GetName())) {
-              pruneNamespace(ns)
-              return e, true
-            }
-          }
-          return e, false
-        }), nil
-      },
-    },
-    &v1.Namespace{},
-    resyncPeriod,
-    cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
-  )
-}
-
-// newNonCopiedCsvInformerForNamespace creates a csv-based informer that filters out copied csvs and csv events coming
-// from namespaces the plug-in is not interested in: payload namespaces (except openshift-operators) and
-// non openshift- prefixed namespaces
-// the informer also prunes the csvs to only keep basic type and object metadata and annotations
-func newNonCopiedCsvInformerForNamespace(namespace string, externalClient versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-  // create a new csv informer and prune status to reduce memory footprint
-  pruneCSV := func(csv *v1alpha1.ClusterServiceVersion) {
-    csv = &v1alpha1.ClusterServiceVersion{
-      TypeMeta: csv.TypeMeta,
-      ObjectMeta: metav1.ObjectMeta{
-        Name:        csv.GetName(),
-        Namespace:   csv.GetNamespace(),
-        Annotations: csv.GetAnnotations(),
-      },
-    }
-  }
-
-  return cache.NewSharedIndexInformer(
-    &cache.ListWatch{
-      ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-        options.LabelSelector = noCopiedCsvSelector
-        list, err := externalClient.OperatorsV1alpha1().ClusterServiceVersions(namespace).List(context.Background(), options)
-        if err != nil {
-          return list, err
-        }
-
-        // filter and prune csvs
-        var filteredList []v1alpha1.ClusterServiceVersion
-        for i := range list.Items {
-          csv := list.Items[i]
-          if !(ignoreNamespace(csv.GetNamespace())) {
-            pruneCSV(&csv)
-            filteredList = append(filteredList, csv)
-          }
-        }
-        return &v1alpha1.ClusterServiceVersionList{
-          Items: filteredList,
-        }, nil
-      },
-      WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-        options.LabelSelector = noCopiedCsvSelector
-        csvWatch, err := externalClient.OperatorsV1alpha1().ClusterServiceVersions(namespace).Watch(context.Background(), options)
-        if err != nil {
-          return csvWatch, err
-        }
-        return watch.Filter(csvWatch, func(e watch.Event) (watch.Event, bool) {
-          if csv, ok := e.Object.(*v1alpha1.ClusterServiceVersion); ok {
-            if !(ignoreNamespace(csv.GetNamespace())) && !csv.IsCopied() {
-              pruneCSV(csv)
-              return e, true
-            }
-          }
-          return e, false
-        }), nil
-      },
-    },
-    &v1alpha1.ClusterServiceVersion{},
-    resyncPeriod,
-    cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
-  )
+	if p.logger != nil {
+		p.logger.Infof("[CSV NS Plug-in] "+format, args...)
+	}
 }
 
 func hasOpenshiftPrefix(namespaceName string) bool {
-  return strings.HasPrefix(namespaceName, openshiftPrefix)
+	return strings.HasPrefix(namespaceName, openshiftPrefix)
 }
 
 func ignoreNamespace(namespace string) bool {
-  // ignore non-openshift-* and payload openshift-* namespaces
-  return !hasOpenshiftPrefix(namespace) || IsNamespacePSALabelSyncExemptedInVendoredOCPVersion(namespace)
+	// ignore non-openshift-* and payload openshift-* namespaces
+	return !hasOpenshiftPrefix(namespace) || IsNamespacePSALabelSyncExemptedInVendoredOCPVersion(namespace)
 }
 
 func applyLabelSyncerLabel(ctx context.Context, kubeClient operatorclient.ClientInterface, namespace *v1.Namespace) error {
-  if _, ok := namespace.GetLabels()[NamespaceLabelSyncerLabelKey]; !ok {
-    nsCopy := namespace.DeepCopy()
-    if nsCopy.GetLabels() == nil {
-      nsCopy.SetLabels(map[string]string{})
-    }
-    nsCopy.GetLabels()[NamespaceLabelSyncerLabelKey] = "true"
-    if _, err := kubeClient.KubernetesInterface().CoreV1().Namespaces().Update(ctx, nsCopy, metav1.UpdateOptions{}); err != nil {
-      return err
-    }
-  }
-  return nil
+	if _, ok := namespace.GetLabels()[NamespaceLabelSyncerLabelKey]; !ok {
+		nsCopy := namespace.DeepCopy()
+		if nsCopy.GetLabels() == nil {
+			nsCopy.SetLabels(map[string]string{})
+		}
+		nsCopy.GetLabels()[NamespaceLabelSyncerLabelKey] = "true"
+		if _, err := kubeClient.KubernetesInterface().CoreV1().Namespaces().Update(ctx, nsCopy, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func hasLabelSyncerLabel(namespace *v1.Namespace) bool {
-  _, ok := namespace.GetLabels()[NamespaceLabelSyncerLabelKey]
-  return ok
+	_, ok := namespace.GetLabels()[NamespaceLabelSyncerLabelKey]
+	return ok
 }

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/plugins/operator_plugin.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/plugins/operator_plugin.go
@@ -5,9 +5,19 @@ import (
 	"time"
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	operatorsv1informers "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/informers/externalversions/operators/v1"
+	operatorsv1alpha1informers "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/informers/externalversions/operators/v1alpha1"
+	operatorsv2informers "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/informers/externalversions/operators/v2"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer"
 	"github.com/sirupsen/logrus"
+	extensionsv1informers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
+	appsv1informers "k8s.io/client-go/informers/apps/v1"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	rbacv1informers "k8s.io/client-go/informers/rbac/v1"
+	"k8s.io/client-go/metadata/metadatalister"
+	"k8s.io/client-go/tools/cache"
+	apiregistrationv1informers "k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1"
 )
 
 type PluginID string
@@ -17,6 +27,29 @@ type OperatorPlugInFactoryMap map[PluginID]OperatorPlugInFactoryFunc
 type HostOperator interface {
 	queueinformer.ObservableOperator
 	queueinformer.ExtensibleOperator
+	Informers() map[string]*Informers
+}
+
+// Informers exposes informer caches that the host operator has already started, for re-use by plugins.
+type Informers struct {
+	CSVInformer                operatorsv1alpha1informers.ClusterServiceVersionInformer
+	CopiedCSVInformer          cache.SharedIndexInformer
+	CopiedCSVLister            metadatalister.Lister
+	OperatorGroupInformer      operatorsv1informers.OperatorGroupInformer
+	OperatorConditionInformer  operatorsv2informers.OperatorConditionInformer
+	SubscriptionInformer       operatorsv1alpha1informers.SubscriptionInformer
+	DeploymentInformer         appsv1informers.DeploymentInformer
+	RoleInformer               rbacv1informers.RoleInformer
+	RoleBindingInformer        rbacv1informers.RoleBindingInformer
+	SecretInformer             corev1informers.SecretInformer
+	ServiceInformer            corev1informers.ServiceInformer
+	ServiceAccountInformer     corev1informers.ServiceAccountInformer
+	OLMConfigInformer          operatorsv1informers.OLMConfigInformer
+	ClusterRoleInformer        rbacv1informers.ClusterRoleInformer
+	ClusterRoleBindingInformer rbacv1informers.ClusterRoleBindingInformer
+	NamespaceInformer          corev1informers.NamespaceInformer
+	APIServiceInformer         apiregistrationv1informers.APIServiceInformer
+	CRDInformer                extensionsv1informers.CustomResourceDefinitionInformer
 }
 
 // OperatorConfig gives access to required configuration from the host operator

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer/queueinformer_operator.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer/queueinformer_operator.go
@@ -141,6 +141,12 @@ func (o *operator) RegisterInformer(informer cache.SharedIndexInformer) error {
 }
 
 func (o *operator) registerInformer(informer cache.SharedIndexInformer) {
+	// never double-register an informer
+	for i := range o.informers {
+		if o.informers[i] == informer {
+			return
+		}
+	}
 	o.informers = append(o.informers, informer)
 	o.addHasSynced(informer.HasSynced)
 }


### PR DESCRIPTION
scripts: add a Go-based bumper

This script sohuld be easier to maintain, automate, and have less
historical baggage as compared to the shell scripts. As an example, the
problem space of "cherry-pick some small number of commits on top of an
in-sync branch" is much smaller than the "cherry-pick some unknownn
number of commits on some dirty branch state with out-of-order commits
already present."

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>
