### PR TITLE
 OCPBUGS-17950: Make packageserver wakeup interval configurable

### DIFF
--- a/cmd/package-server-manager/main.go
+++ b/cmd/package-server-manager/main.go
@@ -29,6 +29,7 @@ const (
 	defaultMetricsPort          = "0"
 	defaultHealthCheckPort      = ":8080"
 	defaultPprofPort            = ":6060"
+	defaultInterval             = "5m"
 	leaderElectionConfigmapName = "packageserver-controller-lock"
 )
 
@@ -59,6 +60,10 @@ func run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	pprofAddr, err := cmd.Flags().GetString("pprof")
+	if err != nil {
+		return err
+	}
+	interval, err := cmd.Flags().GetString("interval")
 	if err != nil {
 		return err
 	}
@@ -99,6 +104,7 @@ func run(cmd *cobra.Command, args []string) error {
 		Name:      name,
 		Namespace: namespace,
 		Image:     os.Getenv("PACKAGESERVER_IMAGE"),
+		Interval:  interval,
 		Client:    mgr.GetClient(),
 		Log:       ctrl.Log.WithName("controllers").WithName(name),
 		Scheme:    mgr.GetScheme(),

--- a/cmd/package-server-manager/start.go
+++ b/cmd/package-server-manager/start.go
@@ -16,6 +16,7 @@ func newStartCmd() *cobra.Command {
 	cmd.Flags().String("namespace", defaultNamespace, "configures the metadata.namespace that contains the packageserver csv resource")
 	cmd.Flags().String("health", defaultHealthCheckPort, "configures the health check port that the kubelet is configured to probe")
 	cmd.Flags().String("pprof", defaultPprofPort, "configures the pprof port that the process exposes")
+	cmd.Flags().String("interval", defaultInterval, "configures the wakeup interval for the packageserver csc resource")
 	cmd.Flags().Bool("disable-leader-election", false, "configures whether leader election will be disabled")
 
 	return cmd

--- a/manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
+++ b/manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
@@ -41,6 +41,8 @@ spec:
             - $(PACKAGESERVER_NAME)
             - --namespace
             - $(PACKAGESERVER_NAMESPACE)
+            - --interval
+            - $(PACKAGESERVER_INTERVAL)
           image: quay.io/operator-framework/olm@sha256:de396b540b82219812061d0d753440d5655250c621c753ed1dc67d6154741607
           imagePullPolicy: IfNotPresent
           env:
@@ -52,6 +54,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: PACKAGESERVER_INTERVAL
+              value: 5m
             - name: RELEASE_VERSION
               value: "0.0.1-snapshot"
           resources:

--- a/manifests/0000_50_olm_06-psm-operator.deployment.yaml
+++ b/manifests/0000_50_olm_06-psm-operator.deployment.yaml
@@ -41,6 +41,8 @@ spec:
             - $(PACKAGESERVER_NAME)
             - --namespace
             - $(PACKAGESERVER_NAMESPACE)
+            - --interval
+            - $(PACKAGESERVER_INTERVAL)
           image: quay.io/operator-framework/olm@sha256:de396b540b82219812061d0d753440d5655250c621c753ed1dc67d6154741607
           imagePullPolicy: IfNotPresent
           env:
@@ -52,6 +54,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: PACKAGESERVER_INTERVAL
+              value: 5m
             - name: RELEASE_VERSION
               value: "0.0.1-snapshot"
           resources:

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -31,6 +31,25 @@ func NewPackageServerCSV(opts ...CSVOption) (*olmv1alpha1.ClusterServiceVersion,
 	return &csv, nil
 }
 
+func WithRunFlags(flags []string) CSVOption {
+	return func(csv *olmv1alpha1.ClusterServiceVersion) {
+		for i, deployment := range csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs {
+			for j, container := range deployment.Spec.Template.Spec.Containers {
+				// TODO: Should be fine to hardcode this for now, but likely want
+				// to pass this as a parameter?
+				if container.Name == "packageserver" {
+					for _, flag := range flags {
+						container.Command = append(container.Command, flag)
+					}
+					csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[i].Spec.Template.Spec.Containers[j].Command = container.Command
+					break
+				}
+			}
+		}
+
+	}
+}
+
 func WithName(name string) CSVOption {
 	return func(csv *olmv1alpha1.ClusterServiceVersion) {
 		csv.Name = name

--- a/pkg/package-server-manager/config.go
+++ b/pkg/package-server-manager/config.go
@@ -66,11 +66,12 @@ func getTopologyModeFromInfra(infra *configv1.Infrastructure) bool {
 // resource matches that of the codified defaults and high availability configurations, where
 // codified defaults are defined by the csv returned by the manifests.NewPackageServerCSV
 // function.
-func ensureCSV(log logr.Logger, image string, csv *olmv1alpha1.ClusterServiceVersion, highlyAvailableMode bool) (bool, error) {
+func ensureCSV(log logr.Logger, image string, interval string, csv *olmv1alpha1.ClusterServiceVersion, highlyAvailableMode bool) (bool, error) {
 	expectedCSV, err := manifests.NewPackageServerCSV(
 		manifests.WithName(csv.Name),
 		manifests.WithNamespace(csv.Namespace),
 		manifests.WithImage(image),
+		manifests.WithRunFlags([]string{"--interval", interval}),
 	)
 	if err != nil {
 		return false, err

--- a/pkg/package-server-manager/controller_test.go
+++ b/pkg/package-server-manager/controller_test.go
@@ -22,6 +22,7 @@ var (
 	name      = "packageserver"
 	namespace = "openshift-operator-lifecycle-manager"
 	image     = getImageFromManifest()
+	interval  = "5m"
 )
 
 func TestHighlyAvailableFromInstructure(t *testing.T) {
@@ -111,6 +112,7 @@ func newTestCSV(
 	csv, err := manifests.NewPackageServerCSV(
 		manifests.WithName(name),
 		manifests.WithNamespace(namespace),
+		manifests.WithRunFlags([]string{"--interval", interval}),
 	)
 	if err != nil {
 		return nil
@@ -133,6 +135,7 @@ func getImageFromManifest() string {
 	csv, err := manifests.NewPackageServerCSV(
 		manifests.WithName(name),
 		manifests.WithNamespace(namespace),
+		manifests.WithRunFlags([]string{"--interval", interval}),
 	)
 	if err != nil {
 		return ""
@@ -258,7 +261,7 @@ func TestEnsureCSV(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
-			gotBool, gotErr := ensureCSV(logger, image, tc.inputCSV, tc.highlyAvailable)
+			gotBool, gotErr := ensureCSV(logger, image, interval, tc.inputCSV, tc.highlyAvailable)
 			require.EqualValues(t, tc.want.expectedBool, gotBool)
 			require.EqualValues(t, tc.want.expectedErr, gotErr)
 			require.EqualValues(t, tc.inputCSV.Spec, tc.expectedCSV.Spec)

--- a/scripts/generate_crds_manifests.sh
+++ b/scripts/generate_crds_manifests.sh
@@ -151,6 +151,8 @@ spec:
             - \$(PACKAGESERVER_NAME)
             - --namespace
             - \$(PACKAGESERVER_NAMESPACE)
+            - --interval
+            - \$(PACKAGESERVER_INTERVAL)
           image: quay.io/operator-framework/olm@sha256:de396b540b82219812061d0d753440d5655250c621c753ed1dc67d6154741607
           imagePullPolicy: IfNotPresent
           env:
@@ -162,6 +164,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: PACKAGESERVER_INTERVAL
+              value: 5m
             - name: RELEASE_VERSION
               value: "0.0.1-snapshot"
           resources:


### PR DESCRIPTION
The packageserver wakeup interval is used to update its package manifest from CatSrcs. However, this does not need to happen periodically (especially 5m) as the CatSrc pods will restart when a change occurs to data it is caching, and this will be acted upon by packageserver.

This allows configuration of this interval via the package-server-manager deployment (which then gets passed onto the packageserver deployment).