### PR TITLE
OCPBUGS-17950: Increase packageserver wakeup interval to 24h

### DIFF
--- a/pkg/manifests/csv.yaml
+++ b/pkg/manifests/csv.yaml
@@ -121,6 +121,7 @@ spec:
                       - "5443"
                       - --global-namespace
                       - openshift-marketplace
+                      - --interval 24h
                     image: quay.io/operator-framework/olm@sha256:de396b540b82219812061d0d753440d5655250c621c753ed1dc67d6154741607
                     imagePullPolicy: IfNotPresent
                     ports:

--- a/values.yaml
+++ b/values.yaml
@@ -82,6 +82,7 @@ package:
     pullPolicy: IfNotPresent
   service:
     internalPort: 5443
+  commandArgs: "--interval 24h"
   nodeSelector:
     kubernetes.io/os: linux
     node-role.kubernetes.io/master: ""


### PR DESCRIPTION
The packageserver wakeup interval is used to update its package manifest from CatSrcs. However, this does not need to happen periodically (especially 5m) as the CatSrc pods will restart when a change occurs to data it is caching, and this will be acted upon by packageserver.