### PR TITLE
OCPBUGS-17791: opm: always serve pprof endpoints, improve server allocations (#1129)

### DIFF
--- a/staging/operator-registry/pkg/cache/json.go
+++ b/staging/operator-registry/pkg/cache/json.go
@@ -159,13 +159,16 @@ func (q *JSON) existingDigest() (string, error) {
 }
 
 func (q *JSON) computeDigest(fbcFsys fs.FS) (string, error) {
+	// We are not sensitive to the size of this buffer, we just need it to be shared.
+	// For simplicity, do the same as io.Copy() would.
+	buf := make([]byte, 32*1024)
 	computedHasher := fnv.New64a()
-	if err := fsToTar(computedHasher, fbcFsys); err != nil {
+	if err := fsToTar(computedHasher, fbcFsys, buf); err != nil {
 		return "", err
 	}
 
 	if cacheFS, err := fs.Sub(os.DirFS(q.baseDir), jsonDir); err == nil {
-		if err := fsToTar(computedHasher, cacheFS); err != nil && !errors.Is(err, os.ErrNotExist) {
+		if err := fsToTar(computedHasher, cacheFS, buf); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return "", fmt.Errorf("compute hash: %v", err)
 		}
 	}

--- a/staging/operator-registry/pkg/cache/tar.go
+++ b/staging/operator-registry/pkg/cache/tar.go
@@ -13,7 +13,12 @@ import (
 // This function unsets user and group information in the tar archive so that readers
 // of archives produced by this function do not need to account for differences in
 // permissions between source and destination filesystems.
-func fsToTar(w io.Writer, fsys fs.FS) error {
+func fsToTar(w io.Writer, fsys fs.FS, buf []byte) error {
+	if buf == nil || len(buf) == 0 {
+		// We are not sensitive to the size of this buffer, we just need it to be shared.
+		// For simplicity, do the same as io.Copy() would.
+		buf = make([]byte, 32*1024)
+	}
 	tw := tar.NewWriter(w)
 	if err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -52,7 +57,7 @@ func fsToTar(w io.Writer, fsys fs.FS) error {
 			return fmt.Errorf("open file %q: %v", path, err)
 		}
 		defer f.Close()
-		if _, err := io.Copy(tw, f); err != nil {
+		if _, err := io.CopyBuffer(tw, f, buf); err != nil {
 			return fmt.Errorf("write tar data for %q: %v", path, err)
 		}
 		return nil

--- a/staging/operator-registry/pkg/cache/tar_test.go
+++ b/staging/operator-registry/pkg/cache/tar_test.go
@@ -51,7 +51,7 @@ func Test_fsToTar(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			w := bytes.Buffer{}
-			err := fsToTar(&w, tc.fsys())
+			err := fsToTar(&w, tc.fsys(), nil)
 			tc.expect(t, w.Bytes(), err)
 		})
 	}

--- a/vendor/github.com/operator-framework/operator-registry/pkg/cache/json.go
+++ b/vendor/github.com/operator-framework/operator-registry/pkg/cache/json.go
@@ -159,13 +159,16 @@ func (q *JSON) existingDigest() (string, error) {
 }
 
 func (q *JSON) computeDigest(fbcFsys fs.FS) (string, error) {
+	// We are not sensitive to the size of this buffer, we just need it to be shared.
+	// For simplicity, do the same as io.Copy() would.
+	buf := make([]byte, 32*1024)
 	computedHasher := fnv.New64a()
-	if err := fsToTar(computedHasher, fbcFsys); err != nil {
+	if err := fsToTar(computedHasher, fbcFsys, buf); err != nil {
 		return "", err
 	}
 
 	if cacheFS, err := fs.Sub(os.DirFS(q.baseDir), jsonDir); err == nil {
-		if err := fsToTar(computedHasher, cacheFS); err != nil && !errors.Is(err, os.ErrNotExist) {
+		if err := fsToTar(computedHasher, cacheFS, buf); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return "", fmt.Errorf("compute hash: %v", err)
 		}
 	}

--- a/vendor/github.com/operator-framework/operator-registry/pkg/cache/tar.go
+++ b/vendor/github.com/operator-framework/operator-registry/pkg/cache/tar.go
@@ -13,7 +13,12 @@ import (
 // This function unsets user and group information in the tar archive so that readers
 // of archives produced by this function do not need to account for differences in
 // permissions between source and destination filesystems.
-func fsToTar(w io.Writer, fsys fs.FS) error {
+func fsToTar(w io.Writer, fsys fs.FS, buf []byte) error {
+	if buf == nil || len(buf) == 0 {
+		// We are not sensitive to the size of this buffer, we just need it to be shared.
+		// For simplicity, do the same as io.Copy() would.
+		buf = make([]byte, 32*1024)
+	}
 	tw := tar.NewWriter(w)
 	if err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -52,7 +57,7 @@ func fsToTar(w io.Writer, fsys fs.FS) error {
 			return fmt.Errorf("open file %q: %v", path, err)
 		}
 		defer f.Close()
-		if _, err := io.Copy(tw, f); err != nil {
+		if _, err := io.CopyBuffer(tw, f, buf); err != nil {
 			return fmt.Errorf("write tar data for %q: %v", path, err)
 		}
 		return nil


### PR DESCRIPTION
* pkg/cache: use a shared buffer to limit allocations

Previously, new buffers were allocated on each file we read in, which was unnecessary and wasteful.



* cmd/opm: serve pprof endpoints by default

There is no substantial runtime cost to serving pprof endpoints, and when things hit the fan and we need to investigate performance in situ, there is no time to restart pods and change flags. Capturing profiles remains opt-in, since those are costly.



---------


Upstream-repository: operator-registry
Upstream-commit: 68e13df96590977370ffcd1a8e9ff76e0f2a03f2