### PR TITLE
OCPBUGS-23508: [release-4.14] Use generated namespaces in e2e tests

### DIFF
--- a/staging/operator-lifecycle-manager/test/e2e/catalog_exclusion_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/catalog_exclusion_test.go
@@ -22,7 +22,7 @@ const magicCatalogDir = "magiccatalog"
 
 var _ = Describe("Global Catalog Exclusion", func() {
 	var (
-		testNamespace       corev1.Namespace
+		generatedNamespace  corev1.Namespace
 		determinedE2eClient *util.DeterminedE2EClient
 		operatorGroup       operatorsv1.OperatorGroup
 		localCatalog        *MagicCatalog
@@ -43,7 +43,7 @@ var _ = Describe("Global Catalog Exclusion", func() {
 				TargetNamespaces: []string{e2eTestNamespace},
 			},
 		}
-		testNamespace = SetupGeneratedTestNamespaceWithOperatorGroup(e2eTestNamespace, operatorGroup)
+		generatedNamespace = SetupGeneratedTestNamespaceWithOperatorGroup(e2eTestNamespace, operatorGroup)
 
 		By("creating a broken catalog in the global namespace")
 		globalCatalog := &v1alpha1.CatalogSource{
@@ -67,7 +67,7 @@ var _ = Describe("Global Catalog Exclusion", func() {
 		var err error = nil
 
 		fbcPath := filepath.Join(testdataDir, magicCatalogDir, "fbc_initial.yaml")
-		localCatalog, err = NewMagicCatalogFromFile(determinedE2eClient, testNamespace.GetName(), localCatalogName, fbcPath)
+		localCatalog, err = NewMagicCatalogFromFile(determinedE2eClient, generatedNamespace.GetName(), localCatalogName, fbcPath)
 		Expect(err).To(Succeed())
 
 		// deploy catalog blocks until the catalog has reached a ready state or fails
@@ -80,7 +80,7 @@ var _ = Describe("Global Catalog Exclusion", func() {
 	})
 
 	AfterEach(func() {
-		TeardownNamespace(testNamespace.GetName())
+		TeardownNamespace(generatedNamespace.GetName())
 	})
 
 	When("a subscription referring to the local catalog is created", func() {
@@ -89,7 +89,7 @@ var _ = Describe("Global Catalog Exclusion", func() {
 		BeforeEach(func() {
 			subscription = &v1alpha1.Subscription{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: testNamespace.GetName(),
+					Namespace: generatedNamespace.GetName(),
 					Name:      genName("local-subscription-"),
 				},
 				Spec: &v1alpha1.SubscriptionSpec{

--- a/staging/operator-lifecycle-manager/test/e2e/crd_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/crd_e2e_test.go
@@ -23,19 +23,19 @@ import (
 
 var _ = Describe("CRD Versions", func() {
 	var (
-		ns  corev1.Namespace
-		c   operatorclient.ClientInterface
-		crc versioned.Interface
+		generatedNamespace corev1.Namespace
+		c                  operatorclient.ClientInterface
+		crc                versioned.Interface
 	)
 
 	BeforeEach(func() {
 		c = ctx.Ctx().KubeClient()
 		crc = ctx.Ctx().OperatorClient()
-		ns = SetupGeneratedTestNamespace(genName("crd-e2e-"))
+		generatedNamespace = SetupGeneratedTestNamespace(genName("crd-e2e-"))
 	})
 
 	AfterEach(func() {
-		TeardownNamespace(ns.GetName())
+		TeardownNamespace(generatedNamespace.GetName())
 	})
 
 	// issue: https://github.com/operator-framework/operator-lifecycle-manager/issues/2640
@@ -71,7 +71,7 @@ var _ = Describe("CRD Versions", func() {
 			},
 		}
 
-		mainCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), nil, nil, nil)
+		mainCSV := newCSV(mainPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), nil, nil, nil)
 		mainCatalogName := genName("mock-ocs-main-update2-")
 		mainManifests := []registry.PackageManifest{
 			{
@@ -84,22 +84,22 @@ var _ = Describe("CRD Versions", func() {
 		}
 
 		// Create the catalog sources
-		_, cleanupMainCatalogSource := createV1CRDInternalCatalogSource(GinkgoT(), c, crc, mainCatalogName, ns.GetName(), mainManifests, []apiextensionsv1.CustomResourceDefinition{v1crd}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
+		_, cleanupMainCatalogSource := createV1CRDInternalCatalogSource(GinkgoT(), c, crc, mainCatalogName, generatedNamespace.GetName(), mainManifests, []apiextensionsv1.CustomResourceDefinition{v1crd}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
 		defer cleanupMainCatalogSource()
 		defer func() {
-			_ = crc.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Delete(context.TODO(), mainCSV.GetName(), metav1.DeleteOptions{})
+			_ = crc.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Delete(context.TODO(), mainCSV.GetName(), metav1.DeleteOptions{})
 			_ = c.ApiextensionsInterface().ApiextensionsV1().CustomResourceDefinitions().Delete(context.TODO(), v1crd.GetName(), metav1.DeleteOptions{})
 		}()
 
 		// Attempt to get the catalog source before creating install plan
-		_, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, ns.GetName(), catalogSourceRegistryPodSynced)
+		_, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 		Expect(err).ToNot(HaveOccurred())
 
 		subscriptionName := genName("sub-nginx-update2-")
-		subscriptionCleanup := createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+		subscriptionCleanup := createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 		defer subscriptionCleanup()
 
-		subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
+		subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(subscription).ToNot(Equal(nil))
 		Expect(subscription.Status.InstallPlanRef).ToNot(Equal(nil))
@@ -108,7 +108,7 @@ var _ = Describe("CRD Versions", func() {
 		installPlanName := subscription.Status.InstallPlanRef.Name
 
 		// Wait for InstallPlan to be status: Complete before checking resource presence
-		fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
+		fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
 		Expect(err).ToNot(HaveOccurred())
 		GinkgoT().Logf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase)
 		Expect(fetchedInstallPlan.Status.Phase).To(Equal(operatorsv1alpha1.InstallPlanPhaseComplete))
@@ -206,8 +206,8 @@ var _ = Describe("CRD Versions", func() {
 			},
 		}
 
-		oldCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{oldCRD}, nil, nil)
-		newCSV := newCSV(mainPackageAlpha, ns.GetName(), mainPackageStable, semver.MustParse("0.1.1"), []apiextensions.CustomResourceDefinition{newCRD}, nil, nil)
+		oldCSV := newCSV(mainPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{oldCRD}, nil, nil)
+		newCSV := newCSV(mainPackageAlpha, generatedNamespace.GetName(), mainPackageStable, semver.MustParse("0.1.1"), []apiextensions.CustomResourceDefinition{newCRD}, nil, nil)
 		mainCatalogName := genName("mock-ocs-main-update2-")
 		mainManifests := []registry.PackageManifest{
 			{
@@ -221,24 +221,24 @@ var _ = Describe("CRD Versions", func() {
 		}
 
 		// Create the catalog sources
-		_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, ns.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{oldCRD, newCRD}, []operatorsv1alpha1.ClusterServiceVersion{oldCSV, newCSV})
+		_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, generatedNamespace.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{oldCRD, newCRD}, []operatorsv1alpha1.ClusterServiceVersion{oldCSV, newCSV})
 		defer cleanupMainCatalogSource()
 		defer func() {
-			_ = crc.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Delete(context.TODO(), oldCSV.GetName(), metav1.DeleteOptions{})
-			_ = crc.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Delete(context.TODO(), newCSV.GetName(), metav1.DeleteOptions{})
+			_ = crc.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Delete(context.TODO(), oldCSV.GetName(), metav1.DeleteOptions{})
+			_ = crc.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Delete(context.TODO(), newCSV.GetName(), metav1.DeleteOptions{})
 			_ = c.ApiextensionsInterface().ApiextensionsV1().CustomResourceDefinitions().Delete(context.TODO(), oldCRD.GetName(), metav1.DeleteOptions{})
 			_ = c.ApiextensionsInterface().ApiextensionsV1().CustomResourceDefinitions().Delete(context.TODO(), newCRD.GetName(), metav1.DeleteOptions{})
 		}()
 
 		// Attempt to get the catalog source before creating install plan
-		_, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, ns.GetName(), catalogSourceRegistryPodSynced)
+		_, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 		Expect(err).ToNot(HaveOccurred())
 
 		subscriptionName := genName("sub-nginx-update2-")
-		subscriptionCleanup := createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+		subscriptionCleanup := createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 		defer subscriptionCleanup()
 
-		subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
+		subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(subscription).ToNot(BeNil())
 		Expect(subscription.Status.InstallPlanRef).ToNot(Equal(nil))
@@ -247,7 +247,7 @@ var _ = Describe("CRD Versions", func() {
 		installPlanName := subscription.Status.InstallPlanRef.Name
 
 		// Wait for InstallPlan to be status: Complete before checking resource presence
-		fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
+		fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
 		Expect(err).ToNot(HaveOccurred())
 		GinkgoT().Logf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase)
 		Expect(fetchedInstallPlan.Status.Phase).To(Equal(operatorsv1alpha1.InstallPlanPhaseComplete))
@@ -266,14 +266,14 @@ var _ = Describe("CRD Versions", func() {
 		}
 
 		// fetch new subscription
-		s, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionAtLatestWithDifferentInstallPlan)
+		s, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionAtLatestWithDifferentInstallPlan)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(s).ToNot(BeNil())
 		Expect(s.Status.InstallPlanRef).ToNot(Equal(nil))
 
 		// Check the error on the installplan - should be related to data loss and the CRD upgrade missing a stored version
 		Eventually(func() (*operatorsv1alpha1.InstallPlan, error) {
-			return crc.OperatorsV1alpha1().InstallPlans(ns.GetName()).Get(context.TODO(), s.Status.InstallPlanRef.Name, metav1.GetOptions{})
+			return crc.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).Get(context.TODO(), s.Status.InstallPlanRef.Name, metav1.GetOptions{})
 		}).Should(And(
 			WithTransform(
 				func(v *operatorsv1alpha1.InstallPlan) operatorsv1alpha1.InstallPlanPhase {
@@ -399,9 +399,9 @@ var _ = Describe("CRD Versions", func() {
 		mainPackageName := genName("nginx-update2-")
 		mainPackageStable := fmt.Sprintf("%s-stable", mainPackageName)
 		stableChannel := "stable"
-		catalogCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{catalogCRD}, nil, nil)
+		catalogCSV := newCSV(mainPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{catalogCRD}, nil, nil)
 		defer func() {
-			_ = crc.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Delete(context.TODO(), catalogCSV.GetName(), metav1.DeleteOptions{})
+			_ = crc.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Delete(context.TODO(), catalogCSV.GetName(), metav1.DeleteOptions{})
 			_ = c.ApiextensionsInterface().ApiextensionsV1().CustomResourceDefinitions().Delete(context.TODO(), catalogCRD.GetName(), metav1.DeleteOptions{})
 		}()
 
@@ -417,17 +417,17 @@ var _ = Describe("CRD Versions", func() {
 		}
 
 		// Create the catalog sources
-		_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, ns.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{catalogCRD}, []operatorsv1alpha1.ClusterServiceVersion{catalogCSV})
+		_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, generatedNamespace.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{catalogCRD}, []operatorsv1alpha1.ClusterServiceVersion{catalogCSV})
 		defer cleanupMainCatalogSource()
 
 		// Attempt to get the catalog source before creating install plan
-		_, err = fetchCatalogSourceOnStatus(crc, mainCatalogName, ns.GetName(), catalogSourceRegistryPodSynced)
+		_, err = fetchCatalogSourceOnStatus(crc, mainCatalogName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 		Expect(err).ToNot(HaveOccurred())
 
 		subscriptionName := genName("sub-nginx-update2-")
-		_ = createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+		_ = createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 
-		subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
+		subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(subscription).ToNot(BeNil())
 		Expect(subscription.Status.InstallPlanRef).ToNot(Equal(nil))
@@ -436,7 +436,7 @@ var _ = Describe("CRD Versions", func() {
 		// Check the error on the installplan - should be related to data loss and the CRD upgrade missing a stored version (v1alpha1)
 		Eventually(
 			func() (*operatorsv1alpha1.InstallPlan, error) {
-				return crc.OperatorsV1alpha1().InstallPlans(ns.GetName()).Get(context.TODO(), subscription.Status.InstallPlanRef.Name, metav1.GetOptions{})
+				return crc.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).Get(context.TODO(), subscription.Status.InstallPlanRef.Name, metav1.GetOptions{})
 			},
 			90*time.Second, // exhaust retries
 		).Should(WithTransform(
@@ -454,20 +454,20 @@ var _ = Describe("CRD Versions", func() {
 
 		// install should now succeed
 		oldInstallPlanRef := subscription.Status.InstallPlanRef.Name
-		err = crc.OperatorsV1alpha1().InstallPlans(ns.GetName()).Delete(context.TODO(), subscription.Status.InstallPlanRef.Name, metav1.DeleteOptions{})
+		err = crc.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).Delete(context.TODO(), subscription.Status.InstallPlanRef.Name, metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred(), "error deleting failed install plan")
 		// remove old subscription
-		err = crc.OperatorsV1alpha1().Subscriptions(ns.GetName()).Delete(context.TODO(), subscription.GetName(), metav1.DeleteOptions{})
+		err = crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).Delete(context.TODO(), subscription.GetName(), metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred(), "error deleting old subscription")
 		// remove old csv
-		crc.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Delete(context.TODO(), mainPackageStable, metav1.DeleteOptions{})
+		crc.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Delete(context.TODO(), mainPackageStable, metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred(), "error deleting old subscription")
 
 		// recreate subscription
 		subscriptionNameNew := genName("sub-nginx-update2-new-")
-		_ = createSubscriptionForCatalog(crc, ns.GetName(), subscriptionNameNew, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+		_ = createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionNameNew, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 
-		subscription, err = fetchSubscription(crc, ns.GetName(), subscriptionNameNew, subscriptionHasInstallPlanChecker)
+		subscription, err = fetchSubscription(crc, generatedNamespace.GetName(), subscriptionNameNew, subscriptionHasInstallPlanChecker)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(subscription).ToNot(BeNil())
 		Expect(subscription.Status.InstallPlanRef).ToNot(Equal(nil))
@@ -475,15 +475,15 @@ var _ = Describe("CRD Versions", func() {
 
 		// eventually the subscription should create a new install plan
 		Eventually(func() bool {
-			sub, _ := crc.OperatorsV1alpha1().Subscriptions(ns.GetName()).Get(context.TODO(), subscription.GetName(), metav1.GetOptions{})
+			sub, _ := crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).Get(context.TODO(), subscription.GetName(), metav1.GetOptions{})
 			GinkgoT().Logf("waiting for subscription %s to generate a new install plan...", subscription.GetName())
 			return sub.Status.InstallPlanRef.Name != oldInstallPlanRef
 		}, 5*time.Minute, 10*time.Second).Should(BeTrue())
 
 		// eventually the new installplan should succeed
 		Eventually(func() bool {
-			sub, _ := crc.OperatorsV1alpha1().Subscriptions(ns.GetName()).Get(context.TODO(), subscription.GetName(), metav1.GetOptions{})
-			ip, err := crc.OperatorsV1alpha1().InstallPlans(ns.GetName()).Get(context.TODO(), sub.Status.InstallPlanRef.Name, metav1.GetOptions{})
+			sub, _ := crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).Get(context.TODO(), subscription.GetName(), metav1.GetOptions{})
+			ip, err := crc.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).Get(context.TODO(), sub.Status.InstallPlanRef.Name, metav1.GetOptions{})
 			if apierrors.IsNotFound(err) {
 				return false
 			}

--- a/staging/operator-lifecycle-manager/test/e2e/csv_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/csv_e2e_test.go
@@ -37,9 +37,9 @@ import (
 
 var _ = Describe("ClusterServiceVersion", func() {
 	var (
-		ns  corev1.Namespace
-		c   operatorclient.ClientInterface
-		crc versioned.Interface
+		generatedNamespace corev1.Namespace
+		c                  operatorclient.ClientInterface
+		crc                versioned.Interface
 	)
 
 	BeforeEach(func() {
@@ -48,14 +48,14 @@ var _ = Describe("ClusterServiceVersion", func() {
 	})
 
 	AfterEach(func() {
-		TeardownNamespace(ns.GetName())
+		TeardownNamespace(generatedNamespace.GetName())
 	})
 
 	Context("OwnNamespace OperatorGroup", func() {
 
 		BeforeEach(func() {
 			nsName := genName("csv-e2e-")
-			ns = SetupGeneratedTestNamespace(nsName, nsName)
+			generatedNamespace = SetupGeneratedTestNamespace(nsName, nsName)
 		})
 
 		When("a CustomResourceDefinition was installed alongside a ClusterServiceVersion", func() {
@@ -72,7 +72,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: apifullname,
 						Annotations: map[string]string{
-							"operatorframework.io/installed-alongside-0": fmt.Sprintf("%s/associated-csv", ns.GetName()),
+							"operatorframework.io/installed-alongside-0": fmt.Sprintf("%s/associated-csv", generatedNamespace.GetName()),
 						},
 					},
 					Spec: apiextensionsv1.CustomResourceDefinitionSpec{
@@ -111,7 +111,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				associated := operatorsv1alpha1.ClusterServiceVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "associated-csv",
-						Namespace: ns.GetName(),
+						Namespace: generatedNamespace.GetName(),
 					},
 					Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
 						CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
@@ -169,7 +169,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				unassociated := operatorsv1alpha1.ClusterServiceVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "unassociated-csv",
-						Namespace: ns.GetName(),
+						Namespace: generatedNamespace.GetName(),
 					},
 					Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
 						CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
@@ -193,7 +193,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				associated := operatorsv1alpha1.ClusterServiceVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "associated-csv",
-						Namespace: ns.GetName(),
+						Namespace: generatedNamespace.GetName(),
 					},
 					Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
 						CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
@@ -228,7 +228,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				unassociated := operatorsv1alpha1.ClusterServiceVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "unassociated-csv",
-						Namespace: ns.GetName(),
+						Namespace: generatedNamespace.GetName(),
 					},
 					Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
 						CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
@@ -293,7 +293,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: apifullname,
 						Annotations: map[string]string{
-							"operatorframework.io/installed-alongside-0": fmt.Sprintf("%s/associated-csv", ns.GetName()),
+							"operatorframework.io/installed-alongside-0": fmt.Sprintf("%s/associated-csv", generatedNamespace.GetName()),
 						},
 					},
 					Spec: apiextensionsv1.CustomResourceDefinitionSpec{
@@ -326,7 +326,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				associated := operatorsv1alpha1.ClusterServiceVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "associated-csv",
-						Namespace: ns.GetName(),
+						Namespace: generatedNamespace.GetName(),
 					},
 					Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
 						CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
@@ -350,7 +350,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				unassociated := operatorsv1alpha1.ClusterServiceVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "unassociated-csv",
-						Namespace: ns.GetName(),
+						Namespace: generatedNamespace.GetName(),
 					},
 					Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
 						CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
@@ -400,9 +400,8 @@ var _ = Describe("ClusterServiceVersion", func() {
 	})
 
 	Context("AllNamespaces OperatorGroup", func() {
-
 		BeforeEach(func() {
-			ns = SetupGeneratedTestNamespace(genName("csv-e2e-"))
+			generatedNamespace = SetupGeneratedTestNamespace(genName("csv-e2e-"))
 		})
 
 		When("a csv exists specifying two replicas with one max unavailable", func() {
@@ -418,7 +417,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				csv = operatorsv1alpha1.ClusterServiceVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "test-csv",
-						Namespace:    ns.GetName(),
+						Namespace:    generatedNamespace.GetName(),
 					},
 					Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
 						InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
@@ -507,7 +506,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 
 			It("remains in phase Succeeded when only one pod is available", func() {
 				Eventually(func() int32 {
-					dep, err := c.GetDeployment(ns.GetName(), "deployment")
+					dep, err := c.GetDeployment(generatedNamespace.GetName(), "deployment")
 					if err != nil || dep == nil {
 						return 0
 					}
@@ -547,7 +546,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "csv-",
-						Namespace:    ns.GetName(),
+						Namespace:    generatedNamespace.GetName(),
 					},
 					Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
 						InstallStrategy: newNginxInstallStrategy(genName("csv-"), nil, nil),
@@ -612,7 +611,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				cm = corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "cm-",
-						Namespace:    ns.GetName(),
+						Namespace:    generatedNamespace.GetName(),
 					},
 				}
 				Expect(ctx.Ctx().Client().Create(context.Background(), &cm)).To(Succeed())
@@ -620,7 +619,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				sa = corev1.ServiceAccount{
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "sa-",
-						Namespace:    ns.GetName(),
+						Namespace:    generatedNamespace.GetName(),
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								Name:       cm.GetName(),
@@ -640,7 +639,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "csv-",
-						Namespace:    ns.GetName(),
+						Namespace:    generatedNamespace.GetName(),
 					},
 					Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
 						InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
@@ -743,16 +742,16 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvPendingChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvPendingChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Shouldn't create deployment
 			Consistently(func() bool {
-				_, err := c.GetDeployment(ns.GetName(), depName)
+				_, err := c.GetDeployment(generatedNamespace.GetName(), depName)
 				return apierrors.IsNotFound(err)
 			}).Should(BeTrue())
 		})
@@ -804,16 +803,16 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvPendingChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvPendingChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Shouldn't create deployment
 			Consistently(func() bool {
-				_, err := c.GetDeployment(ns.GetName(), depName)
+				_, err := c.GetDeployment(generatedNamespace.GetName(), depName)
 				return apierrors.IsNotFound(err)
 			}).Should(BeTrue())
 		})
@@ -923,16 +922,16 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCRD()
 
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), true, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), true, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvPendingChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvPendingChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Shouldn't create deployment
 			Consistently(func() bool {
-				_, err := c.GetDeployment(ns.GetName(), depName)
+				_, err := c.GetDeployment(generatedNamespace.GetName(), depName)
 				return apierrors.IsNotFound(err)
 			}).Should(BeTrue())
 		})
@@ -982,16 +981,16 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvPendingChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvPendingChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Shouldn't create deployment
 			Consistently(func() bool {
-				_, err := c.GetDeployment(ns.GetName(), depName)
+				_, err := c.GetDeployment(generatedNamespace.GetName(), depName)
 				return apierrors.IsNotFound(err)
 			}).Should(BeTrue())
 		})
@@ -1069,16 +1068,16 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvPendingChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvPendingChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Shouldn't create deployment
 			Consistently(func() bool {
-				_, err := c.GetDeployment(ns.GetName(), depName)
+				_, err := c.GetDeployment(generatedNamespace.GetName(), depName)
 				return apierrors.IsNotFound(err)
 			}).Should(BeTrue())
 		})
@@ -1118,16 +1117,16 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvPendingChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvPendingChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Shouldn't create deployment
 			Consistently(func() bool {
-				_, err := c.GetDeployment(ns.GetName(), depName)
+				_, err := c.GetDeployment(generatedNamespace.GetName(), depName)
 				return apierrors.IsNotFound(err)
 			}).Should(BeTrue())
 		})
@@ -1212,16 +1211,16 @@ var _ = Describe("ClusterServiceVersion", func() {
 			}
 
 			// Create CSV first, knowing it will fail
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), true, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), true, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			fetchedCSV, err := fetchCSV(crc, csv.Name, ns.GetName(), csvPendingChecker)
+			fetchedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvPendingChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			sa := corev1.ServiceAccount{}
 			sa.SetName(saName)
-			sa.SetNamespace(ns.GetName())
+			sa.SetNamespace(generatedNamespace.GetName())
 			sa.SetOwnerReferences([]metav1.OwnerReference{{
 				Name:       fetchedCSV.GetName(),
 				APIVersion: operatorsv1alpha1.ClusterServiceVersionAPIVersion,
@@ -1280,7 +1279,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 			role.SetName(genName("dep-"))
-			role.SetNamespace(ns.GetName())
+			role.SetNamespace(generatedNamespace.GetName())
 			_, err = c.CreateRole(&role)
 			Expect(err).ShouldNot(HaveOccurred(), "could not create Role")
 
@@ -1300,7 +1299,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 			roleBinding.SetName(genName("dep-"))
-			roleBinding.SetNamespace(ns.GetName())
+			roleBinding.SetNamespace(generatedNamespace.GetName())
 			_, err = c.CreateRoleBinding(&roleBinding)
 			Expect(err).ShouldNot(HaveOccurred(), "could not create RoleBinding")
 
@@ -1370,7 +1369,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			ctx.Ctx().Logf("checking for deployment")
 			// Poll for deployment to be ready
 			Eventually(func() (bool, error) {
-				dep, err := c.GetDeployment(ns.GetName(), depName)
+				dep, err := c.GetDeployment(generatedNamespace.GetName(), depName)
 				if apierrors.IsNotFound(err) {
 					ctx.Ctx().Logf("deployment %s not found\n", depName)
 					return false, nil
@@ -1388,14 +1387,14 @@ var _ = Describe("ClusterServiceVersion", func() {
 				return false, nil
 			}).Should(BeTrue())
 
-			fetchedCSV, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Delete CRD
 			cleanupCRD()
 
 			// Wait for CSV failure
-			fetchedCSV, err = fetchCSV(crc, csv.Name, ns.GetName(), csvPendingChecker)
+			fetchedCSV, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvPendingChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Recreate the CRD
@@ -1404,14 +1403,14 @@ var _ = Describe("ClusterServiceVersion", func() {
 			defer cleanupCRD()
 
 			// Wait for CSV success again
-			fetchedCSV, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("create requirements met API service", func() {
 
 			sa := corev1.ServiceAccount{}
 			sa.SetName(genName("sa-"))
-			sa.SetNamespace(ns.GetName())
+			sa.SetNamespace(generatedNamespace.GetName())
 			_, err := c.CreateServiceAccount(&sa)
 			Expect(err).ShouldNot(HaveOccurred(), "could not create ServiceAccount")
 
@@ -1497,7 +1496,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 			role.SetName(genName("dep-"))
-			role.SetNamespace(ns.GetName())
+			role.SetNamespace(generatedNamespace.GetName())
 			_, err = c.CreateRole(&role)
 			Expect(err).ShouldNot(HaveOccurred(), "could not create Role")
 
@@ -1517,7 +1516,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 			roleBinding.SetName(genName("dep-"))
-			roleBinding.SetNamespace(ns.GetName())
+			roleBinding.SetNamespace(generatedNamespace.GetName())
 			_, err = c.CreateRoleBinding(&roleBinding)
 			Expect(err).ShouldNot(HaveOccurred(), "could not create RoleBinding")
 
@@ -1553,15 +1552,15 @@ var _ = Describe("ClusterServiceVersion", func() {
 			_, err = c.CreateClusterRoleBinding(&clusterRoleBinding)
 			Expect(err).ShouldNot(HaveOccurred(), "could not create ClusterRoleBinding")
 
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			fetchedCSV, err := fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Fetch cluster service version again to check for unnecessary control loops
-			sameCSV, err := fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			sameCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
 		})
@@ -1632,7 +1631,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			csv.SetName(depName)
 
 			// Create the APIService CSV
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer func() {
 				watcher, err := c.ApiregistrationV1Interface().ApiregistrationV1().APIServices().Watch(context.TODO(), metav1.ListOptions{FieldSelector: "metadata.name=" + apiServiceName})
@@ -1659,11 +1658,11 @@ var _ = Describe("ClusterServiceVersion", func() {
 				<-deleted
 			}()
 
-			fetchedCSV, err := fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should create Deployment
-			dep, err := c.GetDeployment(ns.GetName(), depName)
+			dep, err := c.GetDeployment(generatedNamespace.GetName(), depName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Deployment")
 
 			// Should create APIService
@@ -1672,20 +1671,20 @@ var _ = Describe("ClusterServiceVersion", func() {
 
 			// Should create Service
 			serviceName := fmt.Sprintf("%s-service", depName)
-			_, err = c.GetService(ns.GetName(), serviceName)
+			_, err = c.GetService(generatedNamespace.GetName(), serviceName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Service")
 
 			// Should create certificate Secret
 			secretName := fmt.Sprintf("%s-cert", serviceName)
-			_, err = c.GetSecret(ns.GetName(), secretName)
+			_, err = c.GetSecret(generatedNamespace.GetName(), secretName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret")
 
 			// Should create a Role for the Secret
-			_, err = c.GetRole(ns.GetName(), secretName)
+			_, err = c.GetRole(generatedNamespace.GetName(), secretName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret Role")
 
 			// Should create a RoleBinding for the Secret
-			_, err = c.GetRoleBinding(ns.GetName(), secretName)
+			_, err = c.GetRoleBinding(generatedNamespace.GetName(), secretName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting exptected Secret RoleBinding")
 
 			// Should create a system:auth-delegator Cluster RoleBinding
@@ -1708,9 +1707,9 @@ var _ = Describe("ClusterServiceVersion", func() {
 				return nil
 			})).Should(Succeed())
 
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
 				// Should create deployment
-				dep, err = c.GetDeployment(ns.GetName(), depName)
+				dep, err = c.GetDeployment(generatedNamespace.GetName(), depName)
 				if err != nil {
 					return false
 				}
@@ -1739,7 +1738,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for CSV success
-			fetchedCSV, err = fetchCSV(crc, csv.GetName(), ns.GetName(), func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
+			fetchedCSV, err = fetchCSV(crc, csv.GetName(), generatedNamespace.GetName(), func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
 				// Should create an APIService
 				apiService, err := c.GetAPIService(apiServiceName)
 				if err != nil {
@@ -1820,14 +1819,14 @@ var _ = Describe("ClusterServiceVersion", func() {
 			csv.SetName("csv-hat-1")
 
 			// Create the APIService CSV
-			_, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			_, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should create Deployment
-			_, err = c.GetDeployment(ns.GetName(), depName)
+			_, err = c.GetDeployment(generatedNamespace.GetName(), depName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Deployment")
 
 			// Should create APIService
@@ -1836,20 +1835,20 @@ var _ = Describe("ClusterServiceVersion", func() {
 
 			// Should create Service
 			serviceName := fmt.Sprintf("%s-service", depName)
-			_, err = c.GetService(ns.GetName(), serviceName)
+			_, err = c.GetService(generatedNamespace.GetName(), serviceName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Service")
 
 			// Should create certificate Secret
 			secretName := fmt.Sprintf("%s-cert", serviceName)
-			_, err = c.GetSecret(ns.GetName(), secretName)
+			_, err = c.GetSecret(generatedNamespace.GetName(), secretName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret")
 
 			// Should create a Role for the Secret
-			_, err = c.GetRole(ns.GetName(), secretName)
+			_, err = c.GetRole(generatedNamespace.GetName(), secretName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret Role")
 
 			// Should create a RoleBinding for the Secret
-			_, err = c.GetRoleBinding(ns.GetName(), secretName)
+			_, err = c.GetRoleBinding(generatedNamespace.GetName(), secretName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting exptected Secret RoleBinding")
 
 			// Should create a system:auth-delegator Cluster RoleBinding
@@ -1895,15 +1894,15 @@ var _ = Describe("ClusterServiceVersion", func() {
 			csv2.SetName("csv-hat-2")
 
 			// Create CSV2 to replace CSV
-			cleanupCSV2, err := createCSV(c, crc, csv2, ns.GetName(), false, true)
+			cleanupCSV2, err := createCSV(c, crc, csv2, generatedNamespace.GetName(), false, true)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV2()
 
-			_, err = fetchCSV(crc, csv2.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv2.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should create Deployment
-			_, err = c.GetDeployment(ns.GetName(), depName)
+			_, err = c.GetDeployment(generatedNamespace.GetName(), depName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Deployment")
 
 			// Should create APIService
@@ -1912,27 +1911,27 @@ var _ = Describe("ClusterServiceVersion", func() {
 
 			// Should create Service
 			Eventually(func() error {
-				_, err := c.GetService(ns.GetName(), serviceName)
+				_, err := c.GetService(generatedNamespace.GetName(), serviceName)
 				return err
 			}, timeout, interval).ShouldNot(HaveOccurred())
 
 			// Should create certificate Secret
 			secretName = fmt.Sprintf("%s-cert", serviceName)
 			Eventually(func() error {
-				_, err = c.GetSecret(ns.GetName(), secretName)
+				_, err = c.GetSecret(generatedNamespace.GetName(), secretName)
 				return err
 			}, timeout, interval).ShouldNot(HaveOccurred())
 
 			// Should create a Role for the Secret
-			_, err = c.GetRole(ns.GetName(), secretName)
+			_, err = c.GetRole(generatedNamespace.GetName(), secretName)
 			Eventually(func() error {
-				_, err = c.GetRole(ns.GetName(), secretName)
+				_, err = c.GetRole(generatedNamespace.GetName(), secretName)
 				return err
 			}, timeout, interval).ShouldNot(HaveOccurred())
 
 			// Should create a RoleBinding for the Secret
 			Eventually(func() error {
-				_, err = c.GetRoleBinding(ns.GetName(), secretName)
+				_, err = c.GetRoleBinding(generatedNamespace.GetName(), secretName)
 				return err
 			}, timeout, interval).ShouldNot(HaveOccurred())
 
@@ -1951,25 +1950,25 @@ var _ = Describe("ClusterServiceVersion", func() {
 
 			// Should eventually GC the CSV
 			Eventually(func() bool {
-				return csvExists(ns.GetName(), crc, csv.Name)
+				return csvExists(generatedNamespace.GetName(), crc, csv.Name)
 			}).Should(BeFalse())
 
 			// Rename the initial CSV
 			csv.SetName("csv-hat-3")
 
 			// Recreate the old CSV
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, true)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, true)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			fetched, err := fetchCSV(crc, csv.Name, ns.GetName(), buildCSVReasonChecker(operatorsv1alpha1.CSVReasonOwnerConflict))
+			fetched, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), buildCSVReasonChecker(operatorsv1alpha1.CSVReasonOwnerConflict))
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(fetched.Status.Phase).Should(Equal(operatorsv1alpha1.CSVPhaseFailed))
 		})
 		It("create same CSV with owned API service multi namespace", func() {
 
 			// Create new namespace in a new operator group
-			secondNamespaceName := genName(ns.GetName() + "-")
+			secondNamespaceName := genName(generatedNamespace.GetName() + "-")
 			matchingLabel := map[string]string{"inGroup": secondNamespaceName}
 
 			_, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
@@ -2077,15 +2076,15 @@ var _ = Describe("ClusterServiceVersion", func() {
 			csv.SetName("csv-hat-1")
 
 			// Create the initial CSV
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should create Deployment
-			_, err = c.GetDeployment(ns.GetName(), depName)
+			_, err = c.GetDeployment(generatedNamespace.GetName(), depName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Deployment")
 
 			// Should create APIService
@@ -2094,20 +2093,20 @@ var _ = Describe("ClusterServiceVersion", func() {
 
 			// Should create Service
 			serviceName := fmt.Sprintf("%s-service", depName)
-			_, err = c.GetService(ns.GetName(), serviceName)
+			_, err = c.GetService(generatedNamespace.GetName(), serviceName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Service")
 
 			// Should create certificate Secret
 			secretName := fmt.Sprintf("%s-cert", serviceName)
-			_, err = c.GetSecret(ns.GetName(), secretName)
+			_, err = c.GetSecret(generatedNamespace.GetName(), secretName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret")
 
 			// Should create a Role for the Secret
-			_, err = c.GetRole(ns.GetName(), secretName)
+			_, err = c.GetRole(generatedNamespace.GetName(), secretName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected Secret Role")
 
 			// Should create a RoleBinding for the Secret
-			_, err = c.GetRoleBinding(ns.GetName(), secretName)
+			_, err = c.GetRoleBinding(generatedNamespace.GetName(), secretName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting exptected Secret RoleBinding")
 
 			// Should create a system:auth-delegator Cluster RoleBinding
@@ -2215,7 +2214,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			orphanedAPISvc, err = c.GetAPIService(apiServiceName)
 			Expect(err).ShouldNot(HaveOccurred(), "error getting expected APIService")
 
-			newLabels = map[string]string{"olm.owner": "hat-serverfd4r5", "olm.owner.kind": "ClusterServiceVersion", "olm.owner.namespace": ns.GetName()}
+			newLabels = map[string]string{"olm.owner": "hat-serverfd4r5", "olm.owner.kind": "ClusterServiceVersion", "olm.owner.namespace": generatedNamespace.GetName()}
 			orphanedAPISvc.SetLabels(newLabels)
 			_, err = c.UpdateAPIService(orphanedAPISvc)
 			Expect(err).ShouldNot(HaveOccurred(), "error updating APIService")
@@ -2278,16 +2277,16 @@ var _ = Describe("ClusterServiceVersion", func() {
 			}
 
 			// Create the CSV and make sure to clean it up
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
 			// Wait for current CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created deployment
-			dep, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[0].Name)
+			dep, err := c.GetDeployment(generatedNamespace.GetName(), strategy.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(dep).ShouldNot(BeNil())
 
@@ -2349,23 +2348,23 @@ var _ = Describe("ClusterServiceVersion", func() {
 			}
 
 			// Create the CSV and make sure to clean it up
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
 			// Wait for current CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created deployment
-			dep, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[0].Name)
+			dep, err := c.GetDeployment(generatedNamespace.GetName(), strategy.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(dep).ShouldNot(BeNil())
 
 			// Make sure that the deployment labels are correct
 			labels := dep.GetLabels()
 			Expect(labels["olm.owner"]).Should(Equal(csv.GetName()))
-			Expect(labels["olm.owner.namespace"]).Should(Equal(ns.GetName()))
+			Expect(labels["olm.owner.namespace"]).Should(Equal(generatedNamespace.GetName()))
 			Expect(labels["application"]).Should(Equal("nginx"))
 			Expect(labels["application.type"]).Should(Equal("proxy"))
 		})
@@ -2465,15 +2464,15 @@ var _ = Describe("ClusterServiceVersion", func() {
 			}
 
 			// Don't need to cleanup this CSV, it will be deleted by the upgrade process
-			_, err = createCSV(c, crc, csv, ns.GetName(), false, false)
+			_, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for current CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created deployment
-			dep, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[0].Name)
+			dep, err := c.GetDeployment(generatedNamespace.GetName(), strategy.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(dep).ShouldNot(BeNil())
 
@@ -2537,27 +2536,27 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 
-			cleanupNewCSV, err := createCSV(c, crc, csvNew, ns.GetName(), true, false)
+			cleanupNewCSV, err := createCSV(c, crc, csvNew, generatedNamespace.GetName(), true, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupNewCSV()
 
 			// Wait for updated CSV to succeed
-			fetchedCSV, err := fetchCSV(crc, csvNew.Name, ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, csvNew.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have updated existing deployment
-			depUpdated, err := c.GetDeployment(ns.GetName(), strategyNew.DeploymentSpecs[0].Name)
+			depUpdated, err := c.GetDeployment(generatedNamespace.GetName(), strategyNew.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(depUpdated).ShouldNot(BeNil())
 			Expect(strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Name).Should(Equal(depUpdated.Spec.Template.Spec.Containers[0].Name))
 
 			// Should eventually GC the CSV
 			Eventually(func() bool {
-				return csvExists(ns.GetName(), crc, csv.Name)
+				return csvExists(generatedNamespace.GetName(), crc, csv.Name)
 			}).Should(BeFalse())
 
 			// Fetch cluster service version again to check for unnecessary control loops
-			sameCSV, err := fetchCSV(crc, csvNew.Name, ns.GetName(), csvSucceededChecker)
+			sameCSV, err := fetchCSV(crc, csvNew.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
 		})
@@ -2656,15 +2655,15 @@ var _ = Describe("ClusterServiceVersion", func() {
 			}
 
 			// don't need to clean up this CSV, it will be deleted by the upgrade process
-			_, err = createCSV(c, crc, csv, ns.GetName(), false, false)
+			_, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for current CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created deployment
-			dep, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[0].Name)
+			dep, err := c.GetDeployment(generatedNamespace.GetName(), strategy.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(dep).ShouldNot(BeNil())
 
@@ -2726,29 +2725,29 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 
-			cleanupNewCSV, err := createCSV(c, crc, csvNew, ns.GetName(), true, false)
+			cleanupNewCSV, err := createCSV(c, crc, csvNew, generatedNamespace.GetName(), true, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupNewCSV()
 
 			// Wait for updated CSV to succeed
-			fetchedCSV, err := fetchCSV(crc, csvNew.Name, ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, csvNew.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Fetch cluster service version again to check for unnecessary control loops
-			sameCSV, err := fetchCSV(crc, csvNew.Name, ns.GetName(), csvSucceededChecker)
+			sameCSV, err := fetchCSV(crc, csvNew.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
 
 			// Should have created new deployment and deleted old
-			depNew, err := c.GetDeployment(ns.GetName(), strategyNew.DeploymentSpecs[0].Name)
+			depNew, err := c.GetDeployment(generatedNamespace.GetName(), strategyNew.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(depNew).ShouldNot(BeNil())
-			err = waitForDeploymentToDelete(ns.GetName(), c, strategy.DeploymentSpecs[0].Name)
+			err = waitForDeploymentToDelete(generatedNamespace.GetName(), c, strategy.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should eventually GC the CSV
 			Eventually(func() bool {
-				return csvExists(ns.GetName(), crc, csv.Name)
+				return csvExists(generatedNamespace.GetName(), crc, csv.Name)
 			}).Should(BeFalse())
 		})
 		It("update multiple intermediates", func() {
@@ -2846,15 +2845,15 @@ var _ = Describe("ClusterServiceVersion", func() {
 			}
 
 			// don't need to clean up this CSV, it will be deleted by the upgrade process
-			_, err = createCSV(c, crc, csv, ns.GetName(), false, false)
+			_, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for current CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created deployment
-			dep, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[0].Name)
+			dep, err := c.GetDeployment(generatedNamespace.GetName(), strategy.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(dep).ShouldNot(BeNil())
 
@@ -2916,29 +2915,29 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 
-			cleanupNewCSV, err := createCSV(c, crc, csvNew, ns.GetName(), true, false)
+			cleanupNewCSV, err := createCSV(c, crc, csvNew, generatedNamespace.GetName(), true, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupNewCSV()
 
 			// Wait for updated CSV to succeed
-			fetchedCSV, err := fetchCSV(crc, csvNew.Name, ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, csvNew.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Fetch cluster service version again to check for unnecessary control loops
-			sameCSV, err := fetchCSV(crc, csvNew.Name, ns.GetName(), csvSucceededChecker)
+			sameCSV, err := fetchCSV(crc, csvNew.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
 
 			// Should have created new deployment and deleted old
-			depNew, err := c.GetDeployment(ns.GetName(), strategyNew.DeploymentSpecs[0].Name)
+			depNew, err := c.GetDeployment(generatedNamespace.GetName(), strategyNew.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(depNew).ShouldNot(BeNil())
-			err = waitForDeploymentToDelete(ns.GetName(), c, strategy.DeploymentSpecs[0].Name)
+			err = waitForDeploymentToDelete(generatedNamespace.GetName(), c, strategy.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should eventually GC the CSV
 			Eventually(func() bool {
-				return csvExists(ns.GetName(), crc, csv.Name)
+				return csvExists(generatedNamespace.GetName(), crc, csv.Name)
 			}).Should(BeFalse())
 		})
 		It("update in place", func() {
@@ -3036,16 +3035,16 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, true)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, true)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
 			// Wait for current CSV to succeed
-			fetchedCSV, err := fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created deployment
-			dep, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[0].Name)
+			dep, err := c.GetDeployment(generatedNamespace.GetName(), strategy.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(dep).ShouldNot(BeNil())
 
@@ -3073,12 +3072,12 @@ var _ = Describe("ClusterServiceVersion", func() {
 			fetchedCSV.Spec.InstallStrategy.StrategySpec = strategyNew
 
 			// Update CSV directly
-			_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Update(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
+			_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Update(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// wait for deployment spec to be updated
 			Eventually(func() (string, error) {
-				fetched, err := c.GetDeployment(ns.GetName(), strategyNew.DeploymentSpecs[0].Name)
+				fetched, err := c.GetDeployment(generatedNamespace.GetName(), strategyNew.DeploymentSpecs[0].Name)
 				if err != nil {
 					return "", err
 				}
@@ -3087,10 +3086,10 @@ var _ = Describe("ClusterServiceVersion", func() {
 			}).Should(Equal(strategyNew.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Name))
 
 			// Wait for updated CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			depUpdated, err := c.GetDeployment(ns.GetName(), strategyNew.DeploymentSpecs[0].Name)
+			depUpdated, err := c.GetDeployment(generatedNamespace.GetName(), strategyNew.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(depUpdated).ShouldNot(BeNil())
 
@@ -3208,15 +3207,15 @@ var _ = Describe("ClusterServiceVersion", func() {
 			}
 
 			// CSV will be deleted by the upgrade process later
-			_, err = createCSV(c, crc, csv, ns.GetName(), false, false)
+			_, err = createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for current CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created deployment
-			dep, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[0].Name)
+			dep, err := c.GetDeployment(generatedNamespace.GetName(), strategy.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(dep).ShouldNot(BeNil())
 
@@ -3287,23 +3286,23 @@ var _ = Describe("ClusterServiceVersion", func() {
 			}
 
 			// Create newly updated CSV
-			_, err = createCSV(c, crc, csvNew, ns.GetName(), false, false)
+			_, err = createCSV(c, crc, csvNew, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for updated CSV to succeed
-			fetchedCSV, err := fetchCSV(crc, csvNew.Name, ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, csvNew.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Fetch cluster service version again to check for unnecessary control loops
-			sameCSV, err := fetchCSV(crc, csvNew.Name, ns.GetName(), csvSucceededChecker)
+			sameCSV, err := fetchCSV(crc, csvNew.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
 
 			// Should have created new deployment and deleted old one
-			depNew, err := c.GetDeployment(ns.GetName(), strategyNew.DeploymentSpecs[0].Name)
+			depNew, err := c.GetDeployment(generatedNamespace.GetName(), strategyNew.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(depNew).ShouldNot(BeNil())
-			err = waitForDeploymentToDelete(ns.GetName(), c, strategy.DeploymentSpecs[0].Name)
+			err = waitForDeploymentToDelete(generatedNamespace.GetName(), c, strategy.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Create updated deployment strategy
@@ -3365,29 +3364,29 @@ var _ = Describe("ClusterServiceVersion", func() {
 			}
 
 			// Create newly updated CSV
-			cleanupNewCSV, err := createCSV(c, crc, csvNew2, ns.GetName(), true, false)
+			cleanupNewCSV, err := createCSV(c, crc, csvNew2, generatedNamespace.GetName(), true, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupNewCSV()
 
 			// Wait for updated CSV to succeed
-			fetchedCSV, err = fetchCSV(crc, csvNew2.Name, ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err = fetchCSV(crc, csvNew2.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Fetch cluster service version again to check for unnecessary control loops
-			sameCSV, err = fetchCSV(crc, csvNew2.Name, ns.GetName(), csvSucceededChecker)
+			sameCSV, err = fetchCSV(crc, csvNew2.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(equality.Semantic.DeepEqual(fetchedCSV, sameCSV)).Should(BeTrue(), diff.ObjectDiff(fetchedCSV, sameCSV))
 
 			// Should have created new deployment and deleted old one
-			depNew, err = c.GetDeployment(ns.GetName(), strategyNew2.DeploymentSpecs[0].Name)
+			depNew, err = c.GetDeployment(generatedNamespace.GetName(), strategyNew2.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(depNew).ShouldNot(BeNil())
-			err = waitForDeploymentToDelete(ns.GetName(), c, strategyNew.DeploymentSpecs[0].Name)
+			err = waitForDeploymentToDelete(generatedNamespace.GetName(), c, strategyNew.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should clean up the CSV
 			Eventually(func() bool {
-				return csvExists(ns.GetName(), crc, csvNew.Name)
+				return csvExists(generatedNamespace.GetName(), crc, csvNew.Name)
 			}).Should(BeFalse())
 		})
 
@@ -3488,19 +3487,19 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), true, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), true, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
 			// Wait for current CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created deployments
-			dep, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[0].Name)
+			dep, err := c.GetDeployment(generatedNamespace.GetName(), strategy.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(dep).ShouldNot(BeNil())
-			dep2, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[1].Name)
+			dep2, err := c.GetDeployment(generatedNamespace.GetName(), strategy.DeploymentSpecs[1].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(dep2).ShouldNot(BeNil())
 
@@ -3521,35 +3520,35 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Fetch the current csv
-			fetchedCSV, err := fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Update csv with same strategy with different deployment's name
 			fetchedCSV.Spec.InstallStrategy.StrategySpec = strategyNew
 
 			// Update the current csv with the new csv
-			_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Update(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
+			_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Update(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for new deployment to exist
-			err = waitForDeployment(ns.GetName(), c, strategyNew.DeploymentSpecs[0].Name)
+			err = waitForDeployment(generatedNamespace.GetName(), c, strategyNew.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for updated CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created new deployment and deleted old
-			depNew, err := c.GetDeployment(ns.GetName(), strategyNew.DeploymentSpecs[0].Name)
+			depNew, err := c.GetDeployment(generatedNamespace.GetName(), strategyNew.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(depNew).ShouldNot(BeNil())
 
 			// Make sure the unchanged deployment still exists
-			depNew2, err := c.GetDeployment(ns.GetName(), strategyNew.DeploymentSpecs[1].Name)
+			depNew2, err := c.GetDeployment(generatedNamespace.GetName(), strategyNew.DeploymentSpecs[1].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(depNew2).ShouldNot(BeNil())
 
-			err = waitForDeploymentToDelete(ns.GetName(), c, strategy.DeploymentSpecs[0].Name)
+			err = waitForDeploymentToDelete(generatedNamespace.GetName(), c, strategy.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("update deployment spec in an existing CSV for a hotfix", func() {
@@ -3648,16 +3647,16 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), true, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), true, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
 			// Wait for current CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Should have created deployment
-			dep, err := c.GetDeployment(ns.GetName(), strategy.DeploymentSpecs[0].Name)
+			dep, err := c.GetDeployment(generatedNamespace.GetName(), strategy.DeploymentSpecs[0].Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(dep).ShouldNot(BeNil())
 
@@ -3674,7 +3673,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			}
 
 			// Fetch the current csv
-			fetchedCSV, err := fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Update csv with modified deployment spec
@@ -3682,15 +3681,15 @@ var _ = Describe("ClusterServiceVersion", func() {
 
 			Eventually(func() error {
 				// Update the current csv
-				_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Update(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
+				_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Update(context.TODO(), fetchedCSV, metav1.UpdateOptions{})
 				return err
 			}).Should(Succeed())
 
 			// Wait for updated CSV to succeed
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
 
 				// Should have updated existing deployment
-				depUpdated, err := c.GetDeployment(ns.GetName(), strategyNew.DeploymentSpecs[0].Name)
+				depUpdated, err := c.GetDeployment(generatedNamespace.GetName(), strategyNew.DeploymentSpecs[0].Name)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(depUpdated).ShouldNot(BeNil())
 				// container name has been updated and differs from initial CSV spec and updated CSV spec
@@ -3738,7 +3737,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 					},
 				},
 			}
-			csv.SetNamespace(ns.GetName())
+			csv.SetNamespace(generatedNamespace.GetName())
 			csv.SetName(genName("csv-"))
 
 			clientCtx := context.Background()
@@ -3750,7 +3749,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 
 			// Watch latest events from test namespace for CSV
 			listOpts.ResourceVersion = events.ResourceVersion
-			w, err := c.KubernetesInterface().CoreV1().Events(ns.GetName()).Watch(context.Background(), listOpts)
+			w, err := c.KubernetesInterface().CoreV1().Events(generatedNamespace.GetName()).Watch(context.Background(), listOpts)
 			Expect(err).ToNot(HaveOccurred())
 			defer w.Stop()
 
@@ -3870,7 +3869,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), true, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), true, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
@@ -3893,7 +3892,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				return false
 			}
 
-			fetchedCSV, err := fetchCSV(crc, csv.Name, ns.GetName(), csvCheckPhaseAndRequirementStatus)
+			fetchedCSV, err := fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvCheckPhaseAndRequirementStatus)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			Expect(fetchedCSV.Status.RequirementStatus).Should(ContainElement(notServedStatus))
@@ -3964,19 +3963,19 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 			csv.SetName("csv-hat-1")
-			csv.SetNamespace(ns.GetName())
+			csv.SetNamespace(generatedNamespace.GetName())
 
-			createLegacyAPIResources(ns.GetName(), &csv, owned[0], c)
+			createLegacyAPIResources(generatedNamespace.GetName(), &csv, owned[0], c)
 
 			// Create the APIService CSV
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			checkLegacyAPIResources(ns.GetName(), owned[0], true, c)
+			checkLegacyAPIResources(generatedNamespace.GetName(), owned[0], true, c)
 		})
 
 		It("API service resource not migrated if not adoptable", func() {
@@ -4044,22 +4043,22 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 			csv.SetName("csv-hat-1")
-			csv.SetNamespace(ns.GetName())
+			csv.SetNamespace(generatedNamespace.GetName())
 
-			createLegacyAPIResources(ns.GetName(), nil, owned[0], c)
+			createLegacyAPIResources(generatedNamespace.GetName(), nil, owned[0], c)
 
 			// Create the APIService CSV
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			checkLegacyAPIResources(ns.GetName(), owned[0], false, c)
+			checkLegacyAPIResources(generatedNamespace.GetName(), owned[0], false, c)
 
 			// Cleanup the resources created for this test that were not cleaned up.
-			deleteLegacyAPIResources(ns.GetName(), owned[0], c)
+			deleteLegacyAPIResources(generatedNamespace.GetName(), owned[0], c)
 		})
 
 		It("multiple API services on a single pod", func() {
@@ -4161,14 +4160,14 @@ var _ = Describe("ClusterServiceVersion", func() {
 				},
 			}
 			csv.SetName("csv-hat-1")
-			csv.SetNamespace(ns.GetName())
+			csv.SetNamespace(generatedNamespace.GetName())
 
 			// Create the APIService CSV
-			cleanupCSV, err := createCSV(c, crc, csv, ns.GetName(), false, false)
+			cleanupCSV, err := createCSV(c, crc, csv, generatedNamespace.GetName(), false, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			defer cleanupCSV()
 
-			_, err = fetchCSV(crc, csv.Name, ns.GetName(), csvSucceededChecker)
+			_, err = fetchCSV(crc, csv.Name, generatedNamespace.GetName(), csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Check that the APIService caBundles are equal

--- a/staging/operator-lifecycle-manager/test/e2e/deprecated_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/deprecated_e2e_test.go
@@ -19,7 +19,7 @@ import (
 var missingAPI = `{"apiVersion":"verticalpodautoscalers.autoscaling.k8s.io/v1","kind":"VerticalPodAutoscaler","metadata":{"name":"my.thing","namespace":"foo"}}`
 
 var _ = Describe("Not found APIs", func() {
-	var ns corev1.Namespace
+	var generatedNamespace corev1.Namespace
 
 	BeforeEach(func() {
 		namespaceName := genName("deprecated-e2e-")
@@ -29,14 +29,14 @@ var _ = Describe("Not found APIs", func() {
 				Namespace: namespaceName,
 			},
 		}
-		ns = SetupGeneratedTestNamespaceWithOperatorGroup(namespaceName, og)
+		generatedNamespace = SetupGeneratedTestNamespaceWithOperatorGroup(namespaceName, og)
 
-		csv := newCSV("test-csv", ns.GetName(), "", semver.Version{}, nil, nil, nil)
+		csv := newCSV("test-csv", generatedNamespace.GetName(), "", semver.Version{}, nil, nil, nil)
 		Expect(ctx.Ctx().Client().Create(context.TODO(), &csv)).To(Succeed())
 	})
 
 	AfterEach(func() {
-		TeardownNamespace(ns.GetName())
+		TeardownNamespace(generatedNamespace.GetName())
 	})
 
 	Context("objects with APIs that are not on-cluster are created in the installplan", func() {
@@ -45,7 +45,7 @@ var _ = Describe("Not found APIs", func() {
 				ip := &operatorsv1alpha1.InstallPlan{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-plan-api",
-						Namespace: ns.GetName(),
+						Namespace: generatedNamespace.GetName(),
 					},
 					Spec: operatorsv1alpha1.InstallPlanSpec{
 						Approval:                   operatorsv1alpha1.ApprovalAutomatic,

--- a/staging/operator-lifecycle-manager/test/e2e/disabling_copied_csv_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/disabling_copied_csv_e2e_test.go
@@ -28,21 +28,21 @@ const (
 
 var _ = Describe("Disabling copied CSVs", func() {
 	var (
-		ns                              corev1.Namespace
+		generatedNamespace              corev1.Namespace
 		csv                             operatorsv1alpha1.ClusterServiceVersion
 		nonTerminatingNamespaceSelector = fields.ParseSelectorOrDie("status.phase!=Terminating")
 		protectedCopiedCSVNamespaces    = map[string]struct{}{}
 	)
 
 	BeforeEach(func() {
-		nsname := genName("csv-toggle-test-")
+		nsname := genName("disabling-copied-csv-e2e-")
 		og := operatorsv1.OperatorGroup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("%s-operatorgroup", nsname),
 				Namespace: nsname,
 			},
 		}
-		ns = SetupGeneratedTestNamespaceWithOperatorGroup(nsname, og)
+		generatedNamespace = SetupGeneratedTestNamespaceWithOperatorGroup(nsname, og)
 
 		csv = operatorsv1alpha1.ClusterServiceVersion{
 			ObjectMeta: metav1.ObjectMeta{
@@ -67,7 +67,7 @@ var _ = Describe("Disabling copied CSVs", func() {
 		Eventually(func() error {
 			return client.IgnoreNotFound(ctx.Ctx().Client().Delete(context.Background(), &csv))
 		}).Should(Succeed())
-		TeardownNamespace(ns.GetName())
+		TeardownNamespace(generatedNamespace.GetName())
 	})
 
 	When("an operator is installed in AllNamespace mode", func() {

--- a/staging/operator-lifecycle-manager/test/e2e/gc_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/gc_e2e_test.go
@@ -25,9 +25,9 @@ import (
 
 var _ = Describe("Garbage collection for dependent resources", func() {
 	var (
-		kubeClient     operatorclient.ClientInterface
-		operatorClient versioned.Interface
-		ns             corev1.Namespace
+		kubeClient         operatorclient.ClientInterface
+		operatorClient     versioned.Interface
+		generatedNamespace corev1.Namespace
 	)
 
 	BeforeEach(func() {
@@ -35,11 +35,11 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 		operatorClient = ctx.Ctx().OperatorClient()
 
 		namespaceName := genName("gc-e2e-")
-		ns = SetupGeneratedTestNamespace(namespaceName, namespaceName)
+		generatedNamespace = SetupGeneratedTestNamespace(namespaceName, namespaceName)
 	})
 
 	AfterEach(func() {
-		TeardownNamespace(ns.GetName())
+		TeardownNamespace(generatedNamespace.GetName())
 	})
 
 	Context("Given a ClusterRole owned by a CustomResourceDefinition", func() {
@@ -218,18 +218,18 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 
 		BeforeEach(func() {
 
-			ownerA = newCSV("ownera", ns.GetName(), "", semver.MustParse("0.0.0"), nil, nil, nil)
-			ownerB = newCSV("ownerb", ns.GetName(), "", semver.MustParse("0.0.0"), nil, nil, nil)
+			ownerA = newCSV("ownera", generatedNamespace.GetName(), "", semver.MustParse("0.0.0"), nil, nil, nil)
+			ownerB = newCSV("ownerb", generatedNamespace.GetName(), "", semver.MustParse("0.0.0"), nil, nil, nil)
 
 			// create all owners
 			var err error
 			Eventually(func() error {
-				fetchedA, err = operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Create(context.Background(), &ownerA, metav1.CreateOptions{})
+				fetchedA, err = operatorClient.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Create(context.Background(), &ownerA, metav1.CreateOptions{})
 				return err
 			}).Should(Succeed())
 
 			Eventually(func() error {
-				fetchedB, err = operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Create(context.Background(), &ownerB, metav1.CreateOptions{})
+				fetchedB, err = operatorClient.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Create(context.Background(), &ownerB, metav1.CreateOptions{})
 				return err
 			}).Should(Succeed())
 
@@ -246,7 +246,7 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 
 			// create ConfigMap dependent
 			Eventually(func() error {
-				_, err = kubeClient.KubernetesInterface().CoreV1().ConfigMaps(ns.GetName()).Create(context.Background(), dependent, metav1.CreateOptions{})
+				_, err = kubeClient.KubernetesInterface().CoreV1().ConfigMaps(generatedNamespace.GetName()).Create(context.Background(), dependent, metav1.CreateOptions{})
 				return err
 			}).Should(Succeed(), "dependent could not be created")
 
@@ -259,20 +259,20 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 			BeforeEach(func() {
 				// delete ownerA in the foreground (to ensure any "blocking" dependents are deleted before ownerA)
 				Eventually(func() bool {
-					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Delete(context.Background(), fetchedA.GetName(), options)
+					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Delete(context.Background(), fetchedA.GetName(), options)
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// wait for deletion of ownerA
 				Eventually(func() bool {
-					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Get(context.Background(), ownerA.GetName(), metav1.GetOptions{})
+					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Get(context.Background(), ownerA.GetName(), metav1.GetOptions{})
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 			})
 
 			It("should not have deleted the dependent since ownerB CSV is still present", func() {
 				Eventually(func() error {
-					_, err := kubeClient.KubernetesInterface().CoreV1().ConfigMaps(ns.GetName()).Get(context.Background(), dependent.GetName(), metav1.GetOptions{})
+					_, err := kubeClient.KubernetesInterface().CoreV1().ConfigMaps(generatedNamespace.GetName()).Get(context.Background(), dependent.GetName(), metav1.GetOptions{})
 					return err
 				}).Should(Succeed(), "dependent deleted after one of the owner was deleted")
 				ctx.Ctx().Logf("dependent still exists after one owner was deleted")
@@ -284,32 +284,32 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 			BeforeEach(func() {
 				// delete ownerA in the foreground (to ensure any "blocking" dependents are deleted before ownerA)
 				Eventually(func() bool {
-					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Delete(context.Background(), fetchedA.GetName(), options)
+					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Delete(context.Background(), fetchedA.GetName(), options)
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// wait for deletion of ownerA
 				Eventually(func() bool {
-					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Get(context.Background(), ownerA.GetName(), metav1.GetOptions{})
+					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Get(context.Background(), ownerA.GetName(), metav1.GetOptions{})
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// delete ownerB in the foreground (to ensure any "blocking" dependents are deleted before ownerB)
 				Eventually(func() bool {
-					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Delete(context.Background(), fetchedB.GetName(), options)
+					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Delete(context.Background(), fetchedB.GetName(), options)
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// wait for deletion of ownerB
 				Eventually(func() bool {
-					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Get(context.Background(), ownerB.GetName(), metav1.GetOptions{})
+					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Get(context.Background(), ownerB.GetName(), metav1.GetOptions{})
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 			})
 
 			It("should have deleted the dependent since both the owners were deleted", func() {
 				Eventually(func() bool {
-					_, err := kubeClient.KubernetesInterface().CoreV1().ConfigMaps(ns.GetName()).Get(context.Background(), dependent.GetName(), metav1.GetOptions{})
+					_, err := kubeClient.KubernetesInterface().CoreV1().ConfigMaps(generatedNamespace.GetName()).Get(context.Background(), dependent.GetName(), metav1.GetOptions{})
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue(), "expected dependency configmap would be properly garabage collected")
 				ctx.Ctx().Logf("dependent successfully garbage collected after both owners were deleted")
@@ -344,7 +344,7 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      sourceName,
-					Namespace: ns.GetName(),
+					Namespace: generatedNamespace.GetName(),
 					Labels:    map[string]string{"olm.catalogSource": sourceName},
 				},
 				Spec: v1alpha1.CatalogSourceSpec{
@@ -374,25 +374,25 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 			_ = createSubscriptionForCatalog(operatorClient, source.GetNamespace(), subName, source.GetName(), packageName, channelName, "", v1alpha1.ApprovalAutomatic)
 
 			// Wait for the Subscription to succeed
-			sub, err := fetchSubscription(operatorClient, ns.GetName(), subName, subscriptionStateAtLatestChecker)
+			sub, err := fetchSubscription(operatorClient, generatedNamespace.GetName(), subName, subscriptionStateAtLatestChecker)
 			Expect(err).ToNot(HaveOccurred(), "could not get subscription at latest status")
 
 			installPlanRef = sub.Status.InstallPlanRef.Name
 
 			// Wait for the installplan to complete (5 minute timeout)
-			_, err = fetchInstallPlan(GinkgoT(), operatorClient, installPlanRef, ns.GetName(), buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete))
+			_, err = fetchInstallPlan(GinkgoT(), operatorClient, installPlanRef, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete))
 			Expect(err).ToNot(HaveOccurred(), "could not get installplan at complete phase")
 
 			ctx.Ctx().Logf("install plan %s completed", installPlanRef)
 
 			// confirm extra bundle objects (secret and configmap) are installed
 			Eventually(func() error {
-				_, err := kubeClient.GetSecret(ns.GetName(), secretName)
+				_, err := kubeClient.GetSecret(generatedNamespace.GetName(), secretName)
 				return err
 			}).Should(Succeed(), "expected no error getting secret object associated with CSV")
 
 			Eventually(func() error {
-				_, err := kubeClient.GetConfigMap(ns.GetName(), configmapName)
+				_, err := kubeClient.GetConfigMap(generatedNamespace.GetName(), configmapName)
 				return err
 			}).Should(Succeed(), "expected no error getting configmap object associated with CSV")
 		})
@@ -404,25 +404,25 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 			BeforeEach(func() {
 				// Delete subscription first
 				Eventually(func() bool {
-					err := operatorClient.OperatorsV1alpha1().Subscriptions(ns.GetName()).Delete(context.Background(), subName, metav1.DeleteOptions{})
+					err := operatorClient.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).Delete(context.Background(), subName, metav1.DeleteOptions{})
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// wait for deletion
 				Eventually(func() bool {
-					_, err := operatorClient.OperatorsV1alpha1().Subscriptions(ns.GetName()).Get(context.Background(), subName, metav1.GetOptions{})
+					_, err := operatorClient.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).Get(context.Background(), subName, metav1.GetOptions{})
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// Delete CSV
 				Eventually(func() bool {
-					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Delete(context.Background(), csvName, metav1.DeleteOptions{})
+					err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Delete(context.Background(), csvName, metav1.DeleteOptions{})
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				// wait for deletion
 				Eventually(func() bool {
-					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Get(context.Background(), csvName, metav1.GetOptions{})
+					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Get(context.Background(), csvName, metav1.GetOptions{})
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 			})
@@ -430,12 +430,12 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 			It("OLM should delete the associated configmap and secret", func() {
 				// confirm extra bundle objects (secret and configmap) are no longer installed on the cluster
 				Eventually(func() bool {
-					_, err := kubeClient.GetSecret(ns.GetName(), secretName)
+					_, err := kubeClient.GetSecret(generatedNamespace.GetName(), secretName)
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				Eventually(func() bool {
-					_, err := kubeClient.GetConfigMap(ns.GetName(), configmapName)
+					_, err := kubeClient.GetConfigMap(generatedNamespace.GetName(), configmapName)
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 				ctx.Ctx().Logf("dependent successfully garbage collected after csv owner was deleted")
@@ -467,7 +467,7 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      sourceName,
-					Namespace: ns.GetName(),
+					Namespace: generatedNamespace.GetName(),
 					Labels:    map[string]string{"olm.catalogSource": sourceName},
 				},
 				Spec: v1alpha1.CatalogSourceSpec{
@@ -493,17 +493,17 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 			_ = createSubscriptionForCatalog(operatorClient, source.GetNamespace(), subName, source.GetName(), packageName, channelName, "", v1alpha1.ApprovalAutomatic)
 
 			// Wait for the Subscription to succeed
-			sub, err := fetchSubscription(operatorClient, ns.GetName(), subName, subscriptionStateAtLatestChecker)
+			sub, err := fetchSubscription(operatorClient, generatedNamespace.GetName(), subName, subscriptionStateAtLatestChecker)
 			Expect(err).ToNot(HaveOccurred(), "could not get subscription at latest status")
 
 			installPlanRef = sub.Status.InstallPlanRef.Name
 
 			// Wait for the installplan to complete (5 minute timeout)
-			_, err = fetchInstallPlan(GinkgoT(), operatorClient, installPlanRef, ns.GetName(), buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete))
+			_, err = fetchInstallPlan(GinkgoT(), operatorClient, installPlanRef, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete))
 			Expect(err).ToNot(HaveOccurred(), "could not get installplan at complete phase")
 
 			Eventually(func() error {
-				_, err := kubeClient.GetConfigMap(ns.GetName(), configmapName)
+				_, err := kubeClient.GetConfigMap(generatedNamespace.GetName(), configmapName)
 				return err
 			}).Should(Succeed(), "expected no error getting configmap object associated with CSV")
 		})
@@ -519,36 +519,36 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 			BeforeEach(func() {
 				Eventually(func() error {
 					// update subscription first
-					sub, err := operatorClient.OperatorsV1alpha1().Subscriptions(ns.GetName()).Get(context.Background(), subName, metav1.GetOptions{})
+					sub, err := operatorClient.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).Get(context.Background(), subName, metav1.GetOptions{})
 					if err != nil {
 						return fmt.Errorf("could not get subscription")
 					}
 					// update channel on sub
 					sub.Spec.Channel = upgradeChannelName
-					_, err = operatorClient.OperatorsV1alpha1().Subscriptions(ns.GetName()).Update(context.Background(), sub, metav1.UpdateOptions{})
+					_, err = operatorClient.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).Update(context.Background(), sub, metav1.UpdateOptions{})
 					return err
 				}).Should(Succeed(), "could not update subscription")
 
 				// Wait for the Subscription to succeed
-				sub, err := fetchSubscription(operatorClient, ns.GetName(), subName, subscriptionStateAtLatestChecker)
+				sub, err := fetchSubscription(operatorClient, generatedNamespace.GetName(), subName, subscriptionStateAtLatestChecker)
 				Expect(err).ToNot(HaveOccurred(), "could not get subscription at latest status")
 
 				installPlanRef = sub.Status.InstallPlanRef.Name
 
 				// Wait for the installplan to complete (5 minute timeout)
-				_, err = fetchInstallPlan(GinkgoT(), operatorClient, installPlanRef, ns.GetName(), buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete))
+				_, err = fetchInstallPlan(GinkgoT(), operatorClient, installPlanRef, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete))
 				Expect(err).ToNot(HaveOccurred(), "could not get installplan at complete phase")
 
 				// Ensure the new csv is installed
 				Eventually(func() error {
-					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Get(context.Background(), newCSVname, metav1.GetOptions{})
+					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Get(context.Background(), newCSVname, metav1.GetOptions{})
 					return err
 				}).Should(BeNil())
 			})
 
 			It("OLM should have upgraded associated configmap in place", func() {
 				Eventually(func() (string, error) {
-					cfg, err := kubeClient.GetConfigMap(ns.GetName(), configmapName)
+					cfg, err := kubeClient.GetConfigMap(generatedNamespace.GetName(), configmapName)
 					if err != nil {
 						return "", err
 					}
@@ -585,7 +585,7 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      sourceName,
-					Namespace: ns.GetName(),
+					Namespace: generatedNamespace.GetName(),
 					Labels:    map[string]string{"olm.catalogSource": sourceName},
 				},
 				Spec: v1alpha1.CatalogSourceSpec{
@@ -611,17 +611,17 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 			_ = createSubscriptionForCatalog(operatorClient, source.GetNamespace(), subName, source.GetName(), packageName, channelName, "", v1alpha1.ApprovalAutomatic)
 
 			// Wait for the Subscription to succeed
-			sub, err := fetchSubscription(operatorClient, ns.GetName(), subName, subscriptionStateAtLatestChecker)
+			sub, err := fetchSubscription(operatorClient, generatedNamespace.GetName(), subName, subscriptionStateAtLatestChecker)
 			Expect(err).ToNot(HaveOccurred(), "could not get subscription at latest status")
 
 			installPlanRef = sub.Status.InstallPlanRef.Name
 
 			// Wait for the installplan to complete (5 minute timeout)
-			_, err = fetchInstallPlan(GinkgoT(), operatorClient, installPlanRef, ns.GetName(), buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete))
+			_, err = fetchInstallPlan(GinkgoT(), operatorClient, installPlanRef, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete))
 			Expect(err).ToNot(HaveOccurred(), "could not get installplan at complete phase")
 
 			Eventually(func() error {
-				_, err := kubeClient.GetConfigMap(ns.GetName(), configmapName)
+				_, err := kubeClient.GetConfigMap(generatedNamespace.GetName(), configmapName)
 				return err
 			}).Should(Succeed(), "expected no error getting configmap object associated with CSV")
 		})
@@ -638,29 +638,29 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 			BeforeEach(func() {
 				Eventually(func() error {
 					// update subscription first
-					sub, err := operatorClient.OperatorsV1alpha1().Subscriptions(ns.GetName()).Get(context.Background(), subName, metav1.GetOptions{})
+					sub, err := operatorClient.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).Get(context.Background(), subName, metav1.GetOptions{})
 					if err != nil {
 						return fmt.Errorf("could not get subscription")
 					}
 					// update channel on sub
 					sub.Spec.Channel = upgradeChannelName
-					_, err = operatorClient.OperatorsV1alpha1().Subscriptions(ns.GetName()).Update(context.Background(), sub, metav1.UpdateOptions{})
+					_, err = operatorClient.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).Update(context.Background(), sub, metav1.UpdateOptions{})
 					return err
 				}).Should(Succeed(), "could not update subscription")
 
 				// Wait for the Subscription to succeed
-				sub, err := fetchSubscription(operatorClient, ns.GetName(), subName, subscriptionStateAtLatestChecker)
+				sub, err := fetchSubscription(operatorClient, generatedNamespace.GetName(), subName, subscriptionStateAtLatestChecker)
 				Expect(err).ToNot(HaveOccurred(), "could not get subscription at latest status")
 
 				installPlanRef = sub.Status.InstallPlanRef.Name
 
 				// Wait for the installplan to complete (5 minute timeout)
-				_, err = fetchInstallPlan(GinkgoT(), operatorClient, installPlanRef, ns.GetName(), buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete))
+				_, err = fetchInstallPlan(GinkgoT(), operatorClient, installPlanRef, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(v1alpha1.InstallPlanPhaseComplete))
 				Expect(err).ToNot(HaveOccurred(), "could not get installplan at complete phase")
 
 				// Ensure the new csv is installed
 				Eventually(func() error {
-					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Get(context.Background(), newCSVname, metav1.GetOptions{})
+					_, err := operatorClient.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Get(context.Background(), newCSVname, metav1.GetOptions{})
 					return err
 				}).Should(BeNil())
 			})
@@ -668,12 +668,12 @@ var _ = Describe("Garbage collection for dependent resources", func() {
 			// flake issue: https://github.com/operator-framework/operator-lifecycle-manager/issues/2626
 			It("[FLAKE] should have removed the old configmap and put the new configmap in place", func() {
 				Eventually(func() bool {
-					_, err := kubeClient.GetConfigMap(ns.GetName(), configmapName)
+					_, err := kubeClient.GetConfigMap(generatedNamespace.GetName(), configmapName)
 					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				Eventually(func() error {
-					_, err := kubeClient.GetConfigMap(ns.GetName(), upgradedConfigMapName)
+					_, err := kubeClient.GetConfigMap(generatedNamespace.GetName(), upgradedConfigMapName)
 					return err
 				}).Should(BeNil())
 				ctx.Ctx().Logf("dependent successfully updated after csv owner was updated")

--- a/staging/operator-lifecycle-manager/test/e2e/installplan_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/installplan_e2e_test.go
@@ -3077,22 +3077,6 @@ var _ = Describe("Install Plan", func() {
 			GinkgoT().Logf("%s: %s", time.Now().Format("15:04:05.9999"), s)
 		}
 
-		ns := &corev1.Namespace{}
-		ns.SetName(genName("ns-"))
-
-		// Create a namespace an OperatorGroup
-		ns, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
-		require.NoError(GinkgoT(), err)
-		deleteOpts := &metav1.DeleteOptions{}
-		defer func() {
-			require.NoError(GinkgoT(), c.KubernetesInterface().CoreV1().Namespaces().Delete(context.Background(), generatedNamespace.GetName(), *deleteOpts))
-		}()
-
-		og := &operatorsv1.OperatorGroup{}
-		og.SetName("og")
-		_, err = crc.OperatorsV1().OperatorGroups(generatedNamespace.GetName()).Create(context.Background(), og, metav1.CreateOptions{})
-		require.NoError(GinkgoT(), err)
-
 		mainPackageName := genName("nginx-")
 		dependentPackageName := genName("nginxdep-")
 
@@ -3211,6 +3195,7 @@ var _ = Describe("Install Plan", func() {
 		require.NoError(GinkgoT(), err)
 
 		// Make sure to clean up the installed CRD
+		deleteOpts := &metav1.DeleteOptions{}
 		defer func() {
 			require.NoError(GinkgoT(), c.ApiextensionsInterface().ApiextensionsV1().CustomResourceDefinitions().Delete(context.Background(), dependentCRD.GetName(), *deleteOpts))
 		}()
@@ -3224,17 +3209,11 @@ var _ = Describe("Install Plan", func() {
 	When("an InstallPlan is created with no valid OperatorGroup present", func() {
 		var (
 			installPlanName string
-			ns              *corev1.Namespace
 		)
 
 		BeforeEach(func() {
-			ns = &corev1.Namespace{}
-			ns.SetName(genName("ns-"))
-
-			// Create a namespace
-			Eventually(func() error {
-				return ctx.Ctx().Client().Create(context.Background(), ns)
-			}, timeout, interval).Should(Succeed(), "could not create Namespace")
+			// Make sure there are no OGs in the namespace already
+			require.NoError(GinkgoT(), crc.OperatorsV1().OperatorGroups(generatedNamespace.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 
 			// Create InstallPlan
 			installPlanName = "ip"
@@ -3253,8 +3232,6 @@ var _ = Describe("Install Plan", func() {
 		AfterEach(func() {
 			err := crc.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).Delete(context.Background(), installPlanName, metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			err = c.KubernetesInterface().CoreV1().Namespaces().Delete(context.Background(), generatedNamespace.GetName(), metav1.DeleteOptions{})
-			Expect(err).ToNot(HaveOccurred())
 		})
 
 		// issue: https://github.com/operator-framework/operator-lifecycle-manager/issues/2636

--- a/staging/operator-lifecycle-manager/test/e2e/installplan_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/installplan_e2e_test.go
@@ -56,9 +56,9 @@ const (
 
 var _ = Describe("Install Plan", func() {
 	var (
-		c   operatorclient.ClientInterface
-		crc versioned.Interface
-		ns  corev1.Namespace
+		c                  operatorclient.ClientInterface
+		crc                versioned.Interface
+		generatedNamespace corev1.Namespace
 	)
 
 	BeforeEach(func() {
@@ -69,13 +69,13 @@ var _ = Describe("Install Plan", func() {
 				Namespace: namespaceName,
 			},
 		}
-		ns = SetupGeneratedTestNamespaceWithOperatorGroup(namespaceName, og)
+		generatedNamespace = SetupGeneratedTestNamespaceWithOperatorGroup(namespaceName, og)
 		c = ctx.Ctx().KubeClient()
 		crc = ctx.Ctx().OperatorClient()
 	})
 
 	AfterEach(func() {
-		TeardownNamespace(ns.GetName())
+		TeardownNamespace(generatedNamespace.GetName())
 	})
 
 	When("an InstallPlan step contains a deprecated resource version", func() {
@@ -111,10 +111,10 @@ var _ = Describe("Install Plan", func() {
 
 			Expect(ctx.Ctx().Client().Create(context.Background(), deprecatedCRD)).To(Succeed())
 
-			csv = newCSV(genName("test-csv-"), ns.GetName(), "", semver.Version{}, nil, nil, nil)
+			csv = newCSV(genName("test-csv-"), generatedNamespace.GetName(), "", semver.Version{}, nil, nil, nil)
 			Expect(ctx.Ctx().Client().Create(context.Background(), &csv)).To(Succeed())
 
-			deprecated, err = util.DecodeFile(filepath.Join(testdataDir, deprecatedCRDDir, "deprecated.cr.yaml"), &unstructured.Unstructured{}, util.WithNamespace(ns.GetName()))
+			deprecated, err = util.DecodeFile(filepath.Join(testdataDir, deprecatedCRDDir, "deprecated.cr.yaml"), &unstructured.Unstructured{}, util.WithNamespace(generatedNamespace.GetName()))
 			Expect(err).NotTo(HaveOccurred())
 
 			scheme := runtime.NewScheme()
@@ -126,7 +126,7 @@ var _ = Describe("Install Plan", func() {
 
 			plan = operatorsv1alpha1.InstallPlan{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns.GetName(),
+					Namespace: generatedNamespace.GetName(),
 					Name:      genName("test-plan-"),
 				},
 				Spec: operatorsv1alpha1.InstallPlanSpec{
@@ -175,7 +175,7 @@ var _ = Describe("Install Plan", func() {
 		It("creates an Event surfacing the deprecation warning", func() {
 			Eventually(func() ([]corev1.Event, error) {
 				var events corev1.EventList
-				if err := ctx.Ctx().Client().List(context.Background(), &events, client.InNamespace(ns.GetName())); err != nil {
+				if err := ctx.Ctx().Client().List(context.Background(), &events, client.InNamespace(generatedNamespace.GetName())); err != nil {
 					return nil, err
 				}
 				var result []corev1.Event
@@ -197,7 +197,7 @@ var _ = Describe("Install Plan", func() {
 				InvolvedObject: corev1.ObjectReference{
 					APIVersion: operatorsv1alpha1.InstallPlanAPIVersion,
 					Kind:       operatorsv1alpha1.InstallPlanKind,
-					Namespace:  ns.GetName(),
+					Namespace:  generatedNamespace.GetName(),
 					Name:       plan.GetName(),
 					FieldPath:  "status.plan[0]",
 				},
@@ -223,7 +223,7 @@ var _ = Describe("Install Plan", func() {
 		)
 
 		BeforeEach(func() {
-			csv := newCSV("test-csv", ns.GetName(), "", semver.Version{}, nil, nil, nil)
+			csv := newCSV("test-csv", generatedNamespace.GetName(), "", semver.Version{}, nil, nil, nil)
 			Expect(ctx.Ctx().Client().Create(context.Background(), &csv)).To(Succeed())
 
 			crd = apiextensionsv1.CustomResourceDefinition{
@@ -266,7 +266,7 @@ var _ = Describe("Install Plan", func() {
 
 			plan := operatorsv1alpha1.InstallPlan{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns.GetName(),
+					Namespace: generatedNamespace.GetName(),
 					Name:      "test-plan",
 				},
 				Spec: operatorsv1alpha1.InstallPlanSpec{
@@ -312,7 +312,7 @@ var _ = Describe("Install Plan", func() {
 				return crd.GetAnnotations(), nil
 			}).Should(HaveKeyWithValue(
 				HavePrefix("operatorframework.io/installed-alongside-"),
-				fmt.Sprintf("%s/test-csv", ns.GetName()),
+				fmt.Sprintf("%s/test-csv", generatedNamespace.GetName()),
 			))
 		})
 
@@ -323,12 +323,12 @@ var _ = Describe("Install Plan", func() {
 			)
 
 			BeforeEach(func() {
-				csv = newCSV("test-csv-two", ns.GetName(), "", semver.Version{}, nil, nil, nil)
+				csv = newCSV("test-csv-two", generatedNamespace.GetName(), "", semver.Version{}, nil, nil, nil)
 				Expect(ctx.Ctx().Client().Create(context.Background(), &csv)).To(Succeed())
 
 				plan = operatorsv1alpha1.InstallPlan{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: ns.GetName(),
+						Namespace: generatedNamespace.GetName(),
 						Name:      "test-plan-two",
 					},
 					Spec: operatorsv1alpha1.InstallPlanSpec{
@@ -382,11 +382,11 @@ var _ = Describe("Install Plan", func() {
 				}).Should(ConsistOf(
 					MatchFields(IgnoreExtras, Fields{
 						"Key":   HavePrefix("operatorframework.io/installed-alongside-"),
-						"Value": Equal(fmt.Sprintf("%s/test-csv", ns.GetName())),
+						"Value": Equal(fmt.Sprintf("%s/test-csv", generatedNamespace.GetName())),
 					}),
 					MatchFields(IgnoreExtras, Fields{
 						"Key":   HavePrefix("operatorframework.io/installed-alongside-"),
-						"Value": Equal(fmt.Sprintf("%s/test-csv-two", ns.GetName())),
+						"Value": Equal(fmt.Sprintf("%s/test-csv-two", generatedNamespace.GetName())),
 					}),
 				))
 			})
@@ -407,7 +407,7 @@ var _ = Describe("Install Plan", func() {
 			// during a test.
 			owned = &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns.GetName(),
+					Namespace: generatedNamespace.GetName(),
 					Name:      "test-owned",
 					OwnerReferences: []metav1.OwnerReference{{
 						APIVersion: "operators.coreos.com/v1alpha1",
@@ -425,7 +425,7 @@ var _ = Describe("Install Plan", func() {
 
 			plan = &operatorsv1alpha1.InstallPlan{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns.GetName(),
+					Namespace: generatedNamespace.GetName(),
 					Name:      "test-plan",
 				},
 				Spec: operatorsv1alpha1.InstallPlanSpec{
@@ -474,7 +474,7 @@ var _ = Describe("Install Plan", func() {
 		})
 
 		It("succeeds if there is no error on a later attempt", func() {
-			owner := newCSV("test-owner", ns.GetName(), "", semver.Version{}, nil, nil, nil)
+			owner := newCSV("test-owner", generatedNamespace.GetName(), "", semver.Version{}, nil, nil, nil)
 			Expect(ctx.Ctx().Client().Create(context.Background(), &owner)).To(Succeed())
 			Eventually(func() (*operatorsv1alpha1.InstallPlan, error) {
 				return plan, ctx.Ctx().Client().Get(context.Background(), client.ObjectKeyFromObject(plan), plan)
@@ -490,14 +490,14 @@ var _ = Describe("Install Plan", func() {
 		)
 
 		BeforeEach(func() {
-			csv1 = newCSV("test-csv-old", ns.GetName(), "", semver.Version{}, nil, nil, nil)
+			csv1 = newCSV("test-csv-old", generatedNamespace.GetName(), "", semver.Version{}, nil, nil, nil)
 			Expect(ctx.Ctx().Client().Create(context.Background(), &csv1)).To(Succeed())
-			csv2 = newCSV("test-csv-new", ns.GetName(), "", semver.Version{}, nil, nil, nil)
+			csv2 = newCSV("test-csv-new", generatedNamespace.GetName(), "", semver.Version{}, nil, nil, nil)
 			Expect(ctx.Ctx().Client().Create(context.Background(), &csv2)).To(Succeed())
 
 			sa = corev1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns.GetName(),
+					Namespace: generatedNamespace.GetName(),
 					Name:      "test-serviceaccount",
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -516,7 +516,7 @@ var _ = Describe("Install Plan", func() {
 			var manifest bytes.Buffer
 			Expect(k8sjson.NewSerializer(k8sjson.DefaultMetaFactory, scheme, scheme, false).Encode(&corev1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns.GetName(),
+					Namespace: generatedNamespace.GetName(),
 					Name:      "test-serviceaccount",
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -530,7 +530,7 @@ var _ = Describe("Install Plan", func() {
 
 			plan = operatorsv1alpha1.InstallPlan{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns.GetName(),
+					Namespace: generatedNamespace.GetName(),
 					Name:      "test-plan",
 				},
 				Spec: operatorsv1alpha1.InstallPlanSpec{
@@ -612,7 +612,7 @@ var _ = Describe("Install Plan", func() {
 					APIVersion: "v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns.GetName(),
+					Namespace: generatedNamespace.GetName(),
 					Name:      "test-service",
 				},
 				Spec: corev1.ServiceSpec{
@@ -640,7 +640,7 @@ var _ = Describe("Install Plan", func() {
 
 			plan := &operatorsv1alpha1.InstallPlan{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns.GetName(),
+					Namespace: generatedNamespace.GetName(),
 					Name:      "test-plan",
 				},
 				Spec: operatorsv1alpha1.InstallPlanSpec{
@@ -692,11 +692,11 @@ var _ = Describe("Install Plan", func() {
 		stableChannel := "stable"
 
 		dependentCRD := newCRD(genName("ins-"))
-		mainCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), nil, []apiextensions.CustomResourceDefinition{dependentCRD}, nil)
-		dependentCSV := newCSV(dependentPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{dependentCRD}, nil, nil)
+		mainCSV := newCSV(mainPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), nil, []apiextensions.CustomResourceDefinition{dependentCRD}, nil)
+		dependentCSV := newCSV(dependentPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{dependentCRD}, nil, nil)
 
 		defer func() {
-			require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(ns.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
+			require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 		}()
 
 		dependentCatalogName := genName("mock-ocs-dependent-")
@@ -731,48 +731,48 @@ var _ = Describe("Install Plan", func() {
 		}()
 
 		// Create the catalog sources
-		require.NotEqual(GinkgoT(), "", ns.GetName())
-		_, cleanupDependentCatalogSource := createInternalCatalogSource(c, crc, dependentCatalogName, ns.GetName(), dependentManifests, []apiextensions.CustomResourceDefinition{dependentCRD}, []operatorsv1alpha1.ClusterServiceVersion{dependentCSV})
+		require.NotEqual(GinkgoT(), "", generatedNamespace.GetName())
+		_, cleanupDependentCatalogSource := createInternalCatalogSource(c, crc, dependentCatalogName, generatedNamespace.GetName(), dependentManifests, []apiextensions.CustomResourceDefinition{dependentCRD}, []operatorsv1alpha1.ClusterServiceVersion{dependentCSV})
 		defer cleanupDependentCatalogSource()
 
 		// Attempt to get the catalog source before creating install plan
-		_, err := fetchCatalogSourceOnStatus(crc, dependentCatalogName, ns.GetName(), catalogSourceRegistryPodSynced)
+		_, err := fetchCatalogSourceOnStatus(crc, dependentCatalogName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 		require.NoError(GinkgoT(), err)
 
-		_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, ns.GetName(), mainManifests, nil, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
+		_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, generatedNamespace.GetName(), mainManifests, nil, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
 		defer cleanupMainCatalogSource()
 
 		// Attempt to get the catalog source before creating install plan
-		_, err = fetchCatalogSourceOnStatus(crc, mainCatalogName, ns.GetName(), catalogSourceRegistryPodSynced)
+		_, err = fetchCatalogSourceOnStatus(crc, mainCatalogName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 		require.NoError(GinkgoT(), err)
 
 		// Create expected install plan step sources
 		expectedStepSources := map[registry.ResourceKey]registry.ResourceKey{
-			{Name: dependentCRD.Name, Kind: "CustomResourceDefinition"}:                                                                               {Name: dependentCatalogName, Namespace: ns.GetName()},
-			{Name: dependentPackageStable, Kind: operatorsv1alpha1.ClusterServiceVersionKind}:                                                         {Name: dependentCatalogName, Namespace: ns.GetName()},
-			{Name: mainPackageStable, Kind: operatorsv1alpha1.ClusterServiceVersionKind}:                                                              {Name: mainCatalogName, Namespace: ns.GetName()},
-			{Name: strings.Join([]string{dependentPackageStable, dependentCatalogName, ns.GetName()}, "-"), Kind: operatorsv1alpha1.SubscriptionKind}: {Name: dependentCatalogName, Namespace: ns.GetName()},
+			{Name: dependentCRD.Name, Kind: "CustomResourceDefinition"}:                                                                                               {Name: dependentCatalogName, Namespace: generatedNamespace.GetName()},
+			{Name: dependentPackageStable, Kind: operatorsv1alpha1.ClusterServiceVersionKind}:                                                                         {Name: dependentCatalogName, Namespace: generatedNamespace.GetName()},
+			{Name: mainPackageStable, Kind: operatorsv1alpha1.ClusterServiceVersionKind}:                                                                              {Name: mainCatalogName, Namespace: generatedNamespace.GetName()},
+			{Name: strings.Join([]string{dependentPackageStable, dependentCatalogName, generatedNamespace.GetName()}, "-"), Kind: operatorsv1alpha1.SubscriptionKind}: {Name: dependentCatalogName, Namespace: generatedNamespace.GetName()},
 		}
 
 		subscriptionName := genName("sub-nginx-")
-		subscriptionCleanup := createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+		subscriptionCleanup := createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 		defer subscriptionCleanup()
 
-		subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
+		subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
 
 		installPlanName := subscription.Status.InstallPlanRef.Name
 
 		// Wait for InstallPlan to be status: Complete before checking resource presence
-		fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
+		fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
 		require.NoError(GinkgoT(), err)
 		log(fmt.Sprintf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase))
 
 		require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
 
 		// Fetch installplan again to check for unnecessary control loops
-		fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, fetchedInstallPlan.GetName(), ns.GetName(), func(fip *operatorsv1alpha1.InstallPlan) bool {
+		fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, fetchedInstallPlan.GetName(), generatedNamespace.GetName(), func(fip *operatorsv1alpha1.InstallPlan) bool {
 			// Don't compare object meta as labels can be applied by the operator controller.
 			Expect(equality.Semantic.DeepEqual(fetchedInstallPlan.Spec, fip.Spec)).Should(BeTrue(), diff.ObjectDiff(fetchedInstallPlan, fip))
 			Expect(equality.Semantic.DeepEqual(fetchedInstallPlan.Status, fip.Status)).Should(BeTrue(), diff.ObjectDiff(fetchedInstallPlan, fip))
@@ -806,18 +806,18 @@ var _ = Describe("Install Plan", func() {
 		log("All expected resources resolved")
 
 		// Verify that the dependent subscription is in a good state
-		dependentSubscription, err := fetchSubscription(crc, ns.GetName(), strings.Join([]string{dependentPackageStable, dependentCatalogName, ns.GetName()}, "-"), subscriptionStateAtLatestChecker)
+		dependentSubscription, err := fetchSubscription(crc, generatedNamespace.GetName(), strings.Join([]string{dependentPackageStable, dependentCatalogName, generatedNamespace.GetName()}, "-"), subscriptionStateAtLatestChecker)
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), dependentSubscription)
 		require.NotNil(GinkgoT(), dependentSubscription.Status.InstallPlanRef)
 		require.Equal(GinkgoT(), dependentCSV.GetName(), dependentSubscription.Status.CurrentCSV)
 
 		// Verify CSV is created
-		_, err = awaitCSV(crc, ns.GetName(), dependentCSV.GetName(), csvAnyChecker)
+		_, err = awaitCSV(crc, generatedNamespace.GetName(), dependentCSV.GetName(), csvAnyChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Update dependent subscription in catalog and wait for csv to update
-		updatedDependentCSV := newCSV(dependentPackageStable+"-v2", ns.GetName(), dependentPackageStable, semver.MustParse("0.1.1"), []apiextensions.CustomResourceDefinition{dependentCRD}, nil, nil)
+		updatedDependentCSV := newCSV(dependentPackageStable+"-v2", generatedNamespace.GetName(), dependentPackageStable, semver.MustParse("0.1.1"), []apiextensions.CustomResourceDefinition{dependentCRD}, nil, nil)
 		dependentManifests = []registry.PackageManifest{
 			{
 				PackageName: dependentPackageName,
@@ -828,20 +828,20 @@ var _ = Describe("Install Plan", func() {
 			},
 		}
 
-		updateInternalCatalog(GinkgoT(), c, crc, dependentCatalogName, ns.GetName(), []apiextensions.CustomResourceDefinition{dependentCRD}, []operatorsv1alpha1.ClusterServiceVersion{dependentCSV, updatedDependentCSV}, dependentManifests)
+		updateInternalCatalog(GinkgoT(), c, crc, dependentCatalogName, generatedNamespace.GetName(), []apiextensions.CustomResourceDefinition{dependentCRD}, []operatorsv1alpha1.ClusterServiceVersion{dependentCSV, updatedDependentCSV}, dependentManifests)
 
 		// Wait for subscription to update
-		updatedDepSubscription, err := fetchSubscription(crc, ns.GetName(), strings.Join([]string{dependentPackageStable, dependentCatalogName, ns.GetName()}, "-"), subscriptionHasCurrentCSV(updatedDependentCSV.GetName()))
+		updatedDepSubscription, err := fetchSubscription(crc, generatedNamespace.GetName(), strings.Join([]string{dependentPackageStable, dependentCatalogName, generatedNamespace.GetName()}, "-"), subscriptionHasCurrentCSV(updatedDependentCSV.GetName()))
 		require.NoError(GinkgoT(), err)
 
 		// Verify installplan created and installed
-		fetchedUpdatedDepInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, updatedDepSubscription.Status.InstallPlanRef.Name, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
+		fetchedUpdatedDepInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, updatedDepSubscription.Status.InstallPlanRef.Name, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
 		require.NoError(GinkgoT(), err)
 		log(fmt.Sprintf("Install plan %s fetched with status %s", fetchedUpdatedDepInstallPlan.GetName(), fetchedUpdatedDepInstallPlan.Status.Phase))
 		require.NotEqual(GinkgoT(), fetchedInstallPlan.GetName(), fetchedUpdatedDepInstallPlan.GetName())
 
 		// Wait for csv to update
-		_, err = awaitCSV(crc, ns.GetName(), updatedDependentCSV.GetName(), csvAnyChecker)
+		_, err = awaitCSV(crc, generatedNamespace.GetName(), updatedDependentCSV.GetName(), csvAnyChecker)
 		require.NoError(GinkgoT(), err)
 	})
 
@@ -884,10 +884,10 @@ var _ = Describe("Install Plan", func() {
 			dependentCRD := newCRD(genName("ins-"))
 
 			// Create new CSVs
-			mainStableCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{mainCRD}, []apiextensions.CustomResourceDefinition{dependentCRD}, nil)
-			mainBetaCSV := newCSV(mainPackageBeta, ns.GetName(), mainPackageStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{mainCRD}, []apiextensions.CustomResourceDefinition{dependentCRD}, nil)
-			dependentStableCSV := newCSV(dependentPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{dependentCRD}, nil, nil)
-			dependentBetaCSV := newCSV(dependentPackageBeta, ns.GetName(), dependentPackageStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{dependentCRD}, nil, nil)
+			mainStableCSV := newCSV(mainPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{mainCRD}, []apiextensions.CustomResourceDefinition{dependentCRD}, nil)
+			mainBetaCSV := newCSV(mainPackageBeta, generatedNamespace.GetName(), mainPackageStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{mainCRD}, []apiextensions.CustomResourceDefinition{dependentCRD}, nil)
+			dependentStableCSV := newCSV(dependentPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{dependentCRD}, nil, nil)
+			dependentBetaCSV := newCSV(dependentPackageBeta, generatedNamespace.GetName(), dependentPackageStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{dependentCRD}, nil, nil)
 
 			// Defer CRD clean up
 			defer func() {
@@ -900,16 +900,16 @@ var _ = Describe("Install Plan", func() {
 			}()
 
 			defer func() {
-				require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(ns.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
+				require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 			}()
 
 			// Create the catalog source
 			mainCatalogSourceName := genName("mock-ocs-main-" + strings.ToLower(K8sSafeCurrentTestDescription()) + "-")
-			_, cleanupCatalogSource := createInternalCatalogSource(c, crc, mainCatalogSourceName, ns.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{dependentCRD, mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{dependentBetaCSV, dependentStableCSV, mainStableCSV, mainBetaCSV})
+			_, cleanupCatalogSource := createInternalCatalogSource(c, crc, mainCatalogSourceName, generatedNamespace.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{dependentCRD, mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{dependentBetaCSV, dependentStableCSV, mainStableCSV, mainBetaCSV})
 			defer cleanupCatalogSource()
 
 			// Attempt to get the catalog source before creating install plan(s)
-			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, ns.GetName(), catalogSourceRegistryPodSynced)
+			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 			require.NoError(GinkgoT(), err)
 
 			expectedSteps := map[registry.ResourceKey]struct{}{
@@ -921,30 +921,30 @@ var _ = Describe("Install Plan", func() {
 			cleanupCRD, err := createCRD(c, dependentCRD)
 			require.NoError(GinkgoT(), err)
 			defer cleanupCRD()
-			cleanupCSV, err := createCSV(c, crc, dependentBetaCSV, ns.GetName(), true, false)
+			cleanupCSV, err := createCSV(c, crc, dependentBetaCSV, generatedNamespace.GetName(), true, false)
 			require.NoError(GinkgoT(), err)
 			defer cleanupCSV()
 			GinkgoT().Log("Dependent CRD and preexisting CSV created")
 
 			subscriptionName := genName("sub-nginx-")
-			subscriptionCleanup := createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, mainCatalogSourceName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+			subscriptionCleanup := createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, mainCatalogSourceName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 			defer subscriptionCleanup()
 
-			subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
+			subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
 			require.NoError(GinkgoT(), err)
 			require.NotNil(GinkgoT(), subscription)
 
 			installPlanName := subscription.Status.InstallPlanRef.Name
 
 			// Wait for InstallPlan to be status: Complete or Failed before checking resource presence
-			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete, operatorsv1alpha1.InstallPlanPhaseFailed))
+			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete, operatorsv1alpha1.InstallPlanPhaseFailed))
 			require.NoError(GinkgoT(), err)
 			GinkgoT().Logf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase)
 
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
 
 			// Fetch installplan again to check for unnecessary control loops
-			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, fetchedInstallPlan.GetName(), ns.GetName(), func(fip *operatorsv1alpha1.InstallPlan) bool {
+			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, fetchedInstallPlan.GetName(), generatedNamespace.GetName(), func(fip *operatorsv1alpha1.InstallPlan) bool {
 				Expect(equality.Semantic.DeepEqual(fetchedInstallPlan, fip)).Should(BeTrue(), diff.ObjectDiff(fetchedInstallPlan, fip))
 				return true
 			})
@@ -1295,8 +1295,8 @@ var _ = Describe("Install Plan", func() {
 			}
 
 			// Create new CSVs
-			mainStableCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{*tt.oldCRD}, nil, nil)
-			mainBetaCSV := newCSV(mainPackageBeta, ns.GetName(), mainPackageStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{*tt.oldCRD}, nil, nil)
+			mainStableCSV := newCSV(mainPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{*tt.oldCRD}, nil, nil)
+			mainBetaCSV := newCSV(mainPackageBeta, generatedNamespace.GetName(), mainPackageStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{*tt.oldCRD}, nil, nil)
 
 			// Defer CRD clean up
 			defer func() {
@@ -1319,7 +1319,7 @@ var _ = Describe("Install Plan", func() {
 					"apiVersion": "cluster.com/v1alpha1",
 					"kind":       tt.oldCRD.Spec.Names.Kind,
 					"metadata": map[string]interface{}{
-						"namespace": ns.GetName(),
+						"namespace": generatedNamespace.GetName(),
 						"name":      "my-cr-1",
 					},
 					"spec": map[string]interface{}{
@@ -1330,18 +1330,18 @@ var _ = Describe("Install Plan", func() {
 
 			// Create the catalog source
 			mainCatalogSourceName := genName("mock-ocs-main-")
-			_, cleanupCatalogSource := createInternalCatalogSource(c, crc, mainCatalogSourceName, ns.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{*tt.oldCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainStableCSV, mainBetaCSV})
+			_, cleanupCatalogSource := createInternalCatalogSource(c, crc, mainCatalogSourceName, generatedNamespace.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{*tt.oldCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainStableCSV, mainBetaCSV})
 			defer cleanupCatalogSource()
 
 			// Attempt to get the catalog source before creating install plan(s)
-			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, ns.GetName(), catalogSourceRegistryPodSynced)
+			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 			require.NoError(GinkgoT(), err)
 
 			subscriptionName := genName("sub-nginx-alpha-")
-			cleanupSubscription := createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, mainCatalogSourceName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+			cleanupSubscription := createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, mainCatalogSourceName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 			defer cleanupSubscription()
 
-			subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
+			subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
 			require.NoError(GinkgoT(), err)
 			require.NotNil(GinkgoT(), subscription)
 
@@ -1349,7 +1349,7 @@ var _ = Describe("Install Plan", func() {
 
 			// Wait for InstallPlan to be status: Complete or failed before checking resource presence
 			completeOrFailedFunc := buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete, operatorsv1alpha1.InstallPlanPhaseFailed)
-			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), completeOrFailedFunc)
+			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), completeOrFailedFunc)
 			require.NoError(GinkgoT(), err)
 			GinkgoT().Logf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase)
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
@@ -1378,44 +1378,44 @@ var _ = Describe("Install Plan", func() {
 			require.Equal(GinkgoT(), 0, len(expectedSteps), "Actual resource steps do not match expected")
 
 			// Create initial CR
-			cleanupCR, err := createCR(c, existingCR, "cluster.com", "v1alpha1", ns.GetName(), tt.oldCRD.Spec.Names.Plural, "my-cr-1")
+			cleanupCR, err := createCR(c, existingCR, "cluster.com", "v1alpha1", generatedNamespace.GetName(), tt.oldCRD.Spec.Names.Plural, "my-cr-1")
 			require.NoError(GinkgoT(), err)
 			defer cleanupCR()
 
-			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogSourceName, ns.GetName(), []apiextensions.CustomResourceDefinition{*tt.newCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainStableCSV, mainBetaCSV}, mainManifests)
+			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogSourceName, generatedNamespace.GetName(), []apiextensions.CustomResourceDefinition{*tt.newCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainStableCSV, mainBetaCSV}, mainManifests)
 
 			// Attempt to get the catalog source before creating install plan(s)
-			_, err = fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, ns.GetName(), catalogSourceRegistryPodSynced)
+			_, err = fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 			require.NoError(GinkgoT(), err)
 
 			// Update the subscription resource to point to the beta CSV
 			err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-				subscription, err = fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
+				subscription, err = fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
 				require.NoError(GinkgoT(), err)
 				require.NotNil(GinkgoT(), subscription)
 
 				subscription.Spec.Channel = betaChannel
-				subscription, err = crc.OperatorsV1alpha1().Subscriptions(ns.GetName()).Update(context.Background(), subscription, metav1.UpdateOptions{})
+				subscription, err = crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).Update(context.Background(), subscription, metav1.UpdateOptions{})
 
 				return err
 			})
 
 			// Wait for subscription to have a new installplan
-			subscription, err = fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(fetchedInstallPlan.GetName()))
+			subscription, err = fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(fetchedInstallPlan.GetName()))
 			require.NoError(GinkgoT(), err)
 			require.NotNil(GinkgoT(), subscription)
 
 			installPlanName = subscription.Status.InstallPlanRef.Name
 
 			// Wait for InstallPlan to be status: Complete or Failed before checking resource presence
-			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(tt.expectedPhase))
+			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(tt.expectedPhase))
 			require.NoError(GinkgoT(), err)
 			GinkgoT().Logf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase)
 
 			require.Equal(GinkgoT(), tt.expectedPhase, fetchedInstallPlan.Status.Phase)
 
 			// Ensure correct in-cluster resource(s)
-			fetchedCSV, err := fetchCSV(crc, mainBetaCSV.GetName(), ns.GetName(), csvAnyChecker)
+			fetchedCSV, err := fetchCSV(crc, mainBetaCSV.GetName(), generatedNamespace.GetName(), csvAnyChecker)
 			require.NoError(GinkgoT(), err)
 
 			GinkgoT().Logf("All expected resources resolved %s", fetchedCSV.Status.Phase)
@@ -1550,9 +1550,9 @@ var _ = Describe("Install Plan", func() {
 			}
 
 			// Create new CSVs
-			mainStableCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{*tt.oldCRD}, nil, nil)
-			mainBetaCSV := newCSV(mainPackageBeta, ns.GetName(), mainPackageStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{*tt.intermediateCRD}, nil, nil)
-			mainDeltaCSV := newCSV(mainPackageDelta, ns.GetName(), mainPackageBeta, semver.MustParse("0.3.0"), []apiextensions.CustomResourceDefinition{*tt.newCRD}, nil, nil)
+			mainStableCSV := newCSV(mainPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{*tt.oldCRD}, nil, nil)
+			mainBetaCSV := newCSV(mainPackageBeta, generatedNamespace.GetName(), mainPackageStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{*tt.intermediateCRD}, nil, nil)
+			mainDeltaCSV := newCSV(mainPackageDelta, generatedNamespace.GetName(), mainPackageBeta, semver.MustParse("0.3.0"), []apiextensions.CustomResourceDefinition{*tt.newCRD}, nil, nil)
 
 			// Defer CRD clean up
 			defer func() {
@@ -1578,19 +1578,19 @@ var _ = Describe("Install Plan", func() {
 
 			// Create the catalog source
 			mainCatalogSourceName := genName("mock-ocs-main-")
-			_, cleanupCatalogSource := createInternalCatalogSource(c, crc, mainCatalogSourceName, ns.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{*tt.oldCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainStableCSV})
+			_, cleanupCatalogSource := createInternalCatalogSource(c, crc, mainCatalogSourceName, generatedNamespace.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{*tt.oldCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainStableCSV})
 			defer cleanupCatalogSource()
 
 			// Attempt to get the catalog source before creating install plan(s)
-			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, ns.GetName(), catalogSourceRegistryPodSynced)
+			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 			require.NoError(GinkgoT(), err)
 
 			subscriptionName := genName("sub-nginx-")
 
 			// this subscription will be cleaned up below without the clean up function
-			createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, mainCatalogSourceName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+			createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, mainCatalogSourceName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 
-			subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
+			subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
 			require.NoError(GinkgoT(), err)
 			require.NotNil(GinkgoT(), subscription)
 
@@ -1598,7 +1598,7 @@ var _ = Describe("Install Plan", func() {
 
 			// Wait for InstallPlan to be status: Complete or failed before checking resource presence
 			completeOrFailedFunc := buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete, operatorsv1alpha1.InstallPlanPhaseFailed)
-			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), completeOrFailedFunc)
+			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), completeOrFailedFunc)
 			require.NoError(GinkgoT(), err)
 			GinkgoT().Logf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase)
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
@@ -1621,25 +1621,25 @@ var _ = Describe("Install Plan", func() {
 				},
 			}
 
-			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogSourceName, ns.GetName(), []apiextensions.CustomResourceDefinition{*tt.intermediateCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainStableCSV, mainBetaCSV}, mainManifests)
+			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogSourceName, generatedNamespace.GetName(), []apiextensions.CustomResourceDefinition{*tt.intermediateCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainStableCSV, mainBetaCSV}, mainManifests)
 			// Attempt to get the catalog source before creating install plan(s)
-			_, err = fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, ns.GetName(), catalogSourceRegistryPodSynced)
+			_, err = fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 			require.NoError(GinkgoT(), err)
-			subscription, err = fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(installPlanName))
+			subscription, err = fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(installPlanName))
 			require.NoError(GinkgoT(), err)
 			require.NotNil(GinkgoT(), subscription)
 
 			installPlanName = subscription.Status.InstallPlanRef.Name
 
 			// Wait for InstallPlan to be status: Complete or Failed before checking resource presence
-			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete, operatorsv1alpha1.InstallPlanPhaseFailed))
+			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete, operatorsv1alpha1.InstallPlanPhaseFailed))
 			require.NoError(GinkgoT(), err)
 			GinkgoT().Logf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase)
 
 			require.Equal(GinkgoT(), tt.expectedPhase, fetchedInstallPlan.Status.Phase)
 
 			// Ensure correct in-cluster resource(s)
-			fetchedCSV, err := fetchCSV(crc, mainBetaCSV.GetName(), ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err := fetchCSV(crc, mainBetaCSV.GetName(), generatedNamespace.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Ensure CRD versions are accurate
@@ -1661,25 +1661,25 @@ var _ = Describe("Install Plan", func() {
 				},
 			}
 
-			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogSourceName, ns.GetName(), []apiextensions.CustomResourceDefinition{*tt.newCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainStableCSV, mainBetaCSV, mainDeltaCSV}, mainManifests)
+			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogSourceName, generatedNamespace.GetName(), []apiextensions.CustomResourceDefinition{*tt.newCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainStableCSV, mainBetaCSV, mainDeltaCSV}, mainManifests)
 			// Attempt to get the catalog source before creating install plan(s)
-			_, err = fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, ns.GetName(), catalogSourceRegistryPodSynced)
+			_, err = fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 			require.NoError(GinkgoT(), err)
-			subscription, err = fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(installPlanName))
+			subscription, err = fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(installPlanName))
 			require.NoError(GinkgoT(), err)
 			require.NotNil(GinkgoT(), subscription)
 
 			installPlanName = subscription.Status.InstallPlanRef.Name
 
 			// Wait for InstallPlan to be status: Complete or Failed before checking resource presence
-			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete, operatorsv1alpha1.InstallPlanPhaseFailed))
+			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete, operatorsv1alpha1.InstallPlanPhaseFailed))
 			require.NoError(GinkgoT(), err)
 			GinkgoT().Logf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase)
 
 			require.Equal(GinkgoT(), tt.expectedPhase, fetchedInstallPlan.Status.Phase)
 
 			// Ensure correct in-cluster resource(s)
-			fetchedCSV, err = fetchCSV(crc, mainDeltaCSV.GetName(), ns.GetName(), csvSucceededChecker)
+			fetchedCSV, err = fetchCSV(crc, mainDeltaCSV.GetName(), generatedNamespace.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Ensure CRD versions are accurate
@@ -1706,7 +1706,7 @@ var _ = Describe("Install Plan", func() {
 		It("AmplifyPermissions", func() {
 
 			defer func() {
-				require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(ns.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
+				require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 			}()
 
 			// Build initial catalog
@@ -1774,7 +1774,7 @@ var _ = Describe("Install Plan", func() {
 
 			// Create the catalog sources
 			mainNamedStrategy := newNginxInstallStrategy(genName("dep-"), permissions, clusterPermissions)
-			mainCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), nil, nil, &mainNamedStrategy)
+			mainCSV := newCSV(mainPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), nil, nil, &mainNamedStrategy)
 			mainCatalogName := genName("mock-ocs-amplify-")
 			mainManifests := []registry.PackageManifest{
 				{
@@ -1793,18 +1793,18 @@ var _ = Describe("Install Plan", func() {
 				}).Should(Succeed())
 			}()
 
-			_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, ns.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
+			_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, generatedNamespace.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
 			defer cleanupMainCatalogSource()
 
 			// Attempt to get the catalog source before creating install plan
-			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, ns.GetName(), catalogSourceRegistryPodSynced)
+			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 			require.NoError(GinkgoT(), err)
 
 			subscriptionName := genName("sub-nginx-update-perms1")
-			subscriptionCleanup := createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+			subscriptionCleanup := createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 			defer subscriptionCleanup()
 
-			subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
+			subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
 			require.NoError(GinkgoT(), err)
 			require.NotNil(GinkgoT(), subscription)
 			require.NotNil(GinkgoT(), subscription.Status.InstallPlanRef)
@@ -1813,13 +1813,13 @@ var _ = Describe("Install Plan", func() {
 			installPlanName := subscription.Status.InstallPlanRef.Name
 
 			// Wait for InstallPlan to be status: Complete before checking resource presence
-			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
+			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
 			require.NoError(GinkgoT(), err)
 
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
 
 			// Verify CSV is created
-			_, err = awaitCSV(crc, ns.GetName(), mainCSV.GetName(), csvSucceededChecker)
+			_, err = awaitCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Update CatalogSource with a new CSV with more permissions
@@ -1860,7 +1860,7 @@ var _ = Describe("Install Plan", func() {
 
 			// Create the catalog sources
 			updatedNamedStrategy := newNginxInstallStrategy(genName("dep-"), updatedPermissions, updatedClusterPermissions)
-			updatedCSV := newCSV(mainPackageStable+"-next", ns.GetName(), mainCSV.GetName(), semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{mainCRD}, nil, &updatedNamedStrategy)
+			updatedCSV := newCSV(mainPackageStable+"-next", generatedNamespace.GetName(), mainCSV.GetName(), semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{mainCRD}, nil, &updatedNamedStrategy)
 			updatedManifests := []registry.PackageManifest{
 				{
 					PackageName: mainPackageName,
@@ -1872,20 +1872,20 @@ var _ = Describe("Install Plan", func() {
 			}
 
 			// Update catalog with updated CSV with more permissions
-			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogName, ns.GetName(), []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV, updatedCSV}, updatedManifests)
+			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogName, generatedNamespace.GetName(), []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV, updatedCSV}, updatedManifests)
 
-			_, err = fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(fetchedInstallPlan.GetName()))
+			_, err = fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(fetchedInstallPlan.GetName()))
 			require.NoError(GinkgoT(), err)
 
 			updatedInstallPlanName := subscription.Status.InstallPlanRef.Name
 
 			// Wait for InstallPlan to be status: Complete before checking resource presence
-			fetchedUpdatedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, updatedInstallPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
+			fetchedUpdatedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, updatedInstallPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
 			require.NoError(GinkgoT(), err)
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedUpdatedInstallPlan.Status.Phase)
 
 			// Wait for csv to update
-			_, err = awaitCSV(crc, ns.GetName(), updatedCSV.GetName(), csvSucceededChecker)
+			_, err = awaitCSV(crc, generatedNamespace.GetName(), updatedCSV.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// If the CSV is succeeded, we successfully rolled out the RBAC changes
@@ -1893,7 +1893,7 @@ var _ = Describe("Install Plan", func() {
 		It("AttenuatePermissions", func() {
 
 			defer func() {
-				require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(ns.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
+				require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 			}()
 
 			// Build initial catalog
@@ -1972,7 +1972,7 @@ var _ = Describe("Install Plan", func() {
 
 			// Create the catalog sources
 			mainNamedStrategy := newNginxInstallStrategy(genName("dep-"), permissions, clusterPermissions)
-			mainCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), nil, nil, &mainNamedStrategy)
+			mainCSV := newCSV(mainPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), nil, nil, &mainNamedStrategy)
 			mainCatalogName := genName("mock-ocs-main-update-perms1-")
 			mainManifests := []registry.PackageManifest{
 				{
@@ -1991,18 +1991,18 @@ var _ = Describe("Install Plan", func() {
 				}).Should(Succeed())
 			}()
 
-			_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, ns.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
+			_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, generatedNamespace.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
 			defer cleanupMainCatalogSource()
 
 			// Attempt to get the catalog source before creating install plan
-			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, ns.GetName(), catalogSourceRegistryPodSynced)
+			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 			require.NoError(GinkgoT(), err)
 
 			subscriptionName := genName("sub-nginx-update-perms1")
-			subscriptionCleanup := createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+			subscriptionCleanup := createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 			defer subscriptionCleanup()
 
-			subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
+			subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
 			require.NoError(GinkgoT(), err)
 			require.NotNil(GinkgoT(), subscription)
 			require.NotNil(GinkgoT(), subscription.Status.InstallPlanRef)
@@ -2011,13 +2011,13 @@ var _ = Describe("Install Plan", func() {
 			installPlanName := subscription.Status.InstallPlanRef.Name
 
 			// Wait for InstallPlan to be status: Complete before checking resource presence
-			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
+			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
 			require.NoError(GinkgoT(), err)
 
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
 
 			// Verify CSV is created
-			_, err = awaitCSV(crc, ns.GetName(), mainCSV.GetName(), csvSucceededChecker)
+			_, err = awaitCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Update CatalogSource with a new CSV with more permissions
@@ -2046,12 +2046,12 @@ var _ = Describe("Install Plan", func() {
 				},
 			}
 
-			oldSecrets, err := c.KubernetesInterface().CoreV1().Secrets(ns.GetName()).List(context.Background(), metav1.ListOptions{})
+			oldSecrets, err := c.KubernetesInterface().CoreV1().Secrets(generatedNamespace.GetName()).List(context.Background(), metav1.ListOptions{})
 			require.NoError(GinkgoT(), err, "error listing secrets")
 
 			// Create the catalog sources
 			updatedNamedStrategy := newNginxInstallStrategy(genName("dep-"), updatedPermissions, updatedClusterPermissions)
-			updatedCSV := newCSV(mainPackageStable+"-next", ns.GetName(), mainCSV.GetName(), semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{mainCRD}, nil, &updatedNamedStrategy)
+			updatedCSV := newCSV(mainPackageStable+"-next", generatedNamespace.GetName(), mainCSV.GetName(), semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{mainCRD}, nil, &updatedNamedStrategy)
 			updatedManifests := []registry.PackageManifest{
 				{
 					PackageName: mainPackageName,
@@ -2063,24 +2063,24 @@ var _ = Describe("Install Plan", func() {
 			}
 
 			// Update catalog with updated CSV with more permissions
-			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogName, ns.GetName(), []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV, updatedCSV}, updatedManifests)
+			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogName, generatedNamespace.GetName(), []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV, updatedCSV}, updatedManifests)
 
 			// Wait for subscription to update its status
-			_, err = fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(fetchedInstallPlan.GetName()))
+			_, err = fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(fetchedInstallPlan.GetName()))
 			require.NoError(GinkgoT(), err)
 
 			updatedInstallPlanName := subscription.Status.InstallPlanRef.Name
 
 			// Wait for InstallPlan to be status: Complete before checking resource presence
-			fetchedUpdatedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, updatedInstallPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
+			fetchedUpdatedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, updatedInstallPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
 			require.NoError(GinkgoT(), err)
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedUpdatedInstallPlan.Status.Phase)
 
 			// Wait for csv to update
-			_, err = awaitCSV(crc, ns.GetName(), updatedCSV.GetName(), csvSucceededChecker)
+			_, err = awaitCSV(crc, generatedNamespace.GetName(), updatedCSV.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
-			newSecrets, err := c.KubernetesInterface().CoreV1().Secrets(ns.GetName()).List(context.Background(), metav1.ListOptions{})
+			newSecrets, err := c.KubernetesInterface().CoreV1().Secrets(generatedNamespace.GetName()).List(context.Background(), metav1.ListOptions{})
 			require.NoError(GinkgoT(), err, "error listing secrets")
 
 			// Assert that the number of secrets is not increased from updating service account as part of the install plan,
@@ -2093,7 +2093,7 @@ var _ = Describe("Install Plan", func() {
 			err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
 				res, err := c.KubernetesInterface().AuthorizationV1().SubjectAccessReviews().Create(context.Background(), &authorizationv1.SubjectAccessReview{
 					Spec: authorizationv1.SubjectAccessReviewSpec{
-						User: "system:serviceaccount:" + ns.GetName() + ":" + serviceAccountName,
+						User: "system:serviceaccount:" + generatedNamespace.GetName() + ":" + serviceAccountName,
 						ResourceAttributes: &authorizationv1.ResourceAttributes{
 							Group:    "cluster.com",
 							Version:  "v1alpha1",
@@ -2118,7 +2118,7 @@ var _ = Describe("Install Plan", func() {
 		It("StopOnCSVModifications", func() {
 
 			defer func() {
-				require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(ns.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
+				require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 			}()
 
 			// Build initial catalog
@@ -2188,7 +2188,7 @@ var _ = Describe("Install Plan", func() {
 			// Create the catalog sources
 			deploymentName := genName("dep-")
 			mainNamedStrategy := newNginxInstallStrategy(deploymentName, permissions, clusterPermissions)
-			mainCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), nil, nil, &mainNamedStrategy)
+			mainCSV := newCSV(mainPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), nil, nil, &mainNamedStrategy)
 			mainCatalogName := genName("mock-ocs-stomper-")
 			mainManifests := []registry.PackageManifest{
 				{
@@ -2207,18 +2207,18 @@ var _ = Describe("Install Plan", func() {
 				}).Should(Succeed())
 			}()
 
-			_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, ns.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
+			_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, generatedNamespace.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
 			defer cleanupMainCatalogSource()
 
 			// Attempt to get the catalog source before creating install plan
-			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, ns.GetName(), catalogSourceRegistryPodSynced)
+			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 			require.NoError(GinkgoT(), err)
 
 			subscriptionName := genName("sub-nginx-stompy-")
-			subscriptionCleanup := createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+			subscriptionCleanup := createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 			defer subscriptionCleanup()
 
-			subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
+			subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
 			require.NoError(GinkgoT(), err)
 			require.NotNil(GinkgoT(), subscription)
 			require.NotNil(GinkgoT(), subscription.Status.InstallPlanRef)
@@ -2227,13 +2227,13 @@ var _ = Describe("Install Plan", func() {
 			installPlanName := subscription.Status.InstallPlanRef.Name
 
 			// Wait for InstallPlan to be status: Complete before checking resource presence
-			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
+			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
 			require.NoError(GinkgoT(), err)
 
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
 
 			// Verify CSV is created
-			csv, err := awaitCSV(crc, ns.GetName(), mainCSV.GetName(), csvSucceededChecker)
+			csv, err := awaitCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			addedEnvVar := corev1.EnvVar{Name: "EXAMPLE", Value: "value"}
@@ -2270,16 +2270,16 @@ var _ = Describe("Install Plan", func() {
 				StrategyName: operatorsv1alpha1.InstallStrategyNameDeployment,
 				StrategySpec: modifiedDetails,
 			}
-			_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).Update(context.Background(), csv, metav1.UpdateOptions{})
+			_, err = crc.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).Update(context.Background(), csv, metav1.UpdateOptions{})
 			require.NoError(GinkgoT(), err)
 
 			// Wait for csv to update
-			_, err = awaitCSV(crc, ns.GetName(), csv.GetName(), csvSucceededChecker)
+			_, err = awaitCSV(crc, generatedNamespace.GetName(), csv.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Should have the updated env var
 			err = wait.Poll(pollInterval, pollDuration, func() (bool, error) {
-				dep, err := c.GetDeployment(ns.GetName(), deploymentName)
+				dep, err := c.GetDeployment(generatedNamespace.GetName(), deploymentName)
 				if err != nil {
 					return false, nil
 				}
@@ -2297,7 +2297,7 @@ var _ = Describe("Install Plan", func() {
 
 			// Create the catalog sources
 			// Updated csv has the same deployment strategy as main
-			updatedCSV := newCSV(mainPackageStable+"-next", ns.GetName(), mainCSV.GetName(), semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{mainCRD}, nil, &mainNamedStrategy)
+			updatedCSV := newCSV(mainPackageStable+"-next", generatedNamespace.GetName(), mainCSV.GetName(), semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{mainCRD}, nil, &mainNamedStrategy)
 			updatedManifests := []registry.PackageManifest{
 				{
 					PackageName: mainPackageName,
@@ -2309,24 +2309,24 @@ var _ = Describe("Install Plan", func() {
 			}
 
 			// Update catalog with updated CSV with more permissions
-			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogName, ns.GetName(), []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV, updatedCSV}, updatedManifests)
+			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogName, generatedNamespace.GetName(), []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV, updatedCSV}, updatedManifests)
 
-			_, err = fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(fetchedInstallPlan.GetName()))
+			_, err = fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(fetchedInstallPlan.GetName()))
 			require.NoError(GinkgoT(), err)
 
 			updatedInstallPlanName := subscription.Status.InstallPlanRef.Name
 
 			// Wait for InstallPlan to be status: Complete before checking resource presence
-			fetchedUpdatedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, updatedInstallPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
+			fetchedUpdatedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, updatedInstallPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
 			require.NoError(GinkgoT(), err)
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedUpdatedInstallPlan.Status.Phase)
 
 			// Wait for csv to update
-			_, err = awaitCSV(crc, ns.GetName(), updatedCSV.GetName(), csvSucceededChecker)
+			_, err = awaitCSV(crc, generatedNamespace.GetName(), updatedCSV.GetName(), csvSucceededChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Should have created deployment and stomped on the env changes
-			updatedDep, err := c.GetDeployment(ns.GetName(), deploymentName)
+			updatedDep, err := c.GetDeployment(generatedNamespace.GetName(), deploymentName)
 			require.NoError(GinkgoT(), err)
 			require.NotNil(GinkgoT(), updatedDep)
 
@@ -2416,8 +2416,8 @@ var _ = Describe("Install Plan", func() {
 				},
 			}
 
-			mainCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{mainCRD}, nil, nil)
-			betaCSV := newCSV(mainPackageBeta, ns.GetName(), mainPackageStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{updatedCRD}, nil, nil)
+			mainCSV := newCSV(mainPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{mainCRD}, nil, nil)
+			betaCSV := newCSV(mainPackageBeta, generatedNamespace.GetName(), mainPackageStable, semver.MustParse("0.2.0"), []apiextensions.CustomResourceDefinition{updatedCRD}, nil, nil)
 
 			// Defer CRD clean up
 			defer func() {
@@ -2430,7 +2430,7 @@ var _ = Describe("Install Plan", func() {
 			}()
 
 			defer func() {
-				require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(ns.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
+				require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 			}()
 
 			mainCatalogName := genName("mock-ocs-main-update-")
@@ -2447,17 +2447,17 @@ var _ = Describe("Install Plan", func() {
 			}
 
 			// Create the catalog sources
-			_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, ns.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
+			_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, generatedNamespace.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{mainCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
 			defer cleanupMainCatalogSource()
 
 			// Attempt to get the catalog source before creating install plan
-			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, ns.GetName(), catalogSourceRegistryPodSynced)
+			_, err := fetchCatalogSourceOnStatus(crc, mainCatalogName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 			require.NoError(GinkgoT(), err)
 
 			subscriptionName := genName("sub-nginx-update-")
-			createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+			createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 
-			subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
+			subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
 			require.NoError(GinkgoT(), err)
 			require.NotNil(GinkgoT(), subscription)
 			require.NotNil(GinkgoT(), subscription.Status.InstallPlanRef)
@@ -2466,20 +2466,20 @@ var _ = Describe("Install Plan", func() {
 			installPlanName := subscription.Status.InstallPlanRef.Name
 
 			// Wait for InstallPlan to be status: Complete before checking resource presence
-			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
+			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
 			require.NoError(GinkgoT(), err)
 
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
 
 			// Fetch installplan again to check for unnecessary control loops
-			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, fetchedInstallPlan.GetName(), ns.GetName(), func(fip *operatorsv1alpha1.InstallPlan) bool {
+			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, fetchedInstallPlan.GetName(), generatedNamespace.GetName(), func(fip *operatorsv1alpha1.InstallPlan) bool {
 				Expect(equality.Semantic.DeepEqual(fetchedInstallPlan, fip)).Should(BeTrue(), diff.ObjectDiff(fetchedInstallPlan, fip))
 				return true
 			})
 			require.NoError(GinkgoT(), err)
 
 			// Verify CSV is created
-			_, err = awaitCSV(crc, ns.GetName(), mainCSV.GetName(), csvAnyChecker)
+			_, err = awaitCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvAnyChecker)
 			require.NoError(GinkgoT(), err)
 
 			mainManifests = []registry.PackageManifest{
@@ -2492,18 +2492,18 @@ var _ = Describe("Install Plan", func() {
 				},
 			}
 
-			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogName, ns.GetName(), []apiextensions.CustomResourceDefinition{updatedCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV, betaCSV}, mainManifests)
+			updateInternalCatalog(GinkgoT(), c, crc, mainCatalogName, generatedNamespace.GetName(), []apiextensions.CustomResourceDefinition{updatedCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV, betaCSV}, mainManifests)
 			// Wait for subscription to update
-			updatedSubscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(fetchedInstallPlan.GetName()))
+			updatedSubscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanDifferentChecker(fetchedInstallPlan.GetName()))
 			require.NoError(GinkgoT(), err)
 
 			// Verify installplan created and installed
-			fetchedUpdatedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, updatedSubscription.Status.InstallPlanRef.Name, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
+			fetchedUpdatedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, updatedSubscription.Status.InstallPlanRef.Name, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
 			require.NoError(GinkgoT(), err)
 			require.NotEqual(GinkgoT(), fetchedInstallPlan.GetName(), fetchedUpdatedInstallPlan.GetName())
 
 			// Wait for csv to update
-			_, err = awaitCSV(crc, ns.GetName(), betaCSV.GetName(), csvAnyChecker)
+			_, err = awaitCSV(crc, generatedNamespace.GetName(), betaCSV.GetName(), csvAnyChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Get the CRD to see if it is updated
@@ -2535,7 +2535,7 @@ var _ = Describe("Install Plan", func() {
 		It("UpdatePreexistingCRDFailed", func() {
 
 			defer func() {
-				require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(ns.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
+				require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 			}()
 
 			mainPackageName := genName("nginx-update2-")
@@ -2630,7 +2630,7 @@ var _ = Describe("Install Plan", func() {
 			require.NoError(GinkgoT(), err)
 			defer cleanupCRD()
 
-			mainCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), nil, nil, nil)
+			mainCSV := newCSV(mainPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), nil, nil, nil)
 
 			mainCatalogName := genName("mock-ocs-main-update2-")
 
@@ -2646,18 +2646,18 @@ var _ = Describe("Install Plan", func() {
 			}
 
 			// Create the catalog sources
-			_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, ns.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{updatedCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
+			_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, generatedNamespace.GetName(), mainManifests, []apiextensions.CustomResourceDefinition{updatedCRD}, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
 			defer cleanupMainCatalogSource()
 
 			// Attempt to get the catalog source before creating install plan
-			_, err = fetchCatalogSourceOnStatus(crc, mainCatalogName, ns.GetName(), catalogSourceRegistryPodSynced)
+			_, err = fetchCatalogSourceOnStatus(crc, mainCatalogName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 			require.NoError(GinkgoT(), err)
 
 			subscriptionName := genName("sub-nginx-update2-")
-			subscriptionCleanup := createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+			subscriptionCleanup := createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 			defer subscriptionCleanup()
 
-			subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
+			subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
 			require.NoError(GinkgoT(), err)
 			require.NotNil(GinkgoT(), subscription)
 			require.NotNil(GinkgoT(), subscription.Status.InstallPlanRef)
@@ -2666,20 +2666,20 @@ var _ = Describe("Install Plan", func() {
 			installPlanName := subscription.Status.InstallPlanRef.Name
 
 			// Wait for InstallPlan to be status: Complete before checking resource presence
-			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
+			fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
 			require.NoError(GinkgoT(), err)
 
 			require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
 
 			// Fetch installplan again to check for unnecessary control loops
-			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, fetchedInstallPlan.GetName(), ns.GetName(), func(fip *operatorsv1alpha1.InstallPlan) bool {
+			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, fetchedInstallPlan.GetName(), generatedNamespace.GetName(), func(fip *operatorsv1alpha1.InstallPlan) bool {
 				Expect(equality.Semantic.DeepEqual(fetchedInstallPlan, fip)).Should(BeTrue(), diff.ObjectDiff(fetchedInstallPlan, fip))
 				return true
 			})
 			require.NoError(GinkgoT(), err)
 
 			// Verify CSV is created
-			_, err = awaitCSV(crc, ns.GetName(), mainCSV.GetName(), csvAnyChecker)
+			_, err = awaitCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvAnyChecker)
 			require.NoError(GinkgoT(), err)
 
 			// Get the CRD to see if it is updated
@@ -2780,33 +2780,33 @@ var _ = Describe("Install Plan", func() {
 		namedStrategy := newNginxInstallStrategy(genName("dep-"), permissions, clusterPermissions)
 
 		// Create new CSVs
-		stableCSV := newCSV(stableCSVName, ns.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd}, nil, &namedStrategy)
+		stableCSV := newCSV(stableCSVName, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd}, nil, &namedStrategy)
 
 		defer func() {
-			require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(ns.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
+			require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 		}()
 
 		// Create CatalogSource
 		mainCatalogSourceName := genName("nginx-catalog")
-		_, cleanupCatalogSource := createInternalCatalogSource(c, crc, mainCatalogSourceName, ns.GetName(), manifests, []apiextensions.CustomResourceDefinition{crd}, []operatorsv1alpha1.ClusterServiceVersion{stableCSV})
+		_, cleanupCatalogSource := createInternalCatalogSource(c, crc, mainCatalogSourceName, generatedNamespace.GetName(), manifests, []apiextensions.CustomResourceDefinition{crd}, []operatorsv1alpha1.ClusterServiceVersion{stableCSV})
 		defer cleanupCatalogSource()
 
 		// Attempt to get CatalogSource
-		_, err := fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, ns.GetName(), catalogSourceRegistryPodSynced)
+		_, err := fetchCatalogSourceOnStatus(crc, mainCatalogSourceName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 		require.NoError(GinkgoT(), err)
 
 		subscriptionName := genName("sub-nginx-")
-		subscriptionCleanup := createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, mainCatalogSourceName, packageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+		subscriptionCleanup := createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, mainCatalogSourceName, packageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 		defer subscriptionCleanup()
 
-		subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
+		subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
 
 		installPlanName := subscription.Status.InstallPlanRef.Name
 
 		// Attempt to get InstallPlan
-		fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseFailed, operatorsv1alpha1.InstallPlanPhaseComplete))
+		fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseFailed, operatorsv1alpha1.InstallPlanPhaseComplete))
 		require.NoError(GinkgoT(), err)
 		require.NotEqual(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseFailed, fetchedInstallPlan.Status.Phase, "InstallPlan failed")
 
@@ -2934,8 +2934,8 @@ var _ = Describe("Install Plan", func() {
 				}
 			}
 		}()
-		GinkgoT().Logf("Deleting CSV '%v' in namespace %v", stableCSVName, ns.GetName())
-		require.NoError(GinkgoT(), crc.OperatorsV1alpha1().ClusterServiceVersions(ns.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
+		GinkgoT().Logf("Deleting CSV '%v' in namespace %v", stableCSVName, generatedNamespace.GetName())
+		require.NoError(GinkgoT(), crc.OperatorsV1alpha1().ClusterServiceVersions(generatedNamespace.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 		select {
 		case <-done:
 			break
@@ -2947,9 +2947,9 @@ var _ = Describe("Install Plan", func() {
 		require.Emptyf(GinkgoT(), createdClusterRoleBindingNames, "unexpected cluster role binding remain: %v", createdClusterRoleBindingNames)
 
 		Eventually(func() error {
-			_, err := c.GetServiceAccount(ns.GetName(), serviceAccountName)
+			_, err := c.GetServiceAccount(generatedNamespace.GetName(), serviceAccountName)
 			if err == nil {
-				return fmt.Errorf("The %v/%v ServiceAccount should have been deleted", ns.GetName(), serviceAccountName)
+				return fmt.Errorf("The %v/%v ServiceAccount should have been deleted", generatedNamespace.GetName(), serviceAccountName)
 			}
 			if !apierrors.IsNotFound(err) {
 				return err
@@ -3021,7 +3021,7 @@ var _ = Describe("Install Plan", func() {
 		packageName := genName("nginx-")
 		stableChannel := "stable"
 		packageNameStable := packageName + "-" + stableChannel
-		csv := newCSV(packageNameStable, ns.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd}, nil, nil)
+		csv := newCSV(packageNameStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd}, nil, nil)
 
 		// Create PackageManifests
 		manifests := []registry.PackageManifest{
@@ -3036,25 +3036,25 @@ var _ = Describe("Install Plan", func() {
 
 		// Create the CatalogSource
 		catalogSourceName := genName("mock-nginx-")
-		_, cleanupCatalogSource := createInternalCatalogSource(c, crc, catalogSourceName, ns.GetName(), manifests, []apiextensions.CustomResourceDefinition{crd}, []operatorsv1alpha1.ClusterServiceVersion{csv})
+		_, cleanupCatalogSource := createInternalCatalogSource(c, crc, catalogSourceName, generatedNamespace.GetName(), manifests, []apiextensions.CustomResourceDefinition{crd}, []operatorsv1alpha1.ClusterServiceVersion{csv})
 		defer cleanupCatalogSource()
 
 		// Attempt to get the catalog source before creating install plan
-		_, err := fetchCatalogSourceOnStatus(crc, catalogSourceName, ns.GetName(), catalogSourceRegistryPodSynced)
+		_, err := fetchCatalogSourceOnStatus(crc, catalogSourceName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 		require.NoError(GinkgoT(), err)
 
 		subscriptionName := genName("sub-nginx-")
-		cleanupSubscription := createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, catalogSourceName, packageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+		cleanupSubscription := createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, catalogSourceName, packageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 		defer cleanupSubscription()
 
-		subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
+		subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
 
 		installPlanName := subscription.Status.InstallPlanRef.Name
 
 		// Wait for InstallPlan to be status: Complete before checking resource presence
-		fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete, operatorsv1alpha1.InstallPlanPhaseFailed))
+		fetchedInstallPlan, err := fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete, operatorsv1alpha1.InstallPlanPhaseFailed))
 		require.NoError(GinkgoT(), err)
 		GinkgoT().Logf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase)
 
@@ -3085,12 +3085,12 @@ var _ = Describe("Install Plan", func() {
 		require.NoError(GinkgoT(), err)
 		deleteOpts := &metav1.DeleteOptions{}
 		defer func() {
-			require.NoError(GinkgoT(), c.KubernetesInterface().CoreV1().Namespaces().Delete(context.Background(), ns.GetName(), *deleteOpts))
+			require.NoError(GinkgoT(), c.KubernetesInterface().CoreV1().Namespaces().Delete(context.Background(), generatedNamespace.GetName(), *deleteOpts))
 		}()
 
 		og := &operatorsv1.OperatorGroup{}
 		og.SetName("og")
-		_, err = crc.OperatorsV1().OperatorGroups(ns.GetName()).Create(context.Background(), og, metav1.CreateOptions{})
+		_, err = crc.OperatorsV1().OperatorGroups(generatedNamespace.GetName()).Create(context.Background(), og, metav1.CreateOptions{})
 		require.NoError(GinkgoT(), err)
 
 		mainPackageName := genName("nginx-")
@@ -3102,11 +3102,11 @@ var _ = Describe("Install Plan", func() {
 		stableChannel := "stable"
 
 		dependentCRD := newCRD(genName("ins-"))
-		mainCSV := newCSV(mainPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), nil, []apiextensions.CustomResourceDefinition{dependentCRD}, nil)
-		dependentCSV := newCSV(dependentPackageStable, ns.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{dependentCRD}, nil, nil)
+		mainCSV := newCSV(mainPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), nil, []apiextensions.CustomResourceDefinition{dependentCRD}, nil)
+		dependentCSV := newCSV(dependentPackageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{dependentCRD}, nil, nil)
 
 		defer func() {
-			require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(ns.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
+			require.NoError(GinkgoT(), crc.OperatorsV1alpha1().Subscriptions(generatedNamespace.GetName()).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 		}()
 
 		dependentCatalogName := genName("mock-ocs-dependent-")
@@ -3141,11 +3141,11 @@ var _ = Describe("Install Plan", func() {
 		}()
 
 		// Create the dependent catalog source
-		_, cleanupDependentCatalogSource := createInternalCatalogSource(c, crc, dependentCatalogName, ns.GetName(), dependentManifests, []apiextensions.CustomResourceDefinition{dependentCRD}, []operatorsv1alpha1.ClusterServiceVersion{dependentCSV})
+		_, cleanupDependentCatalogSource := createInternalCatalogSource(c, crc, dependentCatalogName, generatedNamespace.GetName(), dependentManifests, []apiextensions.CustomResourceDefinition{dependentCRD}, []operatorsv1alpha1.ClusterServiceVersion{dependentCSV})
 		defer cleanupDependentCatalogSource()
 
 		// Attempt to get the catalog source before creating install plan
-		dependentCatalogSource, err := fetchCatalogSourceOnStatus(crc, dependentCatalogName, ns.GetName(), catalogSourceRegistryPodSynced)
+		dependentCatalogSource, err := fetchCatalogSourceOnStatus(crc, dependentCatalogName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 		require.NoError(GinkgoT(), err)
 
 		// Create the alt dependent catalog sources
@@ -3170,11 +3170,11 @@ var _ = Describe("Install Plan", func() {
 				}
 				addressSource.SetName(genName("alt-dep-"))
 
-				_, err := crc.OperatorsV1alpha1().CatalogSources(ns.GetName()).Create(context.Background(), addressSource, metav1.CreateOptions{})
+				_, err := crc.OperatorsV1alpha1().CatalogSources(generatedNamespace.GetName()).Create(context.Background(), addressSource, metav1.CreateOptions{})
 				require.NoError(GinkgoT(), err)
 
 				// Attempt to get the catalog source before creating install plan
-				_, err = fetchCatalogSourceOnStatus(crc, addressSource.GetName(), ns.GetName(), catalogSourceRegistryPodSynced)
+				_, err = fetchCatalogSourceOnStatus(crc, addressSource.GetName(), generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 				require.NoError(GinkgoT(), err)
 				wg.Done()
 			}(i)
@@ -3182,32 +3182,32 @@ var _ = Describe("Install Plan", func() {
 		wg.Wait()
 
 		// Create the main catalog source
-		_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, ns.GetName(), mainManifests, nil, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
+		_, cleanupMainCatalogSource := createInternalCatalogSource(c, crc, mainCatalogName, generatedNamespace.GetName(), mainManifests, nil, []operatorsv1alpha1.ClusterServiceVersion{mainCSV})
 		defer cleanupMainCatalogSource()
 
 		// Attempt to get the catalog source before creating install plan
-		_, err = fetchCatalogSourceOnStatus(crc, mainCatalogName, ns.GetName(), catalogSourceRegistryPodSynced)
+		_, err = fetchCatalogSourceOnStatus(crc, mainCatalogName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 		require.NoError(GinkgoT(), err)
 
 		subscriptionName := genName("sub-nginx-")
-		subscriptionCleanup := createSubscriptionForCatalog(crc, ns.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
+		subscriptionCleanup := createSubscriptionForCatalog(crc, generatedNamespace.GetName(), subscriptionName, mainCatalogName, mainPackageName, stableChannel, "", operatorsv1alpha1.ApprovalAutomatic)
 		defer subscriptionCleanup()
 
-		subscription, err := fetchSubscription(crc, ns.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
+		subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), subscriptionName, subscriptionHasInstallPlanChecker)
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
 
 		installPlanName := subscription.Status.InstallPlanRef.Name
 
 		// Wait for InstallPlan to be status: Complete before checking resource presence
-		fetchedInstallPlan, err := fetchInstallPlanWithNamespace(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
+		fetchedInstallPlan, err := fetchInstallPlanWithNamespace(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete))
 		require.NoError(GinkgoT(), err)
 		log(fmt.Sprintf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase))
 
 		require.Equal(GinkgoT(), operatorsv1alpha1.InstallPlanPhaseComplete, fetchedInstallPlan.Status.Phase)
 
 		// Verify CSV is created
-		_, err = awaitCSV(crc, ns.GetName(), mainCSV.GetName(), csvSucceededChecker)
+		_, err = awaitCSV(crc, generatedNamespace.GetName(), mainCSV.GetName(), csvSucceededChecker)
 		require.NoError(GinkgoT(), err)
 
 		// Make sure to clean up the installed CRD
@@ -3216,7 +3216,7 @@ var _ = Describe("Install Plan", func() {
 		}()
 
 		// ensure there is only one installplan
-		ips, err := crc.OperatorsV1alpha1().InstallPlans(ns.GetName()).List(context.Background(), metav1.ListOptions{})
+		ips, err := crc.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).List(context.Background(), metav1.ListOptions{})
 		require.NoError(GinkgoT(), err)
 		require.Equal(GinkgoT(), 1, len(ips.Items), "If this test fails it should be taken seriously and not treated as a flake. \n%v", ips.Items)
 	})
@@ -3238,22 +3238,22 @@ var _ = Describe("Install Plan", func() {
 
 			// Create InstallPlan
 			installPlanName = "ip"
-			ip := newInstallPlanWithDummySteps(installPlanName, ns.GetName(), operatorsv1alpha1.InstallPlanPhaseInstalling)
-			outIP, err := crc.OperatorsV1alpha1().InstallPlans(ns.GetName()).Create(context.Background(), ip, metav1.CreateOptions{})
+			ip := newInstallPlanWithDummySteps(installPlanName, generatedNamespace.GetName(), operatorsv1alpha1.InstallPlanPhaseInstalling)
+			outIP, err := crc.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).Create(context.Background(), ip, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(outIP).NotTo(BeNil())
 
 			// The status gets ignored on create so we need to update it else the InstallPlan sync ignores
 			// InstallPlans without any steps or bundle lookups
 			outIP.Status = ip.Status
-			_, err = crc.OperatorsV1alpha1().InstallPlans(ns.GetName()).UpdateStatus(context.Background(), outIP, metav1.UpdateOptions{})
+			_, err = crc.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).UpdateStatus(context.Background(), outIP, metav1.UpdateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		AfterEach(func() {
-			err := crc.OperatorsV1alpha1().InstallPlans(ns.GetName()).Delete(context.Background(), installPlanName, metav1.DeleteOptions{})
+			err := crc.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).Delete(context.Background(), installPlanName, metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			err = c.KubernetesInterface().CoreV1().Namespaces().Delete(context.Background(), ns.GetName(), metav1.DeleteOptions{})
+			err = c.KubernetesInterface().CoreV1().Namespaces().Delete(context.Background(), generatedNamespace.GetName(), metav1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -3265,7 +3265,7 @@ var _ = Describe("Install Plan", func() {
 				Message: "no operator group found that is managing this namespace"}
 
 			Eventually(func() bool {
-				fetchedInstallPlan, err := fetchInstallPlanWithNamespace(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseInstalling))
+				fetchedInstallPlan, err := fetchInstallPlanWithNamespace(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseInstalling))
 				if err != nil || fetchedInstallPlan == nil {
 					return false
 				}
@@ -3279,10 +3279,10 @@ var _ = Describe("Install Plan", func() {
 			og := &operatorsv1.OperatorGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "og",
-					Namespace: ns.GetName(),
+					Namespace: generatedNamespace.GetName(),
 				},
 				Spec: operatorsv1.OperatorGroupSpec{
-					TargetNamespaces: []string{ns.GetName()},
+					TargetNamespaces: []string{generatedNamespace.GetName()},
 				},
 			}
 			Eventually(func() error {
@@ -3298,11 +3298,11 @@ var _ = Describe("Install Plan", func() {
 				},
 				1*time.Minute,
 				interval,
-			).Should(ContainElement(ns.GetName()))
+			).Should(ContainElement(generatedNamespace.GetName()))
 
 			// check that the condition has been cleared up
 			Eventually(func() (bool, error) {
-				fetchedInstallPlan, err := fetchInstallPlanWithNamespace(GinkgoT(), crc, installPlanName, ns.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseInstalling))
+				fetchedInstallPlan, err := fetchInstallPlanWithNamespace(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseInstalling))
 				if err != nil {
 					return false, err
 				}
@@ -3320,26 +3320,10 @@ var _ = Describe("Install Plan", func() {
 	It("compresses installplan step resource manifests to configmap references", func() {
 		// Test ensures that all steps for index-based catalogs are references to configmaps. This avoids the problem
 		// of installplans growing beyond the etcd size limit when manifests are written to the ip status.
-
-		ns, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("ns-"),
-			},
-		}, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
-
-		og := &operatorsv1.OperatorGroup{}
-		og.SetName("og")
-		_, err = crc.OperatorsV1().OperatorGroups(ns.GetName()).Create(context.Background(), og, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
-
-		deleteOpts := &metav1.DeleteOptions{}
-		defer c.KubernetesInterface().CoreV1().Namespaces().Delete(context.Background(), ns.GetName(), *deleteOpts)
-
 		catsrc := &operatorsv1alpha1.CatalogSource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      genName("kiali-"),
-				Namespace: ns.GetName(),
+				Namespace: generatedNamespace.GetName(),
 				Labels:    map[string]string{"olm.catalogSource": "kaili-catalog"},
 			},
 			Spec: operatorsv1alpha1.CatalogSourceSpec{
@@ -3350,7 +3334,7 @@ var _ = Describe("Install Plan", func() {
 				},
 			},
 		}
-		catsrc, err = crc.OperatorsV1alpha1().CatalogSources(catsrc.GetNamespace()).Create(context.Background(), catsrc, metav1.CreateOptions{})
+		catsrc, err := crc.OperatorsV1alpha1().CatalogSources(catsrc.GetNamespace()).Create(context.Background(), catsrc, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		// Wait for the CatalogSource to be ready
@@ -3407,27 +3391,17 @@ var _ = Describe("Install Plan", func() {
 	})
 
 	It("limits installed resources if the scoped serviceaccount has no permissions", func() {
-
-		By("creating a scoped serviceaccount specified in the operatorgroup")
-		ns, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("ns-"),
-			},
-		}, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		defer c.KubernetesInterface().CoreV1().Namespaces().Delete(context.Background(), ns.GetName(), metav1.DeleteOptions{})
-
 		// create SA
 		sa := &corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      genName("sa-"),
-				Namespace: ns.GetName(),
+				Namespace: generatedNamespace.GetName(),
 			},
 		}
-		_, err = c.KubernetesInterface().CoreV1().ServiceAccounts(ns.GetName()).Create(context.Background(), sa, metav1.CreateOptions{})
+		_, err := c.KubernetesInterface().CoreV1().ServiceAccounts(generatedNamespace.GetName()).Create(context.Background(), sa, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		// Create token secret for the serviceaccount
-		_, cleanupSE := newTokenSecret(c, ns.GetName(), sa.GetName())
+		_, cleanupSE := newTokenSecret(c, generatedNamespace.GetName(), sa.GetName())
 		defer cleanupSE()
 
 		// role has no explicit permissions
@@ -3462,24 +3436,22 @@ var _ = Describe("Install Plan", func() {
 		Expect(err).ToNot(HaveOccurred())
 		defer c.KubernetesInterface().RbacV1().ClusterRoles().Delete(context.Background(), role.GetName(), metav1.DeleteOptions{})
 
-		// create operator group referencing the SA
-		og := &operatorsv1.OperatorGroup{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      genName("og-"),
-				Namespace: ns.GetName(),
-			},
-			Spec: operatorsv1.OperatorGroupSpec{
-				ServiceAccountName: sa.GetName(),
-			},
-		}
-		_, err = crc.OperatorsV1().OperatorGroups(ns.GetName()).Create(context.Background(), og, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		// Update the existing OG to use the ServiceAccount
+		Eventually(func() error {
+			existingOG, err := crc.OperatorsV1().OperatorGroups(generatedNamespace.GetName()).Get(context.Background(), fmt.Sprintf("%s-operatorgroup", generatedNamespace.GetName()), metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			existingOG.Spec.ServiceAccountName = sa.GetName()
+			_, err = crc.OperatorsV1().OperatorGroups(generatedNamespace.GetName()).Update(context.Background(), existingOG, metav1.UpdateOptions{})
+			return err
+		}).Should(Succeed())
 
 		// Wait for the OperatorGroup to be synced and have a status.ServiceAccountRef
 		// before moving on. Otherwise the catalog operator treats it as an invalid OperatorGroup
 		// and the InstallPlan is resynced
 		Eventually(func() (*corev1.ObjectReference, error) {
-			outOG, err := crc.OperatorsV1().OperatorGroups(ns.GetName()).Get(context.Background(), og.Name, metav1.GetOptions{})
+			outOG, err := crc.OperatorsV1().OperatorGroups(generatedNamespace.GetName()).Get(context.Background(), fmt.Sprintf("%s-operatorgroup", generatedNamespace.GetName()), metav1.GetOptions{})
 			if err != nil {
 				return nil, err
 			}
@@ -3534,7 +3506,7 @@ var _ = Describe("Install Plan", func() {
 		By("using the OLM client to create the CRD")
 		plan := &operatorsv1alpha1.InstallPlan{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: ns.GetName(),
+				Namespace: generatedNamespace.GetName(),
 				Name:      genName("ip-"),
 			},
 			Spec: operatorsv1alpha1.InstallPlanSpec{
@@ -3576,7 +3548,7 @@ var _ = Describe("Install Plan", func() {
 		// delete installplan, then create one with an additional resource that the SA does not have permissions to create
 		// expect installplan to fail
 		By("failing to install resources that are not explicitly allowed in the SA")
-		err = crc.OperatorsV1alpha1().InstallPlans(ns.GetName()).Delete(context.Background(), plan.GetName(), metav1.DeleteOptions{})
+		err = crc.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).Delete(context.Background(), plan.GetName(), metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		service := &corev1.Service{
@@ -3585,7 +3557,7 @@ var _ = Describe("Install Plan", func() {
 				APIVersion: "v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: ns.GetName(),
+				Namespace: generatedNamespace.GetName(),
 				Name:      "test-service",
 			},
 			Spec: corev1.ServiceSpec{
@@ -3604,7 +3576,7 @@ var _ = Describe("Install Plan", func() {
 
 		newPlan := &operatorsv1alpha1.InstallPlan{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: ns.GetName(),
+				Namespace: generatedNamespace.GetName(),
 				Name:      genName("ip-"),
 			},
 			Spec: operatorsv1alpha1.InstallPlanSpec{
@@ -3645,33 +3617,21 @@ var _ = Describe("Install Plan", func() {
 		}).Should(HavePhase(operatorsv1alpha1.InstallPlanPhaseFailed))
 
 		Expect(client.IgnoreNotFound(ctx.Ctx().Client().Delete(context.Background(), &crd))).To(Succeed())
-		Eventually(func() error {
-			return client.IgnoreNotFound(ctx.Ctx().Client().Delete(context.Background(), ns))
-		}, timeout, interval).Should(Succeed(), "could not delete Namespace")
 	})
 
 	It("uses the correct client when installing resources from an installplan", func() {
-
 		By("creating a scoped serviceaccount specifified in the operatorgroup")
-		ns, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: genName("ns-"),
-			},
-		}, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		defer c.KubernetesInterface().CoreV1().Namespaces().Delete(context.Background(), ns.GetName(), metav1.DeleteOptions{})
-
 		// create SA
 		sa := &corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      genName("sa-"),
-				Namespace: ns.GetName(),
+				Namespace: generatedNamespace.GetName(),
 			},
 		}
-		_, err = c.KubernetesInterface().CoreV1().ServiceAccounts(ns.GetName()).Create(context.Background(), sa, metav1.CreateOptions{})
+		_, err := c.KubernetesInterface().CoreV1().ServiceAccounts(generatedNamespace.GetName()).Create(context.Background(), sa, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		// Create token secret for the serviceaccount
-		_, cleanupSE := newTokenSecret(c, ns.GetName(), sa.GetName())
+		_, cleanupSE := newTokenSecret(c, generatedNamespace.GetName(), sa.GetName())
 		defer cleanupSE()
 
 		// see https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/scoped-operator-install.md
@@ -3731,24 +3691,22 @@ var _ = Describe("Install Plan", func() {
 		Expect(err).ToNot(HaveOccurred())
 		defer c.KubernetesInterface().RbacV1().ClusterRoles().Delete(context.Background(), role.GetName(), metav1.DeleteOptions{})
 
-		// create operator group referencing the SA
-		og := &operatorsv1.OperatorGroup{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      genName("og-"),
-				Namespace: ns.GetName(),
-			},
-			Spec: operatorsv1.OperatorGroupSpec{
-				ServiceAccountName: sa.GetName(),
-			},
-		}
-		_, err = crc.OperatorsV1().OperatorGroups(ns.GetName()).Create(context.Background(), og, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		// Update the existing OG to use the ServiceAccount
+		Eventually(func() error {
+			existingOG, err := crc.OperatorsV1().OperatorGroups(generatedNamespace.GetName()).Get(context.Background(), fmt.Sprintf("%s-operatorgroup", generatedNamespace.GetName()), metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			existingOG.Spec.ServiceAccountName = sa.GetName()
+			_, err = crc.OperatorsV1().OperatorGroups(generatedNamespace.GetName()).Update(context.Background(), existingOG, metav1.UpdateOptions{})
+			return err
+		}).Should(Succeed())
 
 		// Wait for the OperatorGroup to be synced and have a status.ServiceAccountRef
 		// before moving on. Otherwise the catalog operator treats it as an invalid OperatorGroup
 		// and the InstallPlan is resynced
 		Eventually(func() (*corev1.ObjectReference, error) {
-			outOG, err := crc.OperatorsV1().OperatorGroups(ns.GetName()).Get(context.Background(), og.Name, metav1.GetOptions{})
+			outOG, err := crc.OperatorsV1().OperatorGroups(generatedNamespace.GetName()).Get(context.Background(), fmt.Sprintf("%s-operatorgroup", generatedNamespace.GetName()), metav1.GetOptions{})
 			if err != nil {
 				return nil, err
 			}
@@ -3790,7 +3748,7 @@ var _ = Describe("Install Plan", func() {
 				},
 			},
 		}
-		csv := newCSV("stable", ns.GetName(), "", semver.MustParse("0.1.0"), nil, nil, nil)
+		csv := newCSV("stable", generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), nil, nil, nil)
 
 		// Defer CRD clean up
 		defer func() {
@@ -3811,7 +3769,7 @@ var _ = Describe("Install Plan", func() {
 
 		plan := &operatorsv1alpha1.InstallPlan{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: ns.GetName(),
+				Namespace: generatedNamespace.GetName(),
 				Name:      genName("ip-"),
 			},
 			Spec: operatorsv1alpha1.InstallPlanSpec{
@@ -3861,12 +3819,12 @@ var _ = Describe("Install Plan", func() {
 
 		// delete installplan, and create one with just a CSV resource which should succeed
 		By("installing additional resources that are allowed in the SA")
-		err = crc.OperatorsV1alpha1().InstallPlans(ns.GetName()).Delete(context.Background(), plan.GetName(), metav1.DeleteOptions{})
+		err = crc.OperatorsV1alpha1().InstallPlans(generatedNamespace.GetName()).Delete(context.Background(), plan.GetName(), metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		newPlan := &operatorsv1alpha1.InstallPlan{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: ns.GetName(),
+				Namespace: generatedNamespace.GetName(),
 				Name:      genName("ip-"),
 			},
 			Spec: operatorsv1alpha1.InstallPlanSpec{

--- a/staging/operator-lifecycle-manager/test/e2e/installplan_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/installplan_e2e_test.go
@@ -3391,6 +3391,7 @@ var _ = Describe("Install Plan", func() {
 	})
 
 	It("limits installed resources if the scoped serviceaccount has no permissions", func() {
+		By("creating a scoped serviceaccount specified in the operatorgroup")
 		// create SA
 		sa := &corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{

--- a/staging/operator-lifecycle-manager/test/e2e/operator_groups_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/operator_groups_e2e_test.go
@@ -36,17 +36,21 @@ import (
 
 var _ = Describe("Operator Group", func() {
 	var (
-		c   operatorclient.ClientInterface
-		crc versioned.Interface
+		c                  operatorclient.ClientInterface
+		crc                versioned.Interface
+		generatedNamespace corev1.Namespace
 	)
 
 	BeforeEach(func() {
 		c = ctx.Ctx().KubeClient()
 		crc = ctx.Ctx().OperatorClient()
+
+		generatedNamespace = SetupGeneratedTestNamespace(genName("operator-group-e2e-"))
+
 	})
 
 	AfterEach(func() {
-		TearDown(testNamespace)
+		TearDown(generatedNamespace.GetName())
 	})
 
 	It("e2e functionality", func() {
@@ -71,7 +75,7 @@ var _ = Describe("Operator Group", func() {
 
 		csvName := genName("another-csv-") // must be lowercase for DNS-1123 validation
 
-		opGroupNamespace := genName(testNamespace + "-")
+		opGroupNamespace := genName(generatedNamespace.GetName() + "-")
 		matchingLabel := map[string]string{"inGroup": opGroupNamespace}
 		otherNamespaceName := genName(opGroupNamespace + "-")
 		bothNamespaceNames := opGroupNamespace + "," + otherNamespaceName
@@ -232,7 +236,7 @@ var _ = Describe("Operator Group", func() {
 				if apierrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
-				log(fmt.Sprintf("Error (in %v): %v", testNamespace, fetchErr.Error()))
+				log(fmt.Sprintf("Error (in %v): %v", generatedNamespace.GetName(), fetchErr.Error()))
 				return false, fetchErr
 			}
 			if checkOperatorGroupAnnotations(fetchedCSV, &operatorGroup, true, bothNamespaceNames) == nil {
@@ -886,9 +890,9 @@ var _ = Describe("Operator Group", func() {
 		kvgA := fmt.Sprintf("%s.%s.%s", crdA.Spec.Names.Kind, crdA.Spec.Versions[0].Name, crdA.Spec.Group)
 		kvgB := fmt.Sprintf("%s.%s.%s", crdB.Spec.Names.Kind, crdB.Spec.Versions[0].Name, crdB.Spec.Group)
 		kvgD := fmt.Sprintf("%s.%s.%s", crdD.Spec.Names.Kind, crdD.Spec.Versions[0].Name, crdD.Spec.Group)
-		csvA := newCSV(pkgAStable, testNamespace, "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crdA}, nil, &strategyA)
-		csvB := newCSV(pkgBStable, testNamespace, "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crdA, crdB}, nil, &strategyB)
-		csvD := newCSV(pkgDStable, testNamespace, "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crdD}, nil, &strategyD)
+		csvA := newCSV(pkgAStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crdA}, nil, &strategyA)
+		csvB := newCSV(pkgBStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crdA, crdB}, nil, &strategyB)
+		csvD := newCSV(pkgDStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crdD}, nil, &strategyD)
 
 		// Create namespaces
 		nsA, nsB, nsC, nsD, nsE := genName("a-"), genName("b-"), genName("c-"), genName("d-"), genName("e-")
@@ -1105,7 +1109,7 @@ var _ = Describe("Operator Group", func() {
 		require.NoError(GinkgoT(), awaitAnnotations(GinkgoT(), q, map[string]string{v1.OperatorGroupProvidedAPIsAnnotationKey: ""}))
 
 		// Ensure csvA's deployment is deleted
-		require.NoError(GinkgoT(), waitForDeploymentToDelete(testNamespace, c, pkgAStable))
+		require.NoError(GinkgoT(), waitForDeploymentToDelete(generatedNamespace.GetName(), c, pkgAStable))
 
 		// Await csvB's success
 		_, err = awaitCSV(crc, nsB, csvB.GetName(), csvSucceededChecker)
@@ -1159,8 +1163,8 @@ var _ = Describe("Operator Group", func() {
 		crdB := newCRD(genName(pkgB))
 		kvgA := fmt.Sprintf("%s.%s.%s", crdA.Spec.Names.Kind, crdA.Spec.Versions[0].Name, crdA.Spec.Group)
 		kvgB := fmt.Sprintf("%s.%s.%s", crdB.Spec.Names.Kind, crdB.Spec.Versions[0].Name, crdB.Spec.Group)
-		csvA := newCSV(pkgAStable, testNamespace, "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crdA}, nil, &strategyA)
-		csvB := newCSV(pkgBStable, testNamespace, "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crdB}, nil, &strategyB)
+		csvA := newCSV(pkgAStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crdA}, nil, &strategyA)
+		csvB := newCSV(pkgBStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crdB}, nil, &strategyB)
 
 		// Create namespaces
 		nsA, nsB, nsC, nsD := genName("a-"), genName("b-"), genName("c-"), genName("d-")
@@ -1339,7 +1343,7 @@ var _ = Describe("Operator Group", func() {
 
 		csvName := genName("another-csv-") // must be lowercase for DNS-1123 validation
 
-		opGroupNamespace := testNamespace
+		opGroupNamespace := generatedNamespace.GetName()
 		matchingLabel := map[string]string{"inGroup": opGroupNamespace}
 		otherNamespaceName := genName(opGroupNamespace + "-")
 		GinkgoT().Log("Creating CRD")
@@ -1348,8 +1352,7 @@ var _ = Describe("Operator Group", func() {
 		cleanupCRD, err := createCRD(c, mainCRD)
 		require.NoError(GinkgoT(), err)
 		defer cleanupCRD()
-		GinkgoT().Logf("Getting default operator group 'global-operators' installed via operatorgroup-default.yaml %v", opGroupNamespace)
-		operatorGroup, err := crc.OperatorsV1().OperatorGroups(opGroupNamespace).Get(context.TODO(), "global-operators", metav1.GetOptions{})
+		operatorGroup, err := crc.OperatorsV1().OperatorGroups(opGroupNamespace).Get(context.TODO(), fmt.Sprintf("%v-operatorgroup", opGroupNamespace), metav1.GetOptions{})
 		require.NoError(GinkgoT(), err)
 
 		expectedOperatorGroupStatus := v1.OperatorGroupStatus{
@@ -1506,7 +1509,7 @@ var _ = Describe("Operator Group", func() {
 				if apierrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
-				GinkgoT().Logf("Error (in %v): %v", testNamespace, fetchErr.Error())
+				GinkgoT().Logf("Error (in %v): %v", generatedNamespace.GetName(), fetchErr.Error())
 				return false, fetchErr
 			}
 			if checkOperatorGroupAnnotations(fetchedCSV, operatorGroup, true, corev1.NamespaceAll) == nil {
@@ -1585,7 +1588,7 @@ var _ = Describe("Operator Group", func() {
 
 		csvName := genName("another-csv-")
 
-		newNamespaceName := genName(testNamespace + "-")
+		newNamespaceName := genName(generatedNamespace.GetName() + "-")
 
 		_, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1721,7 +1724,7 @@ var _ = Describe("Operator Group", func() {
 
 		csvName := genName("another-csv-")
 
-		newNamespaceName := genName(testNamespace + "-")
+		newNamespaceName := genName(generatedNamespace.GetName() + "-")
 
 		_, err := c.KubernetesInterface().CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1819,7 +1822,7 @@ var _ = Describe("Operator Group", func() {
 
 		csvName := genName("another-csv-") // must be lowercase for DNS-1123 validation
 
-		opGroupNamespace := testNamespace
+		opGroupNamespace := generatedNamespace.GetName()
 		matchingLabel := map[string]string{"inGroup": opGroupNamespace}
 		otherNamespaceName := genName(opGroupNamespace + "-")
 		GinkgoT().Log("Creating CRD")
@@ -1828,8 +1831,7 @@ var _ = Describe("Operator Group", func() {
 		cleanupCRD, err := createCRD(c, mainCRD)
 		require.NoError(GinkgoT(), err)
 		defer cleanupCRD()
-		GinkgoT().Logf("Getting default operator group 'global-operators' installed via operatorgroup-default.yaml %v", opGroupNamespace)
-		operatorGroup, err := crc.OperatorsV1().OperatorGroups(opGroupNamespace).Get(context.TODO(), "global-operators", metav1.GetOptions{})
+		operatorGroup, err := crc.OperatorsV1().OperatorGroups(opGroupNamespace).Get(context.TODO(), fmt.Sprintf("%v-operatorgroup", opGroupNamespace), metav1.GetOptions{})
 		require.NoError(GinkgoT(), err)
 
 		expectedOperatorGroupStatus := v1.OperatorGroupStatus{
@@ -1986,7 +1988,7 @@ var _ = Describe("Operator Group", func() {
 				if apierrors.IsNotFound(fetchErr) {
 					return false, nil
 				}
-				GinkgoT().Logf("Error (in %v): %v", testNamespace, fetchErr.Error())
+				GinkgoT().Logf("Error (in %v): %v", generatedNamespace.GetName(), fetchErr.Error())
 				return false, fetchErr
 			}
 			if checkOperatorGroupAnnotations(fetchedCSV, operatorGroup, true, corev1.NamespaceAll) == nil {

--- a/staging/operator-lifecycle-manager/test/e2e/packagemanifest_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/packagemanifest_e2e_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	opver "github.com/operator-framework/api/pkg/lib/version"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
@@ -24,19 +25,22 @@ import (
 
 var _ = Describe("Package Manifest API lists available Operators from Catalog Sources", func() {
 	var (
-		crc versioned.Interface
-		pmc pmversioned.Interface
-		c   operatorclient.ClientInterface
+		crc                versioned.Interface
+		pmc                pmversioned.Interface
+		c                  operatorclient.ClientInterface
+		generatedNamespace corev1.Namespace
 	)
 
 	BeforeEach(func() {
 		crc = ctx.Ctx().OperatorClient()
 		pmc = newPMClient()
 		c = ctx.Ctx().KubeClient()
+
+		generatedNamespace = SetupGeneratedTestNamespace(genName("package-manifest-e2e"))
 	})
 
 	AfterEach(func() {
-		TearDown(testNamespace)
+		TearDown(generatedNamespace.GetName())
 	})
 
 	Context("Given a CatalogSource created using the ConfigMap as catalog source type", func() {
@@ -73,7 +77,7 @@ var _ = Describe("Package Manifest API lists available Operators from Catalog So
 			crdPlural := genName("ins")
 			crd := newCRD(crdPlural)
 			catsrcName = genName("mock-ocs")
-			csv = newCSV(packageStable, testNamespace, "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd}, nil, nil)
+			csv = newCSV(packageStable, generatedNamespace.GetName(), "", semver.MustParse("0.1.0"), []apiextensions.CustomResourceDefinition{crd}, nil, nil)
 			csv.SetLabels(map[string]string{"projected": "label"})
 			csv.Spec.Keywords = []string{"foo", "bar"}
 			csv.Spec.Links = []v1alpha1.AppLink{
@@ -108,10 +112,10 @@ var _ = Describe("Package Manifest API lists available Operators from Catalog So
 				},
 			}
 
-			_, cleanupCatalogSource = createInternalCatalogSource(c, crc, catsrcName, testNamespace, manifests, []apiextensions.CustomResourceDefinition{crd}, []v1alpha1.ClusterServiceVersion{csv, csvAlpha})
+			_, cleanupCatalogSource = createInternalCatalogSource(c, crc, catsrcName, generatedNamespace.GetName(), manifests, []apiextensions.CustomResourceDefinition{crd}, []v1alpha1.ClusterServiceVersion{csv, csvAlpha})
 
 			// Verify catalog source was created
-			_, err := fetchCatalogSourceOnStatus(crc, catsrcName, testNamespace, catalogSourceRegistryPodSynced)
+			_, err := fetchCatalogSourceOnStatus(crc, catsrcName, generatedNamespace.GetName(), catalogSourceRegistryPodSynced)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -133,7 +137,7 @@ var _ = Describe("Package Manifest API lists available Operators from Catalog So
 
 			expectedStatus := packagev1.PackageManifestStatus{
 				CatalogSource:          catsrcName,
-				CatalogSourceNamespace: testNamespace,
+				CatalogSourceNamespace: generatedNamespace.GetName(),
 				PackageName:            packageName,
 				Channels: []packagev1.PackageChannel{
 					{
@@ -166,7 +170,7 @@ var _ = Describe("Package Manifest API lists available Operators from Catalog So
 				DefaultChannel: stableChannel,
 			}
 
-			pm, err := fetchPackageManifest(pmc, testNamespace, packageName, packageManifestHasStatus)
+			pm, err := fetchPackageManifest(pmc, generatedNamespace.GetName(), packageName, packageManifestHasStatus)
 			Expect(err).ToNot(HaveOccurred(), "error getting package manifest")
 			Expect(pm).ShouldNot(BeNil())
 			Expect(pm.GetName()).Should(Equal(packageName))
@@ -179,7 +183,7 @@ var _ = Describe("Package Manifest API lists available Operators from Catalog So
 		It("lists PackageManifest and ensures it has valid PackageManifest item", func() {
 			// Get a PackageManifestList and ensure it has the correct items
 			Eventually(func() (bool, error) {
-				pmList, err := pmc.OperatorsV1().PackageManifests(testNamespace).List(context.TODO(), metav1.ListOptions{})
+				pmList, err := pmc.OperatorsV1().PackageManifests(generatedNamespace.GetName()).List(context.TODO(), metav1.ListOptions{})
 				return containsPackageManifest(pmList.Items, packageName), err
 			}).Should(BeTrue(), "required package name not found in the list")
 		})
@@ -187,7 +191,7 @@ var _ = Describe("Package Manifest API lists available Operators from Catalog So
 		It("gets the icon from the default channel", func() {
 			var res rest.Result
 			Eventually(func() error {
-				res = pmc.OperatorsV1().RESTClient().Get().Resource("packagemanifests").SubResource("icon").Namespace(testNamespace).Name(packageName).Do(context.Background())
+				res = pmc.OperatorsV1().RESTClient().Get().Resource("packagemanifests").SubResource("icon").Namespace(generatedNamespace.GetName()).Name(packageName).Do(context.Background())
 				return res.Error()
 			}).Should(Succeed(), "error getting icon")
 
@@ -220,7 +224,7 @@ var _ = Describe("Package Manifest API lists available Operators from Catalog So
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      sourceName,
-					Namespace: testNamespace,
+					Namespace: generatedNamespace.GetName(),
 					Labels:    map[string]string{"olm.catalogSource": sourceName},
 				},
 				Spec: v1alpha1.CatalogSourceSpec{
@@ -249,7 +253,7 @@ var _ = Describe("Package Manifest API lists available Operators from Catalog So
 
 		It("lists the CatalogSource contents using the PackageManifest API", func() {
 
-			pm, err := fetchPackageManifest(pmc, testNamespace, packageName, packageManifestHasStatus)
+			pm, err := fetchPackageManifest(pmc, generatedNamespace.GetName(), packageName, packageManifestHasStatus)
 			Expect(err).NotTo(HaveOccurred(), "error getting package manifest")
 			Expect(pm).ShouldNot(BeNil())
 			Expect(pm.GetName()).Should(Equal(packageName))
@@ -267,18 +271,18 @@ var _ = Describe("Package Manifest API lists available Operators from Catalog So
 		When("the display name for catalog source is updated", func() {
 
 			BeforeEach(func() {
-				pm, err := fetchPackageManifest(pmc, testNamespace, packageName, packageManifestHasStatus)
+				pm, err := fetchPackageManifest(pmc, generatedNamespace.GetName(), packageName, packageManifestHasStatus)
 				Expect(err).NotTo(HaveOccurred(), "error getting package manifest")
 				Expect(pm).ShouldNot(BeNil())
 				Expect(pm.GetName()).Should(Equal(packageName))
 				Expect(pm.Status.CatalogSourceDisplayName).Should(Equal(displayName))
 
-				catalogSource, err = crc.OperatorsV1alpha1().CatalogSources(testNamespace).Get(context.TODO(), catalogSource.GetName(), metav1.GetOptions{})
+				catalogSource, err = crc.OperatorsV1alpha1().CatalogSources(generatedNamespace.GetName()).Get(context.TODO(), catalogSource.GetName(), metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred(), "error getting catalogSource")
 
 				displayName = "updated Name"
 				catalogSource.Spec.DisplayName = displayName
-				catalogSource, err = crc.OperatorsV1alpha1().CatalogSources(testNamespace).Update(context.TODO(), catalogSource, metav1.UpdateOptions{})
+				catalogSource, err = crc.OperatorsV1alpha1().CatalogSources(generatedNamespace.GetName()).Update(context.TODO(), catalogSource, metav1.UpdateOptions{})
 				Expect(err).NotTo(HaveOccurred(), "error updating catalogSource")
 				Expect(catalogSource.Spec.DisplayName).Should(Equal(displayName))
 			})
@@ -286,7 +290,7 @@ var _ = Describe("Package Manifest API lists available Operators from Catalog So
 			It("should successfully update the CatalogSource field", func() {
 
 				Eventually(func() (string, error) {
-					pm, err := fetchPackageManifest(pmc, testNamespace, packageName,
+					pm, err := fetchPackageManifest(pmc, generatedNamespace.GetName(), packageName,
 						packageManifestHasStatus)
 					if err != nil {
 						return "", err


### PR DESCRIPTION
This commit updates all of OLM e2e test suites to generate a namespace rather than using a hard coded test namespace passed into the test as a parameter. The motivation for this change include:
1. Decreasing the opportunity for tests to influence each other. Tests are not guaranteed to cleanup after themselves and may influence the results of other tests.
2. Some distributions of OLM run alongside other controllers which may revert changes to resources in predetermined namespaces.

Signed-off-by: Alexander Greene <greene.al1991@gmail.com>

Upstream-repository: operator-lifecycle-manager
Upstream-commit: 108d6db0d11d5224214904c02e91391b0aada286