### PR TITLE
OPRUN-3063: Microshift manifests remove collection-profiles cronjob from kustomization

### DIFF
--- a/microshift-manifests/kustomization.yaml
+++ b/microshift-manifests/kustomization.yaml
@@ -17,7 +17,6 @@ resources:
   - 0000_50_olm_01-olm-operator.serviceaccount.yaml
   - 0000_50_olm_02-olmconfig.yaml
   - 0000_50_olm_02-services.yaml
-  - 0000_50_olm_07-collect-profiles.cronjob.yaml
   - 0000_50_olm_07-olm-operator.deployment.yaml
   - 0000_50_olm_08-catalog-operator.deployment.yaml
   - 0000_50_olm_09-aggregated.clusterrole.yaml

--- a/scripts/generate_crds_manifests.sh
+++ b/scripts/generate_crds_manifests.sh
@@ -520,7 +520,7 @@ microshift_manifests_files=$(find "${ROOT_DIR}/microshift-manifests" -type f -na
 # Let's sort the files so that we can have a deterministic order
 microshift_manifests_files=$(echo "${microshift_manifests_files}" | sort)
 # files to ignore, substring match.
-files_to_ignore=("ibm-cloud-managed.yaml" "kustomization.yaml" "psm-operator" "removed")
+files_to_ignore=("ibm-cloud-managed.yaml" "kustomization.yaml" "psm-operator" "removed" "collect-profiles")
 
 # Add all the manifests files to the kustomization file while ignoring the files in the files_to_ignore list
 for file in ${microshift_manifests_files}; do


### PR DESCRIPTION
Removes the collect profiles cronjob from the microshift kustomization.yaml file.