### PR TITLE
OCPBUGS-17408: Do not derive installplan.spec.clusterServiceNames from bundle IDs

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
@@ -1536,9 +1536,7 @@ func (o *Operator) createInstallPlan(namespace string, gen int, subs []*v1alpha1
 		}
 		catalogSourceMap[s.Resource.CatalogSource] = struct{}{}
 	}
-	for _, b := range bundleLookups {
-		csvNames = append(csvNames, b.Identifier)
-	}
+
 	catalogSources := []string{}
 	for s := range catalogSourceMap {
 		catalogSources = append(catalogSources, s)

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
@@ -1536,9 +1536,7 @@ func (o *Operator) createInstallPlan(namespace string, gen int, subs []*v1alpha1
 		}
 		catalogSourceMap[s.Resource.CatalogSource] = struct{}{}
 	}
-	for _, b := range bundleLookups {
-		csvNames = append(csvNames, b.Identifier)
-	}
+
 	catalogSources := []string{}
 	for s := range catalogSourceMap {
 		catalogSources = append(catalogSources, s)


### PR DESCRIPTION
Problem: Historically, when creating an installPlan it's spec.ClusterServiceVersionNames was derived from two sources:
1. The names of CSVs found in "steps" of the installPlan's status.plan
2. The metadata associated with the bundle image

These sources couldn't result in duplicate entries as the unpacking job would finish after the installPlan was created and the steps weren't populated until the unpacking job finished.

OLM was recently updated to complete the unpacking jobs prior to creating the installPlan, which means that the two sources can cause duplicate entries to appear in the array.

Solution: Now that OLM creates the installPlan after successfully unpacking the bundles, we no longer need to derive the names of the CSV from the bundle metadata.


Upstream-repository: operator-lifecycle-manager
Upstream-commit: 647fe257c