### PR TITLE
OCPBUGS-18305,RHIBMCS-151: Copied csv listing backport

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
@@ -204,27 +204,31 @@ func NewOperator(ctx context.Context, kubeconfigPath string, clock utilclock.Clo
 	// Fields are pruned from local copies of the objects managed
 	// by this informer in order to reduce cached size.
 	prunedCSVInformer := cache.NewSharedIndexInformer(
-		pruning.NewListerWatcher(op.client, metav1.NamespaceAll, func(*metav1.ListOptions) {}, pruning.PrunerFunc(func(csv *v1alpha1.ClusterServiceVersion) {
-			*csv = v1alpha1.ClusterServiceVersion{
-				TypeMeta: csv.TypeMeta,
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        csv.Name,
-					Namespace:   csv.Namespace,
-					Labels:      csv.Labels,
-					Annotations: csv.Annotations,
-				},
-				Spec: v1alpha1.ClusterServiceVersionSpec{
-					CustomResourceDefinitions: csv.Spec.CustomResourceDefinitions,
-					APIServiceDefinitions:     csv.Spec.APIServiceDefinitions,
-					Replaces:                  csv.Spec.Replaces,
-					Version:                   csv.Spec.Version,
-				},
-				Status: v1alpha1.ClusterServiceVersionStatus{
-					Phase:  csv.Status.Phase,
-					Reason: csv.Status.Reason,
-				},
-			}
-		})),
+		pruning.NewListerWatcher(op.client, metav1.NamespaceAll,
+			func(options *metav1.ListOptions) {
+				options.LabelSelector = fmt.Sprintf("!%s", v1alpha1.CopiedLabelKey)
+			},
+			pruning.PrunerFunc(func(csv *v1alpha1.ClusterServiceVersion) {
+				*csv = v1alpha1.ClusterServiceVersion{
+					TypeMeta: csv.TypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        csv.Name,
+						Namespace:   csv.Namespace,
+						Labels:      csv.Labels,
+						Annotations: csv.Annotations,
+					},
+					Spec: v1alpha1.ClusterServiceVersionSpec{
+						CustomResourceDefinitions: csv.Spec.CustomResourceDefinitions,
+						APIServiceDefinitions:     csv.Spec.APIServiceDefinitions,
+						Replaces:                  csv.Spec.Replaces,
+						Version:                   csv.Spec.Version,
+					},
+					Status: v1alpha1.ClusterServiceVersionStatus{
+						Phase:  csv.Status.Phase,
+						Reason: csv.Status.Reason,
+					},
+				}
+			})),
 		&v1alpha1.ClusterServiceVersion{},
 		resyncPeriod(),
 		cache.Indexers{

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
@@ -204,27 +204,31 @@ func NewOperator(ctx context.Context, kubeconfigPath string, clock utilclock.Clo
 	// Fields are pruned from local copies of the objects managed
 	// by this informer in order to reduce cached size.
 	prunedCSVInformer := cache.NewSharedIndexInformer(
-		pruning.NewListerWatcher(op.client, metav1.NamespaceAll, func(*metav1.ListOptions) {}, pruning.PrunerFunc(func(csv *v1alpha1.ClusterServiceVersion) {
-			*csv = v1alpha1.ClusterServiceVersion{
-				TypeMeta: csv.TypeMeta,
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        csv.Name,
-					Namespace:   csv.Namespace,
-					Labels:      csv.Labels,
-					Annotations: csv.Annotations,
-				},
-				Spec: v1alpha1.ClusterServiceVersionSpec{
-					CustomResourceDefinitions: csv.Spec.CustomResourceDefinitions,
-					APIServiceDefinitions:     csv.Spec.APIServiceDefinitions,
-					Replaces:                  csv.Spec.Replaces,
-					Version:                   csv.Spec.Version,
-				},
-				Status: v1alpha1.ClusterServiceVersionStatus{
-					Phase:  csv.Status.Phase,
-					Reason: csv.Status.Reason,
-				},
-			}
-		})),
+		pruning.NewListerWatcher(op.client, metav1.NamespaceAll,
+			func(options *metav1.ListOptions) {
+				options.LabelSelector = fmt.Sprintf("!%s", v1alpha1.CopiedLabelKey)
+			},
+			pruning.PrunerFunc(func(csv *v1alpha1.ClusterServiceVersion) {
+				*csv = v1alpha1.ClusterServiceVersion{
+					TypeMeta: csv.TypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        csv.Name,
+						Namespace:   csv.Namespace,
+						Labels:      csv.Labels,
+						Annotations: csv.Annotations,
+					},
+					Spec: v1alpha1.ClusterServiceVersionSpec{
+						CustomResourceDefinitions: csv.Spec.CustomResourceDefinitions,
+						APIServiceDefinitions:     csv.Spec.APIServiceDefinitions,
+						Replaces:                  csv.Spec.Replaces,
+						Version:                   csv.Spec.Version,
+					},
+					Status: v1alpha1.ClusterServiceVersionStatus{
+						Phase:  csv.Status.Phase,
+						Reason: csv.Status.Reason,
+					},
+				}
+			})),
 		&v1alpha1.ClusterServiceVersion{},
 		resyncPeriod(),
 		cache.Indexers{


### PR DESCRIPTION
This is a selective backport of #532, which contains an optimization that appears to have fixed or reduced the frequency of stale CSVs in the catalog-operator cache. I have removed the changes to the olm operator as they require an `api` version bump which brings in new features.