### PR TITLE
Sync script: handle multi commit merges

### DIFF
--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -29,7 +29,7 @@ fetch_remote() {
 
 new_candidate_branch() {
     echo "Creating a sync branch if it doesn't already exist"
-    git checkout -b "$SYNC_BRANCH_NAME" upstream/master 2>/dev/null || git checkout "$SYNC_BRANCH_NAME"
+    git checkout -b "$SYNC_BRANCH_NAME" master 2>/dev/null || git checkout "$SYNC_BRANCH_NAME"
 }
 
 candidates() {
@@ -50,13 +50,13 @@ pop() {
 }
 
 check_local_branch_commit_diff() {
-    commits_ahead=$(git rev-list upstream/master..HEAD | wc -l)
+    commits_ahead=$(git rev-list master..HEAD | wc -l)
 
     if [[ "$commits_ahead" -gt 1 ]]; then
         # TODO: automatically open a new pull request here.
-        echo "The local sync branch is $commits_ahead commits ahead of the upstream/master branch"
+        echo "The local sync branch is $commits_ahead commits ahead of the master branch"
     else
-        echo "No sync PR is needed as the upstream/master branch is up-to-date"
+        echo "No sync PR is needed as the master branch is up-to-date"
     fi
 }
 

--- a/scripts/sync_get_candidates.sh
+++ b/scripts/sync_get_candidates.sh
@@ -49,7 +49,8 @@ cherrypick_set="${remote}.cherrypick"
 : > "${cherrypick_set}" # clear existing file
 for rc in "${remote_commits[@]}"; do
     if [[ -z $(git log -n 1 --no-merges --grep "${rc}" HEAD) && -z $(grep "${rc}" "${remote}.blacklist") ]]; then
-        git show -s --format="%cI ${remote} %H" "${rc}" >> "${cherrypick_set}"
+        
+        git show -s --format="%cI $(printf "%03d" ${picked}) ${remote} %H" "${rc}" >> "${cherrypick_set}"
         (( ++picked ))
     fi
 done

--- a/scripts/sync_pop_candidate.sh
+++ b/scripts/sync_pop_candidate.sh
@@ -57,9 +57,9 @@ function pop() {
         exit
     fi
     readarray -t rcs < <(echo "$rc" | tr " " "\n")
-    remote="${rcs[1]}"
+    remote="${rcs[2]}"
     subtree_dir="staging/${remote}"
-    rc="${rcs[2]}"
+    rc="${rcs[3]}"
     printf 'popping: %s\n' "${rc}"
 
     # Cherrypick the commit


### PR DESCRIPTION
Fix the sync script to handle commits in a single merge.
The sorting doesn't work as the commit time is all the same, and the next sortable field is the headline.
The commit time is the same, but the authorship time for each commit might be different or out of order.
Add an ordinal to the list of commits from each branch. This is used to sort commits (in original order) with the same commit time.

This is for the bash-based sync scripts.