### PR TITLE
OPRUN-3063: Microshift manifests fixes

### DIFF
--- a/microshift-manifests/0000_50_olm_15-csv-viewer.rbac.yaml
+++ b/microshift-manifests/0000_50_olm_15-csv-viewer.rbac.yaml
@@ -7,7 +7,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   name: copied-csv-viewer
-  namespace: openshift
+  namespace: openshift-operator-lifecycle-manager
 rules:
   - apiGroups:
       - "operators.coreos.com"
@@ -27,7 +27,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   name: copied-csv-viewers
-  namespace: openshift
+  namespace: openshift-operator-lifecycle-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/microshift-manifests/kustomization.yaml
+++ b/microshift-manifests/kustomization.yaml
@@ -22,6 +22,3 @@ resources:
   - 0000_50_olm_09-aggregated.clusterrole.yaml
   - 0000_50_olm_13-operatorgroup-default.yaml
   - 0000_50_olm_15-csv-viewer.rbac.yaml
-  - 0000_50_olm_99-operatorstatus.yaml
-  - 0000_90_olm_00-service-monitor.yaml
-  - 0000_90_olm_01-prometheus-rule.yaml

--- a/scripts/generate_crds_manifests.sh
+++ b/scripts/generate_crds_manifests.sh
@@ -520,7 +520,7 @@ microshift_manifests_files=$(find "${ROOT_DIR}/microshift-manifests" -type f -na
 # Let's sort the files so that we can have a deterministic order
 microshift_manifests_files=$(echo "${microshift_manifests_files}" | sort)
 # files to ignore, substring match.
-files_to_ignore=("ibm-cloud-managed.yaml" "kustomization.yaml" "psm-operator" "removed" "collect-profiles")
+files_to_ignore=("ibm-cloud-managed.yaml" "kustomization.yaml" "psm-operator" "removed" "collect-profiles" "prometheus" "service-monitor" "operatorstatus")
 
 # Add all the manifests files to the kustomization file while ignoring the files in the files_to_ignore list
 for file in ${microshift_manifests_files}; do
@@ -541,3 +541,5 @@ done
 #
 ${SED} -i '/- --writeStatusName/,+3d' ${ROOT_DIR}/microshift-manifests/0000_50_olm_07-olm-operator.deployment.yaml 
 
+# Replace the namespace openshift, as it doesn't exist on microshift, in the rbac file
+${SED} -i 's/  namespace: openshift/  namespace: openshift-operator-lifecycle-manager/g' ${ROOT_DIR}/microshift-manifests/0000_50_olm_15-csv-viewer.rbac.yaml


### PR DESCRIPTION
This PR includes some changes to the manifests generated for microshift.

- Don't include manifests in the kustomization.yaml file from the monitoring API as it is not available
- Use another namespace instead of openshift in the csv-viewer rbac file, as the "openshift" namespace is not available in microshift.