### PR TITLE
OCPBUGS-17950: Use configmap to specify interval

### DIFF
--- a/cmd/package-server-manager/main.go
+++ b/cmd/package-server-manager/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -66,6 +67,14 @@ func run(cmd *cobra.Command, args []string) error {
 	interval, err := cmd.Flags().GetString("interval")
 	if err != nil {
 		return err
+	}
+	// Override with optional envornment
+	i := os.Getenv("PACKAGESERVER_INTERVAL")
+	if i != "" {
+		_, err = time.ParseDuration(i)
+		if err == nil {
+			interval = i
+		}
 	}
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))

--- a/manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
+++ b/manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
@@ -41,8 +41,6 @@ spec:
             - $(PACKAGESERVER_NAME)
             - --namespace
             - $(PACKAGESERVER_NAMESPACE)
-            - --interval
-            - $(PACKAGESERVER_INTERVAL)
           image: quay.io/operator-framework/olm@sha256:de396b540b82219812061d0d753440d5655250c621c753ed1dc67d6154741607
           imagePullPolicy: IfNotPresent
           env:
@@ -55,7 +53,11 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: PACKAGESERVER_INTERVAL
-              value: 5m
+              valueFrom:
+                configMapKeyRef:
+                  name: packageserver-env
+                  key: PACKAGESERVER_INTERVAL
+                  optional: true
             - name: RELEASE_VERSION
               value: "0.0.1-snapshot"
           resources:

--- a/manifests/0000_50_olm_06-psm-operator.deployment.yaml
+++ b/manifests/0000_50_olm_06-psm-operator.deployment.yaml
@@ -41,8 +41,6 @@ spec:
             - $(PACKAGESERVER_NAME)
             - --namespace
             - $(PACKAGESERVER_NAMESPACE)
-            - --interval
-            - $(PACKAGESERVER_INTERVAL)
           image: quay.io/operator-framework/olm@sha256:de396b540b82219812061d0d753440d5655250c621c753ed1dc67d6154741607
           imagePullPolicy: IfNotPresent
           env:
@@ -55,7 +53,11 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: PACKAGESERVER_INTERVAL
-              value: 5m
+              valueFrom:
+                configMapKeyRef:
+                  name: packageserver-env
+                  key: PACKAGESERVER_INTERVAL
+                  optional: true
             - name: RELEASE_VERSION
               value: "0.0.1-snapshot"
           resources:

--- a/scripts/generate_crds_manifests.sh
+++ b/scripts/generate_crds_manifests.sh
@@ -151,8 +151,6 @@ spec:
             - \$(PACKAGESERVER_NAME)
             - --namespace
             - \$(PACKAGESERVER_NAMESPACE)
-            - --interval
-            - \$(PACKAGESERVER_INTERVAL)
           image: quay.io/operator-framework/olm@sha256:de396b540b82219812061d0d753440d5655250c621c753ed1dc67d6154741607
           imagePullPolicy: IfNotPresent
           env:
@@ -165,7 +163,11 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: PACKAGESERVER_INTERVAL
-              value: 5m
+              valueFrom:
+                configMapKeyRef:
+                  name: packageserver-env
+                  key: PACKAGESERVER_INTERVAL
+                  optional: true
             - name: RELEASE_VERSION
               value: "0.0.1-snapshot"
           resources:


### PR DESCRIPTION
Use a configmap `packageserver-env` with key `PACKAGESERVER_INTERVAL`
to specify a value for the package server interval (default: 5m)

Avoids having to disable (part of CVO) to update the interval.
e.g.
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: packageserver-env
  namespace: openshift-operator-lifecycle-manager
data:
  PACKAGESERVER_INTERVAL: 20m
```