### PR TITLE
Remove 5m package-server-manager default

### DIFF
--- a/cmd/package-server-manager/main.go
+++ b/cmd/package-server-manager/main.go
@@ -29,7 +29,7 @@ const (
 	defaultMetricsPort          = "0"
 	defaultHealthCheckPort      = ":8080"
 	defaultPprofPort            = ":6060"
-	defaultInterval             = "5m"
+	defaultInterval             = ""
 	leaderElectionConfigmapName = "packageserver-controller-lock"
 )
 

--- a/manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
+++ b/manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
@@ -67,8 +67,6 @@ spec:
             - $(PACKAGESERVER_NAME)
             - --namespace
             - $(PACKAGESERVER_NAMESPACE)
-            - --interval
-            - $(PACKAGESERVER_INTERVAL)
             - "--metrics=:9090"
           image: quay.io/operator-framework/olm@sha256:de396b540b82219812061d0d753440d5655250c621c753ed1dc67d6154741607
           imagePullPolicy: IfNotPresent
@@ -81,8 +79,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: PACKAGESERVER_INTERVAL
-              value: 5m
             - name: RELEASE_VERSION
               value: "0.0.1-snapshot"
             - name: GOMEMLIMIT

--- a/manifests/0000_50_olm_06-psm-operator.deployment.yaml
+++ b/manifests/0000_50_olm_06-psm-operator.deployment.yaml
@@ -67,8 +67,6 @@ spec:
             - $(PACKAGESERVER_NAME)
             - --namespace
             - $(PACKAGESERVER_NAMESPACE)
-            - --interval
-            - $(PACKAGESERVER_INTERVAL)
             - "--metrics=:9090"
           image: quay.io/operator-framework/olm@sha256:de396b540b82219812061d0d753440d5655250c621c753ed1dc67d6154741607
           imagePullPolicy: IfNotPresent
@@ -81,8 +79,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: PACKAGESERVER_INTERVAL
-              value: 5m
             - name: RELEASE_VERSION
               value: "0.0.1-snapshot"
             - name: GOMEMLIMIT

--- a/pkg/package-server-manager/config.go
+++ b/pkg/package-server-manager/config.go
@@ -67,11 +67,16 @@ func getTopologyModeFromInfra(infra *configv1.Infrastructure) bool {
 // codified defaults are defined by the csv returned by the manifests.NewPackageServerCSV
 // function.
 func ensureCSV(log logr.Logger, image string, interval string, csv *olmv1alpha1.ClusterServiceVersion, highlyAvailableMode bool) (bool, error) {
+
+	flags := []string{}
+	if interval != "" {
+		flags = append(flags, "--interval", interval)
+	}
 	expectedCSV, err := manifests.NewPackageServerCSV(
 		manifests.WithName(csv.Name),
 		manifests.WithNamespace(csv.Namespace),
 		manifests.WithImage(image),
-		manifests.WithRunFlags([]string{"--interval", interval}),
+		manifests.WithRunFlags(flags),
 	)
 	if err != nil {
 		return false, err

--- a/pkg/package-server-manager/controller.go
+++ b/pkg/package-server-manager/controller.go
@@ -74,11 +74,16 @@ func (r *PackageServerCSVReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	highAvailabilityMode := getTopologyModeFromInfra(&infra)
 	log.Info("currently topology mode", "highly available", highAvailabilityMode)
 
+	flags := []string{}
+	if r.Interval != "" {
+		flags = append(flags, "--interval", r.Interval)
+	}
+
 	required, err := manifests.NewPackageServerCSV(
 		manifests.WithName(r.Name),
 		manifests.WithNamespace(r.Namespace),
 		manifests.WithImage(r.Image),
-		manifests.WithRunFlags([]string{"--interval", r.Interval}),
+		manifests.WithRunFlags(flags),
 	)
 	if err != nil {
 		log.Error(err, "failed to serialize a new packageserver csv from the base YAML manifest")

--- a/scripts/generate_crds_manifests.sh
+++ b/scripts/generate_crds_manifests.sh
@@ -181,8 +181,6 @@ spec:
             - \$(PACKAGESERVER_NAME)
             - --namespace
             - \$(PACKAGESERVER_NAMESPACE)
-            - --interval
-            - \$(PACKAGESERVER_INTERVAL)
             - "--metrics=:9090"
           image: quay.io/operator-framework/olm@sha256:de396b540b82219812061d0d753440d5655250c621c753ed1dc67d6154741607
           imagePullPolicy: IfNotPresent
@@ -195,8 +193,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: PACKAGESERVER_INTERVAL
-              value: 5m
             - name: RELEASE_VERSION
               value: "0.0.1-snapshot"
             - name: GOMEMLIMIT


### PR DESCRIPTION
Update the package-server-manager to no longer specify a `5m` default for the packageserver, which will now default to 12h.

This is a follow-on to OCPBUGS-17950.