### PR TITLE
OPRUN-3100: Update Subscription Status with Deprecation Warnings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,9 @@ require (
 	github.com/mikefarah/yq/v3 v3.0.0-20201202084205-8846255d1c37
 	github.com/onsi/ginkgo/v2 v2.9.5
 	github.com/openshift/api v3.9.0+incompatible
-	github.com/operator-framework/api v0.19.0
+	github.com/operator-framework/api v0.20.0
 	github.com/operator-framework/operator-lifecycle-manager v0.0.0-00010101000000-000000000000
-	github.com/operator-framework/operator-registry v1.32.0
+	github.com/operator-framework/operator-registry v1.33.0
 	github.com/sirupsen/logrus v1.9.2
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.3

--- a/staging/operator-lifecycle-manager/go.mod
+++ b/staging/operator-lifecycle-manager/go.mod
@@ -24,8 +24,8 @@ require (
 	github.com/onsi/gomega v1.27.7
 	github.com/openshift/api v3.9.0+incompatible
 	github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a
-	github.com/operator-framework/api v0.19.0
-	github.com/operator-framework/operator-registry v1.32.0
+	github.com/operator-framework/api v0.20.0
+	github.com/operator-framework/operator-registry v1.33.0
 	github.com/otiai10/copy v1.12.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.15.1

--- a/staging/operator-lifecycle-manager/go.sum
+++ b/staging/operator-lifecycle-manager/go.sum
@@ -604,10 +604,17 @@ github.com/openshift/api v0.0.0-20221021112143-4226c2167e40 h1:PxjGCA72RtsdHWToZ
 github.com/openshift/api v0.0.0-20221021112143-4226c2167e40/go.mod h1:aQ6LDasvHMvHZXqLHnX2GRmnfTWCF/iIwz8EMTTIE9A=
 github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c h1:CV76yFOTXmq9VciBR3Bve5ZWzSxdft7gaMVB3kS0rwg=
 github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c/go.mod h1:lFMO8mLHXWFzSdYvGNo8ivF9SfF6zInA8ZGw4phRnUE=
+<<<<<<< HEAD
 github.com/operator-framework/api v0.19.0 h1:QU1CTJU+CufoeneA5rsNlP/uP96s8vDHWUYDFZTauzA=
 github.com/operator-framework/api v0.19.0/go.mod h1:SCCslqke6AVOJ5JM+NqNE1CHuAgJLScsL66pnPaSMXs=
 github.com/operator-framework/operator-registry v1.32.0 h1:RNazXYt3vBf5FZ+JrNNjq4bNh3tDwlkwZJnC+kmCeKk=
 github.com/operator-framework/operator-registry v1.32.0/go.mod h1:89VshAf6+n0V12vdh43+WOi8i1+XpY+kg6Ao4JO0y6k=
+=======
+github.com/operator-framework/api v0.20.0 h1:A2YCRhr+6s0k3pRJacnwjh1Ue8BqjIGuQ2jvPg9XCB4=
+github.com/operator-framework/api v0.20.0/go.mod h1:rXPOhrQ6mMeXqCmpDgt1ALoar9ZlHL+Iy5qut9R99a4=
+github.com/operator-framework/operator-registry v1.33.0 h1:rFvYf6vLdXSUhoePhg8w1S5FHgyFraiNLXDwl47epck=
+github.com/operator-framework/operator-registry v1.33.0/go.mod h1:1V/m2m7iH/o5ROEuMxWa/yhj4ExaPGT6V/ncGS+m6Js=
+>>>>>>> b9638dcaa (Adds the OperatorDeprecated Condition to the status of Subscriptions when the bundle has been deprecated.)
 github.com/otiai10/copy v1.12.0 h1:cLMgSQnXBs1eehF0Wy/FAGsgDTDmAqFR7rQylBb1nDY=
 github.com/otiai10/copy v1.12.0/go.mod h1:rSaLseMUsZFFbsFGc7wCJnnkTAvdc5L6VWxPE4308Ww=
 github.com/otiai10/mint v1.5.1 h1:XaPLeE+9vGbuyEHem1JNk3bYc7KKqyI/na0/mLd/Kks=

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
@@ -346,6 +346,7 @@ func NewOperator(ctx context.Context, kubeconfigPath string, clock utilclock.Clo
 		subscription.WithAppendedReconcilers(subscription.ReconcilerFromLegacySyncHandler(op.syncSubscriptions, nil)),
 		subscription.WithRegistryReconcilerFactory(op.reconciler),
 		subscription.WithGlobalCatalogNamespace(op.namespace),
+		subscription.WithSourceProvider(resolverSourceProvider),
 	)
 	if err != nil {
 		return nil, err

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/subscription/config.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/subscription/config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler"
+	resolverCache "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubestate"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorlister"
 )
@@ -26,6 +27,7 @@ type syncerConfig struct {
 	reconcilers               kubestate.ReconcilerChain
 	registryReconcilerFactory reconciler.RegistryReconcilerFactory
 	globalCatalogNamespace    string
+	sourceProvider            resolverCache.SourceProvider
 }
 
 // SyncerOption is a configuration option for a subscription syncer.
@@ -125,6 +127,12 @@ func WithRegistryReconcilerFactory(r reconciler.RegistryReconcilerFactory) Synce
 func WithGlobalCatalogNamespace(namespace string) SyncerOption {
 	return func(config *syncerConfig) {
 		config.globalCatalogNamespace = namespace
+	}
+}
+
+func WithSourceProvider(provider resolverCache.SourceProvider) SyncerOption {
+	return func(config *syncerConfig) {
+		config.sourceProvider = provider
 	}
 }
 

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/subscription/syncer.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/subscription/syncer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/operator-framework/api/pkg/operators/install"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	listers "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
+	resolverCache "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubestate"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/metrics"
@@ -34,6 +35,7 @@ type subscriptionSyncer struct {
 	installPlanLister      listers.InstallPlanLister
 	globalCatalogNamespace string
 	notify                 kubestate.NotifyFunc
+	sourceProvider         resolverCache.SourceProvider
 }
 
 // now returns the Syncer's current time.
@@ -214,6 +216,7 @@ func newSyncerWithConfig(ctx context.Context, config *syncerConfig) (kubestate.S
 		reconcilers:       config.reconcilers,
 		subscriptionCache: config.subscriptionInformer.GetIndexer(),
 		installPlanLister: config.lister.OperatorsV1alpha1().InstallPlanLister(),
+		sourceProvider:    config.sourceProvider,
 		notify: func(event kubestate.ResourceEvent) {
 			// Notify Subscriptions by enqueuing to the Subscription queue.
 			config.subscriptionQueue.Add(event)
@@ -234,6 +237,7 @@ func newSyncerWithConfig(ctx context.Context, config *syncerConfig) (kubestate.S
 			catalogLister:             config.lister.OperatorsV1alpha1().CatalogSourceLister(),
 			registryReconcilerFactory: config.registryReconcilerFactory,
 			globalCatalogNamespace:    config.globalCatalogNamespace,
+			sourceProvider:            config.sourceProvider,
 		},
 	}
 	s.reconcilers = append(defaultReconcilers, s.reconcilers...)

--- a/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/cache/operators.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/cache/operators.go
@@ -140,11 +140,18 @@ type OperatorSourceInfo struct {
 	StartingCSV    string
 	Catalog        SourceKey
 	DefaultChannel bool
+	Deprecations   *Deprecations
 	Subscription   *v1alpha1.Subscription
 }
 
 func (i *OperatorSourceInfo) String() string {
 	return fmt.Sprintf("%s/%s in %s/%s", i.Package, i.Channel, i.Catalog.Name, i.Catalog.Namespace)
+}
+
+type Deprecations struct {
+	Package *api.Deprecation
+	Channel *api.Deprecation
+	Bundle  *api.Deprecation
 }
 
 type Entry struct {

--- a/staging/operator-lifecycle-manager/test/e2e/testdata/subscription/example-operator.v0.2.0-deprecations.yaml
+++ b/staging/operator-lifecycle-manager/test/e2e/testdata/subscription/example-operator.v0.2.0-deprecations.yaml
@@ -1,0 +1,41 @@
+---
+schema: olm.package
+name: packageA
+defaultChannel: stable
+---
+schema: olm.channel
+package: packageA
+name: stable
+entries:
+  - name: example-operator.v0.2.0
+    replaces: example-operator.v0.1.0
+---
+schema: olm.bundle
+name: example-operator.v0.2.0
+package: packageA
+image: quay.io/olmtest/example-operator-bundle:0.2.0
+properties:
+  - type: olm.gvk
+    value:
+      group: example.com
+      kind: TestA
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: packageA
+      version: 1.0.1
+---
+schema: olm.deprecations
+package: packageA
+entries:
+  - reference:
+      schema: olm.package
+    message: packageA has been deprecated. Please switch to packageB.
+  - reference:
+      schema: olm.channel
+      name: stable
+    message: channel "stable" has been deprecated. Please switch to a different one.
+  - reference:
+      schema: olm.bundle
+      name: example-operator.v0.2.0
+    message: bundle "example-operator.v0.2.0" has been deprecated. Please switch to a different one.

--- a/staging/operator-lifecycle-manager/test/e2e/testdata/subscription/example-operator.v0.3.0-deprecations.yaml
+++ b/staging/operator-lifecycle-manager/test/e2e/testdata/subscription/example-operator.v0.3.0-deprecations.yaml
@@ -1,0 +1,37 @@
+---
+schema: olm.package
+name: packageA
+defaultChannel: stable
+---
+schema: olm.channel
+package: packageA
+name: stable
+entries:
+  - name: example-operator.v0.3.0
+    replaces: example-operator.v0.2.0
+---
+schema: olm.bundle
+name: example-operator.v0.3.0
+package: packageA
+image: quay.io/olmtest/example-operator-bundle:0.3.0
+properties:
+  - type: olm.gvk
+    value:
+      group: example.com
+      kind: TestA
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: packageA
+      version: 0.3.0
+---
+schema: olm.deprecations
+package: packageA
+entries:
+  - reference:
+      schema: olm.package
+    message: packageA has been deprecated. Please switch to packageB.
+  - reference:
+      schema: olm.channel
+      name: stable
+    message: channel "stable" has been deprecated. Please switch to a different one.

--- a/staging/operator-lifecycle-manager/vendor/github.com/operator-framework/api/pkg/operators/v1alpha1/subscription_types.go
+++ b/staging/operator-lifecycle-manager/vendor/github.com/operator-framework/api/pkg/operators/v1alpha1/subscription_types.go
@@ -1,0 +1,353 @@
+package v1alpha1
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	SubscriptionKind          = "Subscription"
+	SubscriptionCRDAPIVersion = GroupName + "/" + GroupVersion
+)
+
+// SubscriptionState tracks when updates are available, installing, or service is up to date
+type SubscriptionState string
+
+const (
+	SubscriptionStateNone             = ""
+	SubscriptionStateFailed           = "UpgradeFailed"
+	SubscriptionStateUpgradeAvailable = "UpgradeAvailable"
+	SubscriptionStateUpgradePending   = "UpgradePending"
+	SubscriptionStateAtLatest         = "AtLatestKnown"
+)
+
+const (
+	SubscriptionReasonInvalidCatalog   ConditionReason = "InvalidCatalog"
+	SubscriptionReasonUpgradeSucceeded ConditionReason = "UpgradeSucceeded"
+)
+
+// SubscriptionSpec defines an Application that can be installed
+type SubscriptionSpec struct {
+	CatalogSource          string              `json:"source"`
+	CatalogSourceNamespace string              `json:"sourceNamespace"`
+	Package                string              `json:"name"`
+	Channel                string              `json:"channel,omitempty"`
+	StartingCSV            string              `json:"startingCSV,omitempty"`
+	InstallPlanApproval    Approval            `json:"installPlanApproval,omitempty"`
+	Config                 *SubscriptionConfig `json:"config,omitempty"`
+}
+
+// SubscriptionConfig contains configuration specified for a subscription.
+type SubscriptionConfig struct {
+	// Selector is the label selector for pods to be configured.
+	// Existing ReplicaSets whose pods are
+	// selected by this will be the ones affected by this deployment.
+	// It must match the pod template's labels.
+	Selector *metav1.LabelSelector `json:"selector,omitempty"`
+
+	// NodeSelector is a selector which must be true for the pod to fit on a node.
+	// Selector which must match a node's labels for the pod to be scheduled on that node.
+	// More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+	// +optional
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+
+	// Tolerations are the pod's tolerations.
+	// +optional
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+
+	// Resources represents compute resources required by this container.
+	// Immutable.
+	// More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+	// +optional
+	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
+
+	// EnvFrom is a list of sources to populate environment variables in the container.
+	// The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+	// will be reported as an event when the container is starting. When a key exists in multiple
+	// sources, the value associated with the last source will take precedence.
+	// Values defined by an Env with a duplicate key will take precedence.
+	// Immutable.
+	// +optional
+	EnvFrom []corev1.EnvFromSource `json:"envFrom,omitempty"`
+	// Env is a list of environment variables to set in the container.
+	// Cannot be updated.
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	// +optional
+	Env []corev1.EnvVar `json:"env,omitempty" patchMergeKey:"name" patchStrategy:"merge"`
+
+	// List of Volumes to set in the podSpec.
+	// +optional
+	Volumes []corev1.Volume `json:"volumes,omitempty"`
+
+	// List of VolumeMounts to set in the container.
+	// +optional
+	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty"`
+
+	// If specified, overrides the pod's scheduling constraints.
+	// nil sub-attributes will *not* override the original values in the pod.spec for those sub-attributes.
+	// Use empty object ({}) to erase original sub-attribute values.
+	// +optional
+	Affinity *corev1.Affinity `json:"affinity,omitempty" protobuf:"bytes,18,opt,name=affinity"`
+}
+
+// SubscriptionConditionType indicates an explicit state condition about a Subscription in "abnormal-true"
+// polarity form (see https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties).
+type SubscriptionConditionType string
+
+const (
+	// SubscriptionCatalogSourcesUnhealthy indicates that some or all of the CatalogSources to be used in resolution are unhealthy.
+	SubscriptionCatalogSourcesUnhealthy SubscriptionConditionType = "CatalogSourcesUnhealthy"
+
+	// SubscriptionInstallPlanMissing indicates that a Subscription's InstallPlan is missing.
+	SubscriptionInstallPlanMissing SubscriptionConditionType = "InstallPlanMissing"
+
+	// SubscriptionInstallPlanPending indicates that a Subscription's InstallPlan is pending installation.
+	SubscriptionInstallPlanPending SubscriptionConditionType = "InstallPlanPending"
+
+	// SubscriptionInstallPlanFailed indicates that the installation of a Subscription's InstallPlan has failed.
+	SubscriptionInstallPlanFailed SubscriptionConditionType = "InstallPlanFailed"
+
+	// SubscriptionResolutionFailed indicates that the dependency resolution in the namespace in which the subscription is created has failed
+	SubscriptionResolutionFailed SubscriptionConditionType = "ResolutionFailed"
+
+	// SubscriptionBundleUnpacking indicates that the unpack job is currently running
+	SubscriptionBundleUnpacking SubscriptionConditionType = "BundleUnpacking"
+
+	// SubscriptionBundleUnpackFailed indicates that the unpack job failed
+	SubscriptionBundleUnpackFailed SubscriptionConditionType = "BundleUnpackFailed"
+
+	// SubscriptionDeprecated is a roll-up condition which indicates that the Operator currently installed with this Subscription
+	//has been deprecated. It will be present when any of the three deprecation types (Package, Channel, Bundle) are present.
+	SubscriptionDeprecated SubscriptionConditionType = "Deprecated"
+
+	// SubscriptionOperatorDeprecated indicates that the Package currently installed with this Subscription has been deprecated.
+	SubscriptionPackageDeprecated SubscriptionConditionType = "PackageDeprecated"
+
+	// SubscriptionOperatorDeprecated indicates that the Channel used with this Subscription has been deprecated.
+	SubscriptionChannelDeprecated SubscriptionConditionType = "ChannelDeprecated"
+
+	// SubscriptionOperatorDeprecated indicates that the Bundle currently installed with this Subscription has been deprecated.
+	SubscriptionBundleDeprecated SubscriptionConditionType = "BundleDeprecated"
+)
+
+const (
+	// NoCatalogSourcesFound is a reason string for Subscriptions with unhealthy CatalogSources due to none being available.
+	NoCatalogSourcesFound = "NoCatalogSourcesFound"
+
+	// AllCatalogSourcesHealthy is a reason string for Subscriptions that transitioned due to all CatalogSources being healthy.
+	AllCatalogSourcesHealthy = "AllCatalogSourcesHealthy"
+
+	// CatalogSourcesAdded is a reason string for Subscriptions that transitioned due to CatalogSources being added.
+	CatalogSourcesAdded = "CatalogSourcesAdded"
+
+	// CatalogSourcesUpdated is a reason string for Subscriptions that transitioned due to CatalogSource being updated.
+	CatalogSourcesUpdated = "CatalogSourcesUpdated"
+
+	// CatalogSourcesDeleted is a reason string for Subscriptions that transitioned due to CatalogSources being removed.
+	CatalogSourcesDeleted = "CatalogSourcesDeleted"
+
+	// UnhealthyCatalogSourceFound is a reason string for Subscriptions that transitioned because an unhealthy CatalogSource was found.
+	UnhealthyCatalogSourceFound = "UnhealthyCatalogSourceFound"
+
+	// ReferencedInstallPlanNotFound is a reason string for Subscriptions that transitioned due to a referenced InstallPlan not being found.
+	ReferencedInstallPlanNotFound = "ReferencedInstallPlanNotFound"
+
+	// InstallPlanNotYetReconciled is a reason string for Subscriptions that transitioned due to a referenced InstallPlan not being reconciled yet.
+	InstallPlanNotYetReconciled = "InstallPlanNotYetReconciled"
+
+	// InstallPlanFailed is a reason string for Subscriptions that transitioned due to a referenced InstallPlan failing without setting an explicit failure condition.
+	InstallPlanFailed = "InstallPlanFailed"
+)
+
+// SubscriptionCondition represents the latest available observations of a Subscription's state.
+type SubscriptionCondition struct {
+	// Type is the type of Subscription condition.
+	Type SubscriptionConditionType `json:"type" description:"type of Subscription condition"`
+
+	// Status is the status of the condition, one of True, False, Unknown.
+	Status corev1.ConditionStatus `json:"status" description:"status of the condition, one of True, False, Unknown"`
+
+	// Reason is a one-word CamelCase reason for the condition's last transition.
+	// +optional
+	Reason string `json:"reason,omitempty" description:"one-word CamelCase reason for the condition's last transition"`
+
+	// Message is a human-readable message indicating details about last transition.
+	// +optional
+	Message string `json:"message,omitempty" description:"human-readable message indicating details about last transition"`
+
+	// LastHeartbeatTime is the last time we got an update on a given condition
+	// +optional
+	LastHeartbeatTime *metav1.Time `json:"lastHeartbeatTime,omitempty" description:"last time we got an update on a given condition"`
+
+	// LastTransitionTime is the last time the condition transit from one status to another
+	// +optional
+	LastTransitionTime *metav1.Time `json:"lastTransitionTime,omitempty" description:"last time the condition transit from one status to another" hash:"ignore"`
+}
+
+// Equals returns true if a SubscriptionCondition equals the one given, false otherwise.
+// Equality is determined by the equality of the type, status, reason, and message fields ONLY.
+func (s SubscriptionCondition) Equals(condition SubscriptionCondition) bool {
+	return s.Type == condition.Type && s.Status == condition.Status && s.Reason == condition.Reason && s.Message == condition.Message
+}
+
+type SubscriptionStatus struct {
+	// CurrentCSV is the CSV the Subscription is progressing to.
+	// +optional
+	CurrentCSV string `json:"currentCSV,omitempty"`
+
+	// InstalledCSV is the CSV currently installed by the Subscription.
+	// +optional
+	InstalledCSV string `json:"installedCSV,omitempty"`
+
+	// Install is a reference to the latest InstallPlan generated for the Subscription.
+	// DEPRECATED: InstallPlanRef
+	// +optional
+	Install *InstallPlanReference `json:"installplan,omitempty"`
+
+	// State represents the current state of the Subscription
+	// +optional
+	State SubscriptionState `json:"state,omitempty"`
+
+	// Reason is the reason the Subscription was transitioned to its current state.
+	// +optional
+	Reason ConditionReason `json:"reason,omitempty"`
+
+	// InstallPlanGeneration is the current generation of the installplan
+	// +optional
+	InstallPlanGeneration int `json:"installPlanGeneration,omitempty"`
+
+	// InstallPlanRef is a reference to the latest InstallPlan that contains the Subscription's current CSV.
+	// +optional
+	InstallPlanRef *corev1.ObjectReference `json:"installPlanRef,omitempty"`
+
+	// CatalogHealth contains the Subscription's view of its relevant CatalogSources' status.
+	// It is used to determine SubscriptionStatusConditions related to CatalogSources.
+	// +optional
+	CatalogHealth []SubscriptionCatalogHealth `json:"catalogHealth,omitempty"`
+
+	// Conditions is a list of the latest available observations about a Subscription's current state.
+	// +optional
+	Conditions []SubscriptionCondition `json:"conditions,omitempty" hash:"set"`
+
+	// LastUpdated represents the last time that the Subscription status was updated.
+	LastUpdated metav1.Time `json:"lastUpdated"`
+}
+
+// GetCondition returns the SubscriptionCondition of the given type if it exists in the SubscriptionStatus' Conditions.
+// Returns a condition of the given type with a ConditionStatus of "Unknown" if not found.
+func (s SubscriptionStatus) GetCondition(conditionType SubscriptionConditionType) SubscriptionCondition {
+	for _, cond := range s.Conditions {
+		if cond.Type == conditionType {
+			return cond
+		}
+	}
+
+	return SubscriptionCondition{
+		Type:   conditionType,
+		Status: corev1.ConditionUnknown,
+	}
+}
+
+// SetCondition sets the given SubscriptionCondition in the SubscriptionStatus' Conditions.
+func (s *SubscriptionStatus) SetCondition(condition SubscriptionCondition) {
+	for i, cond := range s.Conditions {
+		if cond.Type == condition.Type {
+			s.Conditions[i] = condition
+			return
+		}
+	}
+
+	s.Conditions = append(s.Conditions, condition)
+}
+
+// RemoveConditions removes any conditions of the given types from the SubscriptionStatus' Conditions.
+func (s *SubscriptionStatus) RemoveConditions(remove ...SubscriptionConditionType) {
+	exclusions := map[SubscriptionConditionType]struct{}{}
+	for _, r := range remove {
+		exclusions[r] = struct{}{}
+	}
+
+	var filtered []SubscriptionCondition
+	for _, cond := range s.Conditions {
+		if _, ok := exclusions[cond.Type]; ok {
+			// Skip excluded condition types
+			continue
+		}
+		filtered = append(filtered, cond)
+	}
+
+	s.Conditions = filtered
+}
+
+type InstallPlanReference struct {
+	APIVersion string    `json:"apiVersion"`
+	Kind       string    `json:"kind"`
+	Name       string    `json:"name"`
+	UID        types.UID `json:"uuid"`
+}
+
+// SubscriptionCatalogHealth describes the health of a CatalogSource the Subscription knows about.
+type SubscriptionCatalogHealth struct {
+	// CatalogSourceRef is a reference to a CatalogSource.
+	CatalogSourceRef *corev1.ObjectReference `json:"catalogSourceRef"`
+
+	// LastUpdated represents the last time that the CatalogSourceHealth changed
+	LastUpdated *metav1.Time `json:"lastUpdated"`
+
+	// Healthy is true if the CatalogSource is healthy; false otherwise.
+	Healthy bool `json:"healthy"`
+}
+
+// Equals returns true if a SubscriptionCatalogHealth equals the one given, false otherwise.
+// Equality is based SOLEY on health and UID.
+func (s SubscriptionCatalogHealth) Equals(health SubscriptionCatalogHealth) bool {
+	return s.Healthy == health.Healthy && s.CatalogSourceRef.UID == health.CatalogSourceRef.UID
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +genclient
+// +kubebuilder:resource:shortName={sub, subs},categories=olm
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Package",type=string,JSONPath=`.spec.name`,description="The package subscribed to"
+// +kubebuilder:printcolumn:name="Source",type=string,JSONPath=`.spec.source`,description="The catalog source for the specified package"
+// +kubebuilder:printcolumn:name="Channel",type=string,JSONPath=`.spec.channel`,description="The channel of updates to subscribe to"
+
+// Subscription keeps operators up to date by tracking changes to Catalogs.
+type Subscription struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata"`
+
+	Spec *SubscriptionSpec `json:"spec"`
+	// +optional
+	Status SubscriptionStatus `json:"status"`
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// SubscriptionList is a list of Subscription resources.
+type SubscriptionList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata"`
+
+	Items []Subscription `json:"items"`
+}
+
+// GetInstallPlanApproval gets the configured install plan approval or the default
+func (s *Subscription) GetInstallPlanApproval() Approval {
+	if s.Spec.InstallPlanApproval == ApprovalManual {
+		return ApprovalManual
+	}
+	return ApprovalAutomatic
+}
+
+// NewInstallPlanReference returns an InstallPlanReference for the given ObjectReference.
+func NewInstallPlanReference(ref *corev1.ObjectReference) *InstallPlanReference {
+	return &InstallPlanReference{
+		APIVersion: ref.APIVersion,
+		Kind:       ref.Kind,
+		Name:       ref.Name,
+		UID:        ref.UID,
+	}
+}

--- a/staging/operator-lifecycle-manager/vendor/modules.txt
+++ b/staging/operator-lifecycle-manager/vendor/modules.txt
@@ -1,11 +1,11 @@
-# github.com/AdaLogics/go-fuzz-headers v0.0.0-20230106234847-43070de90fa1
-## explicit; go 1.18
+# github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24
+## explicit; go 1.20
 github.com/AdaLogics/go-fuzz-headers
 # github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161
 ## explicit; go 1.16
 github.com/Azure/go-ansiterm
 github.com/Azure/go-ansiterm/winterm
-# github.com/BurntSushi/toml v1.2.1
+# github.com/BurntSushi/toml v1.3.2
 ## explicit; go 1.16
 github.com/BurntSushi/toml
 github.com/BurntSushi/toml/internal
@@ -34,10 +34,10 @@ github.com/Microsoft/go-winio/backuptar
 github.com/Microsoft/go-winio/internal/fs
 github.com/Microsoft/go-winio/internal/socket
 github.com/Microsoft/go-winio/internal/stringbuffer
+github.com/Microsoft/go-winio/pkg/bindfilter
 github.com/Microsoft/go-winio/pkg/guid
-github.com/Microsoft/go-winio/tools/mkwinsyscall
 github.com/Microsoft/go-winio/vhd
-# github.com/Microsoft/hcsshim v0.10.0-rc.7
+# github.com/Microsoft/hcsshim v0.12.0-rc.0
 ## explicit; go 1.18
 github.com/Microsoft/hcsshim
 github.com/Microsoft/hcsshim/computestorage
@@ -68,15 +68,14 @@ github.com/Microsoft/hcsshim/pkg/ociwclayer
 # github.com/NYTimes/gziphandler v1.1.1
 ## explicit; go 1.11
 github.com/NYTimes/gziphandler
-# github.com/adrg/xdg v0.4.0
+# github.com/alessio/shellescape v1.4.1
 ## explicit; go 1.14
-github.com/adrg/xdg
-github.com/adrg/xdg/internal/pathutil
+github.com/alessio/shellescape
 # github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df
 ## explicit; go 1.18
 github.com/antlr/antlr4/runtime/Go/antlr/v4
-# github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535
-## explicit; go 1.12
+# github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
+## explicit; go 1.13
 github.com/asaskevich/govalidator
 # github.com/beorn7/perks v1.0.1
 ## explicit; go 1.11
@@ -84,7 +83,7 @@ github.com/beorn7/perks/quantile
 # github.com/blang/semver/v4 v4.0.0
 ## explicit; go 1.14
 github.com/blang/semver/v4
-# github.com/cenkalti/backoff/v4 v4.2.0
+# github.com/cenkalti/backoff/v4 v4.2.1
 ## explicit; go 1.18
 github.com/cenkalti/backoff/v4
 # github.com/cespare/xxhash/v2 v2.2.0
@@ -96,10 +95,10 @@ github.com/chai2010/gettext-go
 github.com/chai2010/gettext-go/mo
 github.com/chai2010/gettext-go/plural
 github.com/chai2010/gettext-go/po
-# github.com/containerd/cgroups v1.1.0
-## explicit; go 1.17
-github.com/containerd/cgroups/stats/v1
-# github.com/containerd/containerd v1.7.0
+# github.com/containerd/cgroups/v3 v3.0.2
+## explicit; go 1.18
+github.com/containerd/cgroups/v3/cgroup1/stats
+# github.com/containerd/containerd v1.7.6
 ## explicit; go 1.19
 github.com/containerd/containerd/api/events
 github.com/containerd/containerd/api/runtime/sandbox/v1
@@ -143,16 +142,79 @@ github.com/containerd/containerd/sandbox
 github.com/containerd/containerd/snapshots
 github.com/containerd/containerd/tracing
 github.com/containerd/containerd/version
-# github.com/containerd/continuity v0.3.0
-## explicit; go 1.17
+# github.com/containerd/continuity v0.4.2
+## explicit; go 1.19
 github.com/containerd/continuity/fs
 github.com/containerd/continuity/sysx
-# github.com/containerd/ttrpc v1.2.1
+# github.com/containerd/ttrpc v1.2.2
 ## explicit; go 1.13
 github.com/containerd/ttrpc
-# github.com/containerd/typeurl/v2 v2.1.0
+# github.com/containerd/typeurl/v2 v2.1.1
 ## explicit; go 1.13
 github.com/containerd/typeurl/v2
+# github.com/containers/common v0.56.0
+## explicit; go 1.18
+github.com/containers/common/libnetwork/types
+github.com/containers/common/pkg/auth
+github.com/containers/common/pkg/capabilities
+github.com/containers/common/pkg/completion
+github.com/containers/common/pkg/util
+# github.com/containers/image/v5 v5.28.0
+## explicit; go 1.19
+github.com/containers/image/v5/docker
+github.com/containers/image/v5/docker/policyconfiguration
+github.com/containers/image/v5/docker/reference
+github.com/containers/image/v5/internal/blobinfocache
+github.com/containers/image/v5/internal/image
+github.com/containers/image/v5/internal/imagedestination/impl
+github.com/containers/image/v5/internal/imagedestination/stubs
+github.com/containers/image/v5/internal/imagesource
+github.com/containers/image/v5/internal/imagesource/impl
+github.com/containers/image/v5/internal/imagesource/stubs
+github.com/containers/image/v5/internal/iolimits
+github.com/containers/image/v5/internal/manifest
+github.com/containers/image/v5/internal/pkg/platform
+github.com/containers/image/v5/internal/private
+github.com/containers/image/v5/internal/putblobdigest
+github.com/containers/image/v5/internal/rootless
+github.com/containers/image/v5/internal/set
+github.com/containers/image/v5/internal/signature
+github.com/containers/image/v5/internal/streamdigest
+github.com/containers/image/v5/internal/tmpdir
+github.com/containers/image/v5/internal/uploadreader
+github.com/containers/image/v5/internal/useragent
+github.com/containers/image/v5/manifest
+github.com/containers/image/v5/pkg/blobinfocache/none
+github.com/containers/image/v5/pkg/compression
+github.com/containers/image/v5/pkg/compression/internal
+github.com/containers/image/v5/pkg/compression/types
+github.com/containers/image/v5/pkg/docker/config
+github.com/containers/image/v5/pkg/strslice
+github.com/containers/image/v5/pkg/sysregistriesv2
+github.com/containers/image/v5/pkg/tlsclientconfig
+github.com/containers/image/v5/transports
+github.com/containers/image/v5/types
+github.com/containers/image/v5/version
+# github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01
+## explicit
+github.com/containers/libtrust
+# github.com/containers/ocicrypt v1.1.8
+## explicit; go 1.20
+github.com/containers/ocicrypt/spec
+# github.com/containers/storage v1.50.2
+## explicit; go 1.19
+github.com/containers/storage/pkg/chunked/compressor
+github.com/containers/storage/pkg/chunked/internal
+github.com/containers/storage/pkg/homedir
+github.com/containers/storage/pkg/idtools
+github.com/containers/storage/pkg/ioutils
+github.com/containers/storage/pkg/lockfile
+github.com/containers/storage/pkg/longpath
+github.com/containers/storage/pkg/mount
+github.com/containers/storage/pkg/reexec
+github.com/containers/storage/pkg/regexp
+github.com/containers/storage/pkg/system
+github.com/containers/storage/pkg/unshare
 # github.com/coreos/go-semver v0.3.0
 ## explicit
 github.com/coreos/go-semver/semver
@@ -172,14 +234,14 @@ github.com/davecgh/go-spew/spew
 # github.com/distribution/distribution v2.7.1+incompatible
 ## explicit
 github.com/distribution/distribution/reference
-# github.com/docker/cli v23.0.1+incompatible
+# github.com/docker/cli v24.0.6+incompatible
 ## explicit
 github.com/docker/cli/cli/config
 github.com/docker/cli/cli/config/configfile
 github.com/docker/cli/cli/config/credentials
 github.com/docker/cli/cli/config/types
-# github.com/docker/distribution v2.8.2+incompatible => github.com/docker/distribution v0.0.0-20191216044856-a8371794149d
-## explicit; go 1.12
+# github.com/docker/distribution v2.8.2+incompatible
+## explicit
 github.com/docker/distribution
 github.com/docker/distribution/digestset
 github.com/docker/distribution/metrics
@@ -192,7 +254,7 @@ github.com/docker/distribution/registry/client/auth/challenge
 github.com/docker/distribution/registry/client/transport
 github.com/docker/distribution/registry/storage/cache
 github.com/docker/distribution/registry/storage/cache/memory
-# github.com/docker/docker v23.0.3+incompatible
+# github.com/docker/docker v24.0.6+incompatible
 ## explicit
 github.com/docker/docker/api/types
 github.com/docker/docker/api/types/blkiodev
@@ -212,8 +274,8 @@ github.com/docker/docker/pkg/ioutils
 github.com/docker/docker/pkg/jsonmessage
 github.com/docker/docker/pkg/longpath
 github.com/docker/docker/registry
-# github.com/docker/docker-credential-helpers v0.7.0
-## explicit; go 1.18
+# github.com/docker/docker-credential-helpers v0.8.0
+## explicit; go 1.19
 github.com/docker/docker-credential-helpers/client
 github.com/docker/docker-credential-helpers/credentials
 # github.com/docker/go-connections v0.4.0
@@ -239,8 +301,8 @@ github.com/evanphx/json-patch/v5
 # github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
 ## explicit
 github.com/exponent-io/jsonpath
-# github.com/fatih/color v1.13.0
-## explicit; go 1.13
+# github.com/fatih/color v1.15.0
+## explicit; go 1.17
 github.com/fatih/color
 # github.com/felixge/httpsnoop v1.0.3
 ## explicit; go 1.13
@@ -269,25 +331,11 @@ github.com/go-bindata/go-bindata/v3/go-bindata
 # github.com/go-errors/errors v1.4.2
 ## explicit; go 1.14
 github.com/go-errors/errors
-# github.com/go-git/gcfg v1.5.0
-## explicit
-github.com/go-git/gcfg
-github.com/go-git/gcfg/scanner
-github.com/go-git/gcfg/token
-github.com/go-git/gcfg/types
-# github.com/go-git/go-billy/v5 v5.1.0
-## explicit; go 1.13
-github.com/go-git/go-billy/v5
-# github.com/go-git/go-git/v5 v5.3.0
-## explicit; go 1.13
-github.com/go-git/go-git/v5/plumbing/format/config
-github.com/go-git/go-git/v5/plumbing/format/gitignore
-github.com/go-git/go-git/v5/utils/ioutil
 # github.com/go-gorp/gorp/v3 v3.0.5
 ## explicit; go 1.18
 github.com/go-gorp/gorp/v3
-# github.com/go-logr/logr v1.2.4
-## explicit; go 1.16
+# github.com/go-logr/logr v1.3.0
+## explicit; go 1.18
 github.com/go-logr/logr
 github.com/go-logr/logr/funcr
 # github.com/go-logr/stdr v1.2.2
@@ -299,11 +347,11 @@ github.com/go-logr/zapr
 # github.com/go-openapi/jsonpointer v0.19.6
 ## explicit; go 1.13
 github.com/go-openapi/jsonpointer
-# github.com/go-openapi/jsonreference v0.20.1
+# github.com/go-openapi/jsonreference v0.20.2
 ## explicit; go 1.13
 github.com/go-openapi/jsonreference
 github.com/go-openapi/jsonreference/internal
-# github.com/go-openapi/swag v0.22.3
+# github.com/go-openapi/swag v0.22.4
 ## explicit; go 1.18
 github.com/go-openapi/swag
 # github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572
@@ -348,12 +396,12 @@ github.com/golang-migrate/migrate/v4/source/iofs
 github.com/golang/groupcache/lru
 # github.com/golang/mock v1.6.0
 ## explicit; go 1.11
+github.com/golang/mock/gomock
 github.com/golang/mock/mockgen
 github.com/golang/mock/mockgen/model
 # github.com/golang/protobuf v1.5.3
 ## explicit; go 1.9
 github.com/golang/protobuf/proto
-github.com/golang/protobuf/protoc-gen-go/descriptor
 github.com/golang/protobuf/ptypes
 github.com/golang/protobuf/ptypes/any
 github.com/golang/protobuf/ptypes/duration
@@ -388,7 +436,7 @@ github.com/google/gnostic/extensions
 github.com/google/gnostic/jsonschema
 github.com/google/gnostic/openapiv2
 github.com/google/gnostic/openapiv3
-# github.com/google/go-cmp v0.5.9
+# github.com/google/go-cmp v0.6.0
 ## explicit; go 1.13
 github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/internal/diff
@@ -399,13 +447,17 @@ github.com/google/go-cmp/cmp/internal/value
 ## explicit; go 1.12
 github.com/google/gofuzz
 github.com/google/gofuzz/bytesource
-# github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1
-## explicit; go 1.14
+# github.com/google/pprof v0.0.0-20230323073829-e72429f035bd
+## explicit; go 1.19
 github.com/google/pprof/profile
+# github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2
+## explicit; go 1.19
+github.com/google/safetext/common
+github.com/google/safetext/yamltemplate
 # github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 ## explicit; go 1.13
 github.com/google/shlex
-# github.com/google/uuid v1.3.0
+# github.com/google/uuid v1.3.1
 ## explicit
 github.com/google/uuid
 # github.com/googleapis/gnostic v0.5.5
@@ -435,14 +487,11 @@ github.com/gregjones/httpcache
 # github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 ## explicit
 github.com/grpc-ecosystem/go-grpc-prometheus
-# github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0
-## explicit; go 1.14
+# github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
+## explicit; go 1.17
 github.com/grpc-ecosystem/grpc-gateway/v2/internal/httprule
 github.com/grpc-ecosystem/grpc-gateway/v2/runtime
 github.com/grpc-ecosystem/grpc-gateway/v2/utilities
-# github.com/grpc-ecosystem/grpc-health-probe v0.4.11
-## explicit; go 1.18
-github.com/grpc-ecosystem/grpc-health-probe
 # github.com/h2non/filetype v1.1.1
 ## explicit; go 1.13
 github.com/h2non/filetype
@@ -473,16 +522,10 @@ github.com/itchyny/astgen-go
 # github.com/itchyny/gojq v0.11.0
 ## explicit; go 1.14
 github.com/itchyny/gojq
-# github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99
-## explicit
-github.com/jbenet/go-context/io
 # github.com/jmoiron/sqlx v1.3.5
 ## explicit; go 1.10
 github.com/jmoiron/sqlx
 github.com/jmoiron/sqlx/reflectx
-# github.com/joelanford/ignore v0.0.0-20210607151042-0d25dc18b62d
-## explicit; go 1.16
-github.com/joelanford/ignore
 # github.com/josharian/intern v1.0.0
 ## explicit; go 1.5
 github.com/josharian/intern
@@ -493,15 +536,19 @@ github.com/json-iterator/go
 ## explicit; go 1.14
 github.com/kisielk/errcheck
 github.com/kisielk/errcheck/errcheck
-# github.com/klauspost/compress v1.16.0
+# github.com/klauspost/compress v1.16.7
 ## explicit; go 1.18
 github.com/klauspost/compress
+github.com/klauspost/compress/flate
 github.com/klauspost/compress/fse
 github.com/klauspost/compress/huff0
 github.com/klauspost/compress/internal/cpuinfo
 github.com/klauspost/compress/internal/snapref
 github.com/klauspost/compress/zstd
 github.com/klauspost/compress/zstd/internal/xxhash
+# github.com/klauspost/pgzip v1.2.6
+## explicit
+github.com/klauspost/pgzip
 # github.com/kylelemons/godebug v1.1.0
 ## explicit; go 1.11
 github.com/kylelemons/godebug/diff
@@ -533,16 +580,16 @@ github.com/mattn/go-colorable
 # github.com/mattn/go-isatty v0.0.17
 ## explicit; go 1.15
 github.com/mattn/go-isatty
-# github.com/mattn/go-runewidth v0.0.9
+# github.com/mattn/go-runewidth v0.0.15
 ## explicit; go 1.9
 github.com/mattn/go-runewidth
-# github.com/mattn/go-sqlite3 v1.14.16
+# github.com/mattn/go-sqlite3 v1.14.17
 ## explicit; go 1.16
 github.com/mattn/go-sqlite3
 # github.com/matttproud/golang_protobuf_extensions v1.0.4
 ## explicit; go 1.9
 github.com/matttproud/golang_protobuf_extensions/pbutil
-# github.com/maxbrunsfeld/counterfeiter/v6 v6.4.1
+# github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2
 ## explicit; go 1.11
 github.com/maxbrunsfeld/counterfeiter/v6
 github.com/maxbrunsfeld/counterfeiter/v6/arguments
@@ -562,7 +609,7 @@ github.com/mitchellh/go-wordwrap
 # github.com/mitchellh/hashstructure v1.0.0
 ## explicit
 github.com/mitchellh/hashstructure
-# github.com/mitchellh/mapstructure v1.4.1
+# github.com/mitchellh/mapstructure v1.5.0
 ## explicit; go 1.14
 github.com/mitchellh/mapstructure
 # github.com/mitchellh/reflectwalk v1.0.2
@@ -600,8 +647,9 @@ github.com/morikuni/aec
 # github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 ## explicit
 github.com/munnerz/goautoneg
-# github.com/onsi/ginkgo/v2 v2.9.5
+# github.com/onsi/ginkgo/v2 v2.12.0
 ## explicit; go 1.18
+github.com/onsi/ginkgo/v2
 github.com/onsi/ginkgo/v2/config
 github.com/onsi/ginkgo/v2/formatter
 github.com/onsi/ginkgo/v2/ginkgo
@@ -614,35 +662,64 @@ github.com/onsi/ginkgo/v2/ginkgo/outline
 github.com/onsi/ginkgo/v2/ginkgo/run
 github.com/onsi/ginkgo/v2/ginkgo/unfocus
 github.com/onsi/ginkgo/v2/ginkgo/watch
+github.com/onsi/ginkgo/v2/internal
+github.com/onsi/ginkgo/v2/internal/global
 github.com/onsi/ginkgo/v2/internal/interrupt_handler
 github.com/onsi/ginkgo/v2/internal/parallel_support
+github.com/onsi/ginkgo/v2/internal/testingtproxy
 github.com/onsi/ginkgo/v2/reporters
 github.com/onsi/ginkgo/v2/types
-# github.com/onsi/gomega v1.27.7
+# github.com/onsi/gomega v1.27.10
 ## explicit; go 1.18
+github.com/onsi/gomega
+github.com/onsi/gomega/format
+github.com/onsi/gomega/gstruct
 github.com/onsi/gomega/gstruct/errors
+github.com/onsi/gomega/internal
+github.com/onsi/gomega/internal/gutil
+github.com/onsi/gomega/matchers
+github.com/onsi/gomega/matchers/support/goraph/bipartitegraph
+github.com/onsi/gomega/matchers/support/goraph/edge
+github.com/onsi/gomega/matchers/support/goraph/node
+github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
 # github.com/opencontainers/go-digest v1.0.0
 ## explicit; go 1.13
 github.com/opencontainers/go-digest
-# github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b
-## explicit; go 1.17
+# github.com/opencontainers/image-spec v1.1.0-rc5
+## explicit; go 1.18
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
-# github.com/openshift/api v3.9.0+incompatible => github.com/openshift/api v0.0.0-20210517065120-b325f58df679
-## explicit; go 1.15
+# github.com/opencontainers/runc v1.1.9
+## explicit; go 1.17
+github.com/opencontainers/runc/libcontainer/user
+# github.com/opencontainers/runtime-spec v1.1.0
+## explicit
+github.com/opencontainers/runtime-spec/specs-go
+# github.com/openshift/api v3.9.0+incompatible => github.com/openshift/api v0.0.0-20221021112143-4226c2167e40
+## explicit; go 1.18
 github.com/openshift/api/config/v1
-# github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a => github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0
-## explicit; go 1.13
+github.com/openshift/api/config/v1alpha1
+# github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a => github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c
+## explicit; go 1.18
+github.com/openshift/client-go/config/applyconfigurations/config/v1
+github.com/openshift/client-go/config/applyconfigurations/config/v1alpha1
+github.com/openshift/client-go/config/applyconfigurations/internal
 github.com/openshift/client-go/config/clientset/versioned
+github.com/openshift/client-go/config/clientset/versioned/fake
 github.com/openshift/client-go/config/clientset/versioned/scheme
 github.com/openshift/client-go/config/clientset/versioned/typed/config/v1
+github.com/openshift/client-go/config/clientset/versioned/typed/config/v1/fake
+github.com/openshift/client-go/config/clientset/versioned/typed/config/v1alpha1
+github.com/openshift/client-go/config/clientset/versioned/typed/config/v1alpha1/fake
 github.com/openshift/client-go/config/informers/externalversions
 github.com/openshift/client-go/config/informers/externalversions/config
 github.com/openshift/client-go/config/informers/externalversions/config/v1
+github.com/openshift/client-go/config/informers/externalversions/config/v1alpha1
 github.com/openshift/client-go/config/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/config/listers/config/v1
-# github.com/operator-framework/api v0.20.0 => ./staging/api
+github.com/openshift/client-go/config/listers/config/v1alpha1
+# github.com/operator-framework/api v0.20.0
 ## explicit; go 1.19
 github.com/operator-framework/api/crds
 github.com/operator-framework/api/pkg/constraints
@@ -660,135 +737,11 @@ github.com/operator-framework/api/pkg/validation
 github.com/operator-framework/api/pkg/validation/errors
 github.com/operator-framework/api/pkg/validation/interfaces
 github.com/operator-framework/api/pkg/validation/internal
-# github.com/operator-framework/operator-lifecycle-manager v0.0.0-00010101000000-000000000000 => ./staging/operator-lifecycle-manager
+# github.com/operator-framework/operator-registry v1.33.0
 ## explicit; go 1.20
-github.com/operator-framework/operator-lifecycle-manager/cmd/catalog
-github.com/operator-framework/operator-lifecycle-manager/cmd/copy-content
-github.com/operator-framework/operator-lifecycle-manager/cmd/olm
-github.com/operator-framework/operator-lifecycle-manager/cmd/package-server
-github.com/operator-framework/operator-lifecycle-manager/pkg/api/client
-github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned
-github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/scheme
-github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/typed/operators/v1
-github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/typed/operators/v1alpha1
-github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/typed/operators/v1alpha2
-github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/typed/operators/v2
-github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/informers/externalversions
-github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/informers/externalversions/internalinterfaces
-github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/informers/externalversions/operators
-github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/informers/externalversions/operators/v1
-github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/informers/externalversions/operators/v1alpha1
-github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/informers/externalversions/operators/v1alpha2
-github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/informers/externalversions/operators/v2
-github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1
-github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1
-github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha2
-github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v2
-github.com/operator-framework/operator-lifecycle-manager/pkg/api/wrappers
-github.com/operator-framework/operator-lifecycle-manager/pkg/controller/bundle
-github.com/operator-framework/operator-lifecycle-manager/pkg/controller/certs
-github.com/operator-framework/operator-lifecycle-manager/pkg/controller/errors
-github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install
-github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators
-github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog
-github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/subscription
-github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalogtemplate
-github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/decorators
-github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/internal/alongside
-github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/internal/pruning
-github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/labeller
-github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm
-github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/overrides
-github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/overrides/inject
-github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/plugins
-github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/openshift
-github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/validatingroundtripper
-github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry
-github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/grpc
-github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler
-github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver
-github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache
-github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/projection
-github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/solver
-github.com/operator-framework/operator-lifecycle-manager/pkg/feature
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/catalogsource
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/clients
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/codec
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/comparison
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/controller-runtime/client
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/crd
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/csv
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/event
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/filemonitor
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/image
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/index
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/apis/rbac
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/apis/rbac/v1
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/printers
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/printers/storage
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/registry/rbac/validation
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/util/hash
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/util/labels
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/plugin/pkg/auth/authorizer/rbac
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubestate
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/labeler
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorlister
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorstatus
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/profile
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/proxy
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/queueinformer
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/scoped
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/server
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/signals
-github.com/operator-framework/operator-lifecycle-manager/pkg/lib/time
-github.com/operator-framework/operator-lifecycle-manager/pkg/metrics
-github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators
-github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/install
-github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1
-github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apiserver
-github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apiserver/generic
-github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/client/listers/operators/internalversion
-github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/client/openapi
-github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/provider
-github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/server
-github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/storage
-github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/version
-github.com/operator-framework/operator-lifecycle-manager/pkg/version
-github.com/operator-framework/operator-lifecycle-manager/util/cpb
-# github.com/operator-framework/operator-registry v1.33.0 => ./staging/operator-registry
-## explicit; go 1.20
-github.com/operator-framework/operator-registry/alpha/action
-github.com/operator-framework/operator-registry/alpha/declcfg
 github.com/operator-framework/operator-registry/alpha/model
 github.com/operator-framework/operator-registry/alpha/property
-github.com/operator-framework/operator-registry/alpha/template/basic
-github.com/operator-framework/operator-registry/alpha/template/composite
-github.com/operator-framework/operator-registry/alpha/template/semver
-github.com/operator-framework/operator-registry/cmd/configmap-server
-github.com/operator-framework/operator-registry/cmd/initializer
-github.com/operator-framework/operator-registry/cmd/opm
-github.com/operator-framework/operator-registry/cmd/opm/alpha
-github.com/operator-framework/operator-registry/cmd/opm/alpha/bundle
-github.com/operator-framework/operator-registry/cmd/opm/alpha/list
-github.com/operator-framework/operator-registry/cmd/opm/alpha/render-graph
-github.com/operator-framework/operator-registry/cmd/opm/alpha/template
-github.com/operator-framework/operator-registry/cmd/opm/generate
-github.com/operator-framework/operator-registry/cmd/opm/index
-github.com/operator-framework/operator-registry/cmd/opm/init
-github.com/operator-framework/operator-registry/cmd/opm/internal/util
-github.com/operator-framework/operator-registry/cmd/opm/migrate
-github.com/operator-framework/operator-registry/cmd/opm/registry
-github.com/operator-framework/operator-registry/cmd/opm/render
-github.com/operator-framework/operator-registry/cmd/opm/root
-github.com/operator-framework/operator-registry/cmd/opm/serve
-github.com/operator-framework/operator-registry/cmd/opm/validate
-github.com/operator-framework/operator-registry/cmd/opm/version
-github.com/operator-framework/operator-registry/cmd/registry-server
 github.com/operator-framework/operator-registry/pkg/api
-github.com/operator-framework/operator-registry/pkg/api/grpc_health_v1
-github.com/operator-framework/operator-registry/pkg/cache
 github.com/operator-framework/operator-registry/pkg/client
 github.com/operator-framework/operator-registry/pkg/configmap
 github.com/operator-framework/operator-registry/pkg/containertools
@@ -796,18 +749,9 @@ github.com/operator-framework/operator-registry/pkg/image
 github.com/operator-framework/operator-registry/pkg/image/containerdregistry
 github.com/operator-framework/operator-registry/pkg/image/execregistry
 github.com/operator-framework/operator-registry/pkg/lib/bundle
-github.com/operator-framework/operator-registry/pkg/lib/certs
-github.com/operator-framework/operator-registry/pkg/lib/config
-github.com/operator-framework/operator-registry/pkg/lib/dns
 github.com/operator-framework/operator-registry/pkg/lib/encoding
-github.com/operator-framework/operator-registry/pkg/lib/graceful
-github.com/operator-framework/operator-registry/pkg/lib/indexer
-github.com/operator-framework/operator-registry/pkg/lib/log
-github.com/operator-framework/operator-registry/pkg/lib/registry
 github.com/operator-framework/operator-registry/pkg/lib/semver
-github.com/operator-framework/operator-registry/pkg/lib/tmp
 github.com/operator-framework/operator-registry/pkg/lib/validation
-github.com/operator-framework/operator-registry/pkg/mirror
 github.com/operator-framework/operator-registry/pkg/prettyunmarshaler
 github.com/operator-framework/operator-registry/pkg/registry
 github.com/operator-framework/operator-registry/pkg/server
@@ -819,6 +763,9 @@ github.com/otiai10/copy
 # github.com/pbnjay/strptime v0.0.0-20140226051138-5c05b0d668c9
 ## explicit
 github.com/pbnjay/strptime
+# github.com/pelletier/go-toml v1.9.5
+## explicit; go 1.12
+github.com/pelletier/go-toml
 # github.com/peterbourgon/diskv v2.0.1+incompatible
 ## explicit
 github.com/peterbourgon/diskv
@@ -849,6 +796,9 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
+# github.com/rivo/uniseg v0.4.4
+## explicit; go 1.18
+github.com/rivo/uniseg
 # github.com/rubenv/sql-migrate v1.3.1
 ## explicit; go 1.16
 github.com/rubenv/sql-migrate
@@ -859,9 +809,10 @@ github.com/russross/blackfriday/v2
 # github.com/shopspring/decimal v1.3.1
 ## explicit; go 1.13
 github.com/shopspring/decimal
-# github.com/sirupsen/logrus v1.9.2
+# github.com/sirupsen/logrus v1.9.3
 ## explicit; go 1.13
 github.com/sirupsen/logrus
+github.com/sirupsen/logrus/hooks/test
 # github.com/spf13/cast v1.5.0
 ## explicit; go 1.18
 github.com/spf13/cast
@@ -872,29 +823,27 @@ github.com/spf13/cobra/doc
 # github.com/spf13/pflag v1.0.5
 ## explicit; go 1.12
 github.com/spf13/pflag
-# github.com/spiffe/go-spiffe/v2 v2.0.0
-## explicit; go 1.13
-github.com/spiffe/go-spiffe/v2/bundle/jwtbundle
-github.com/spiffe/go-spiffe/v2/bundle/spiffebundle
-github.com/spiffe/go-spiffe/v2/bundle/x509bundle
-github.com/spiffe/go-spiffe/v2/internal/cryptoutil
-github.com/spiffe/go-spiffe/v2/internal/jwtutil
-github.com/spiffe/go-spiffe/v2/internal/pemutil
-github.com/spiffe/go-spiffe/v2/internal/x509util
-github.com/spiffe/go-spiffe/v2/logger
-github.com/spiffe/go-spiffe/v2/proto/spiffe/workload
-github.com/spiffe/go-spiffe/v2/spiffeid
-github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig
-github.com/spiffe/go-spiffe/v2/svid/jwtsvid
-github.com/spiffe/go-spiffe/v2/svid/x509svid
-github.com/spiffe/go-spiffe/v2/workloadapi
 # github.com/stoewer/go-strcase v1.2.0
 ## explicit; go 1.11
 github.com/stoewer/go-strcase
-# github.com/stretchr/testify v1.8.3
+# github.com/stretchr/testify v1.8.4
 ## explicit; go 1.20
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
+# github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
+## explicit
+github.com/syndtr/gocapability/capability
+# github.com/ulikunitz/xz v0.5.11
+## explicit; go 1.12
+github.com/ulikunitz/xz
+github.com/ulikunitz/xz/internal/hash
+github.com/ulikunitz/xz/internal/xlog
+github.com/ulikunitz/xz/lzma
+# github.com/vbatts/tar-split v0.11.5
+## explicit; go 1.17
+github.com/vbatts/tar-split/archive/tar
+github.com/vbatts/tar-split/tar/asm
+github.com/vbatts/tar-split/tar/storage
 # github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb
 ## explicit
 github.com/xeipuuv/gojsonpointer
@@ -907,9 +856,6 @@ github.com/xeipuuv/gojsonschema
 # github.com/xlab/treeprint v1.1.0
 ## explicit; go 1.13
 github.com/xlab/treeprint
-# github.com/zeebo/errs v1.3.0
-## explicit; go 1.12
-github.com/zeebo/errs
 # go.etcd.io/bbolt v1.3.7
 ## explicit; go 1.17
 go.etcd.io/bbolt
@@ -942,21 +888,20 @@ go.opencensus.io/internal
 go.opencensus.io/trace
 go.opencensus.io/trace/internal
 go.opencensus.io/trace/tracestate
-# go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.40.0
-## explicit; go 1.18
+# go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.44.0
+## explicit; go 1.19
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/internal
-# go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.40.0
-## explicit; go 1.18
+# go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.44.0
+## explicit; go 1.19
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
-# go.opentelemetry.io/otel v1.14.0
-## explicit; go 1.18
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/internal/semconvutil
+# go.opentelemetry.io/otel v1.20.0
+## explicit; go 1.20
 go.opentelemetry.io/otel
 go.opentelemetry.io/otel/attribute
 go.opentelemetry.io/otel/baggage
 go.opentelemetry.io/otel/codes
-go.opentelemetry.io/otel/exporters/otlp/internal
-go.opentelemetry.io/otel/exporters/otlp/internal/envconfig
 go.opentelemetry.io/otel/internal
 go.opentelemetry.io/otel/internal/attribute
 go.opentelemetry.io/otel/internal/baggage
@@ -967,35 +912,37 @@ go.opentelemetry.io/otel/semconv/internal/v2
 go.opentelemetry.io/otel/semconv/v1.12.0
 go.opentelemetry.io/otel/semconv/v1.17.0
 go.opentelemetry.io/otel/semconv/v1.17.0/httpconv
-# go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.14.0
-## explicit; go 1.18
-go.opentelemetry.io/otel/exporters/otlp/internal/retry
-# go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.14.0
-## explicit; go 1.18
+go.opentelemetry.io/otel/semconv/v1.21.0
+# go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.20.0
+## explicit; go 1.20
 go.opentelemetry.io/otel/exporters/otlp/otlptrace
-go.opentelemetry.io/otel/exporters/otlp/otlptrace/internal/otlpconfig
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/internal/tracetransform
-# go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.14.0
-## explicit; go 1.18
+# go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.20.0
+## explicit; go 1.20
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc
-# go.opentelemetry.io/otel/metric v0.37.0
-## explicit; go 1.18
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal/envconfig
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal/otlpconfig
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal/retry
+# go.opentelemetry.io/otel/metric v1.20.0
+## explicit; go 1.20
 go.opentelemetry.io/otel/metric
-go.opentelemetry.io/otel/metric/global
-go.opentelemetry.io/otel/metric/instrument
-go.opentelemetry.io/otel/metric/internal/global
-# go.opentelemetry.io/otel/sdk v1.14.0
-## explicit; go 1.18
+go.opentelemetry.io/otel/metric/embedded
+# go.opentelemetry.io/otel/sdk v1.20.0
+## explicit; go 1.20
+go.opentelemetry.io/otel/sdk
 go.opentelemetry.io/otel/sdk/instrumentation
 go.opentelemetry.io/otel/sdk/internal
 go.opentelemetry.io/otel/sdk/internal/env
 go.opentelemetry.io/otel/sdk/resource
 go.opentelemetry.io/otel/sdk/trace
-# go.opentelemetry.io/otel/trace v1.14.0
-## explicit; go 1.18
+# go.opentelemetry.io/otel/trace v1.20.0
+## explicit; go 1.20
 go.opentelemetry.io/otel/trace
-# go.opentelemetry.io/proto/otlp v0.19.0
-## explicit; go 1.14
+go.opentelemetry.io/otel/trace/embedded
+go.opentelemetry.io/otel/trace/noop
+# go.opentelemetry.io/proto/otlp v1.0.0
+## explicit; go 1.17
 go.opentelemetry.io/proto/otlp/collector/trace/v1
 go.opentelemetry.io/proto/otlp/common/v1
 go.opentelemetry.io/proto/otlp/resource/v1
@@ -1031,7 +978,6 @@ golang.org/x/crypto/blowfish
 golang.org/x/crypto/cast5
 golang.org/x/crypto/cryptobyte
 golang.org/x/crypto/cryptobyte/asn1
-golang.org/x/crypto/ed25519
 golang.org/x/crypto/internal/alias
 golang.org/x/crypto/internal/poly1305
 golang.org/x/crypto/nacl/secretbox
@@ -1045,15 +991,16 @@ golang.org/x/crypto/openpgp/s2k
 golang.org/x/crypto/pbkdf2
 golang.org/x/crypto/salsa20/salsa
 golang.org/x/crypto/scrypt
-# golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0
-## explicit; go 1.18
+# golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63
+## explicit; go 1.20
 golang.org/x/exp/constraints
+golang.org/x/exp/maps
 golang.org/x/exp/slices
 # golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 ## explicit; go 1.11
 golang.org/x/lint
 golang.org/x/lint/golint
-# golang.org/x/mod v0.10.0
+# golang.org/x/mod v0.12.0
 ## explicit; go 1.17
 golang.org/x/mod/internal/lazyregexp
 golang.org/x/mod/modfile
@@ -1062,6 +1009,9 @@ golang.org/x/mod/semver
 # golang.org/x/net v0.17.0
 ## explicit; go 1.17
 golang.org/x/net/context
+golang.org/x/net/html
+golang.org/x/net/html/atom
+golang.org/x/net/html/charset
 golang.org/x/net/http/httpguts
 golang.org/x/net/http/httpproxy
 golang.org/x/net/http2
@@ -1072,17 +1022,17 @@ golang.org/x/net/internal/timeseries
 golang.org/x/net/proxy
 golang.org/x/net/trace
 golang.org/x/net/websocket
-# golang.org/x/oauth2 v0.5.0
-## explicit; go 1.17
+# golang.org/x/oauth2 v0.12.0
+## explicit; go 1.18
 golang.org/x/oauth2
 golang.org/x/oauth2/internal
-# golang.org/x/sync v0.2.0
-## explicit
+# golang.org/x/sync v0.3.0
+## explicit; go 1.17
 golang.org/x/sync/errgroup
 golang.org/x/sync/semaphore
 golang.org/x/sync/singleflight
-# golang.org/x/sys v0.13.0
-## explicit; go 1.17
+# golang.org/x/sys v0.14.0
+## explicit; go 1.18
 golang.org/x/sys/cpu
 golang.org/x/sys/execabs
 golang.org/x/sys/plan9
@@ -1096,8 +1046,14 @@ golang.org/x/term
 ## explicit; go 1.17
 golang.org/x/text/cases
 golang.org/x/text/encoding
+golang.org/x/text/encoding/charmap
+golang.org/x/text/encoding/htmlindex
 golang.org/x/text/encoding/internal
 golang.org/x/text/encoding/internal/identifier
+golang.org/x/text/encoding/japanese
+golang.org/x/text/encoding/korean
+golang.org/x/text/encoding/simplifiedchinese
+golang.org/x/text/encoding/traditionalchinese
 golang.org/x/text/encoding/unicode
 golang.org/x/text/feature/plural
 golang.org/x/text/internal
@@ -1121,7 +1077,7 @@ golang.org/x/text/width
 # golang.org/x/time v0.3.0
 ## explicit
 golang.org/x/time/rate
-# golang.org/x/tools v0.9.1
+# golang.org/x/tools v0.12.1-0.20230815132531-74c255bcf846
 ## explicit; go 1.18
 golang.org/x/tools/cmd/stringer
 golang.org/x/tools/go/ast/astutil
@@ -1136,6 +1092,7 @@ golang.org/x/tools/internal/event
 golang.org/x/tools/internal/event/core
 golang.org/x/tools/internal/event/keys
 golang.org/x/tools/internal/event/label
+golang.org/x/tools/internal/event/tag
 golang.org/x/tools/internal/fastwalk
 golang.org/x/tools/internal/gcimporter
 golang.org/x/tools/internal/gocommand
@@ -1162,16 +1119,21 @@ google.golang.org/appengine/internal/log
 google.golang.org/appengine/internal/remote_api
 google.golang.org/appengine/internal/urlfetch
 google.golang.org/appengine/urlfetch
-# google.golang.org/genproto v0.0.0-20230525154841-bd750badd5c6
+# google.golang.org/genproto v0.0.0-20230822172742-b8732ec3820d
+## explicit; go 1.19
+google.golang.org/genproto/internal
+google.golang.org/genproto/protobuf/field_mask
+# google.golang.org/genproto/googleapis/api v0.0.0-20230822172742-b8732ec3820d
 ## explicit; go 1.19
 google.golang.org/genproto/googleapis/api
 google.golang.org/genproto/googleapis/api/annotations
 google.golang.org/genproto/googleapis/api/expr/v1alpha1
 google.golang.org/genproto/googleapis/api/httpbody
+# google.golang.org/genproto/googleapis/rpc v0.0.0-20230822172742-b8732ec3820d
+## explicit; go 1.19
 google.golang.org/genproto/googleapis/rpc/errdetails
 google.golang.org/genproto/googleapis/rpc/status
-google.golang.org/genproto/protobuf/field_mask
-# google.golang.org/grpc v1.54.0 => google.golang.org/grpc v1.40.0
+# google.golang.org/grpc v1.59.0 => google.golang.org/grpc v1.40.0
 ## explicit; go 1.11
 google.golang.org/grpc
 google.golang.org/grpc/attributes
@@ -1184,13 +1146,6 @@ google.golang.org/grpc/binarylog/grpc_binarylog_v1
 google.golang.org/grpc/codes
 google.golang.org/grpc/connectivity
 google.golang.org/grpc/credentials
-google.golang.org/grpc/credentials/alts
-google.golang.org/grpc/credentials/alts/internal
-google.golang.org/grpc/credentials/alts/internal/authinfo
-google.golang.org/grpc/credentials/alts/internal/conn
-google.golang.org/grpc/credentials/alts/internal/handshaker
-google.golang.org/grpc/credentials/alts/internal/handshaker/service
-google.golang.org/grpc/credentials/alts/internal/proto/grpc_gcp
 google.golang.org/grpc/credentials/insecure
 google.golang.org/grpc/encoding
 google.golang.org/grpc/encoding/gzip
@@ -1205,7 +1160,6 @@ google.golang.org/grpc/internal/buffer
 google.golang.org/grpc/internal/channelz
 google.golang.org/grpc/internal/credentials
 google.golang.org/grpc/internal/envconfig
-google.golang.org/grpc/internal/googlecloud
 google.golang.org/grpc/internal/grpclog
 google.golang.org/grpc/internal/grpcrand
 google.golang.org/grpc/internal/grpcsync
@@ -1223,22 +1177,14 @@ google.golang.org/grpc/internal/transport/networktype
 google.golang.org/grpc/keepalive
 google.golang.org/grpc/metadata
 google.golang.org/grpc/peer
-google.golang.org/grpc/reflection
-google.golang.org/grpc/reflection/grpc_reflection_v1alpha
 google.golang.org/grpc/resolver
 google.golang.org/grpc/resolver/manual
 google.golang.org/grpc/serviceconfig
 google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
-# google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0
-## explicit; go 1.9
-google.golang.org/grpc/cmd/protoc-gen-go-grpc
-# google.golang.org/protobuf v1.30.0
+# google.golang.org/protobuf v1.31.0
 ## explicit; go 1.11
-google.golang.org/protobuf/cmd/protoc-gen-go
-google.golang.org/protobuf/cmd/protoc-gen-go/internal_gengo
-google.golang.org/protobuf/compiler/protogen
 google.golang.org/protobuf/encoding/protojson
 google.golang.org/protobuf/encoding/prototext
 google.golang.org/protobuf/encoding/protowire
@@ -1256,7 +1202,6 @@ google.golang.org/protobuf/internal/filetype
 google.golang.org/protobuf/internal/flags
 google.golang.org/protobuf/internal/genid
 google.golang.org/protobuf/internal/impl
-google.golang.org/protobuf/internal/msgfmt
 google.golang.org/protobuf/internal/order
 google.golang.org/protobuf/internal/pragma
 google.golang.org/protobuf/internal/set
@@ -1264,8 +1209,6 @@ google.golang.org/protobuf/internal/strs
 google.golang.org/protobuf/internal/version
 google.golang.org/protobuf/proto
 google.golang.org/protobuf/reflect/protodesc
-google.golang.org/protobuf/reflect/protopath
-google.golang.org/protobuf/reflect/protorange
 google.golang.org/protobuf/reflect/protoreflect
 google.golang.org/protobuf/reflect/protoregistry
 google.golang.org/protobuf/runtime/protoiface
@@ -1279,7 +1222,6 @@ google.golang.org/protobuf/types/known/fieldmaskpb
 google.golang.org/protobuf/types/known/structpb
 google.golang.org/protobuf/types/known/timestamppb
 google.golang.org/protobuf/types/known/wrapperspb
-google.golang.org/protobuf/types/pluginpb
 # gopkg.in/inf.v0 v0.9.1
 ## explicit
 gopkg.in/inf.v0
@@ -1289,15 +1231,6 @@ gopkg.in/natefinch/lumberjack.v2
 # gopkg.in/op/go-logging.v1 v1.0.0-20160211212156-b2cb9fa56473
 ## explicit
 gopkg.in/op/go-logging.v1
-# gopkg.in/square/go-jose.v2 v2.6.0
-## explicit
-gopkg.in/square/go-jose.v2
-gopkg.in/square/go-jose.v2/cipher
-gopkg.in/square/go-jose.v2/json
-gopkg.in/square/go-jose.v2/jwt
-# gopkg.in/warnings.v0 v0.1.2
-## explicit
-gopkg.in/warnings.v0
 # gopkg.in/yaml.v2 v2.4.0
 ## explicit; go 1.15
 gopkg.in/yaml.v2
@@ -1426,9 +1359,12 @@ k8s.io/apiextensions-apiserver/pkg/apiserver/validation
 k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1
 k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset
+k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1
+k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/fake
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1
+k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake
 # k8s.io/apimachinery v0.27.7
 ## explicit; go 1.20
 k8s.io/apimachinery/pkg/api/equality
@@ -1692,9 +1628,11 @@ k8s.io/client-go/applyconfigurations/storage/v1beta1
 k8s.io/client-go/discovery
 k8s.io/client-go/discovery/cached/disk
 k8s.io/client-go/discovery/cached/memory
+k8s.io/client-go/discovery/fake
 k8s.io/client-go/dynamic
 k8s.io/client-go/dynamic/dynamicinformer
 k8s.io/client-go/dynamic/dynamiclister
+k8s.io/client-go/dynamic/fake
 k8s.io/client-go/informers
 k8s.io/client-go/informers/admissionregistration
 k8s.io/client-go/informers/admissionregistration/v1
@@ -1763,58 +1701,110 @@ k8s.io/client-go/informers/storage/v1
 k8s.io/client-go/informers/storage/v1alpha1
 k8s.io/client-go/informers/storage/v1beta1
 k8s.io/client-go/kubernetes
+k8s.io/client-go/kubernetes/fake
 k8s.io/client-go/kubernetes/scheme
 k8s.io/client-go/kubernetes/typed/admissionregistration/v1
+k8s.io/client-go/kubernetes/typed/admissionregistration/v1/fake
 k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1
+k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake
 k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1
+k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/fake
 k8s.io/client-go/kubernetes/typed/apiserverinternal/v1alpha1
+k8s.io/client-go/kubernetes/typed/apiserverinternal/v1alpha1/fake
 k8s.io/client-go/kubernetes/typed/apps/v1
+k8s.io/client-go/kubernetes/typed/apps/v1/fake
 k8s.io/client-go/kubernetes/typed/apps/v1beta1
+k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake
 k8s.io/client-go/kubernetes/typed/apps/v1beta2
+k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake
 k8s.io/client-go/kubernetes/typed/authentication/v1
+k8s.io/client-go/kubernetes/typed/authentication/v1/fake
 k8s.io/client-go/kubernetes/typed/authentication/v1alpha1
+k8s.io/client-go/kubernetes/typed/authentication/v1alpha1/fake
 k8s.io/client-go/kubernetes/typed/authentication/v1beta1
+k8s.io/client-go/kubernetes/typed/authentication/v1beta1/fake
 k8s.io/client-go/kubernetes/typed/authorization/v1
+k8s.io/client-go/kubernetes/typed/authorization/v1/fake
 k8s.io/client-go/kubernetes/typed/authorization/v1beta1
+k8s.io/client-go/kubernetes/typed/authorization/v1beta1/fake
 k8s.io/client-go/kubernetes/typed/autoscaling/v1
+k8s.io/client-go/kubernetes/typed/autoscaling/v1/fake
 k8s.io/client-go/kubernetes/typed/autoscaling/v2
+k8s.io/client-go/kubernetes/typed/autoscaling/v2/fake
 k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1
+k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/fake
 k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2
+k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/fake
 k8s.io/client-go/kubernetes/typed/batch/v1
+k8s.io/client-go/kubernetes/typed/batch/v1/fake
 k8s.io/client-go/kubernetes/typed/batch/v1beta1
+k8s.io/client-go/kubernetes/typed/batch/v1beta1/fake
 k8s.io/client-go/kubernetes/typed/certificates/v1
+k8s.io/client-go/kubernetes/typed/certificates/v1/fake
 k8s.io/client-go/kubernetes/typed/certificates/v1alpha1
+k8s.io/client-go/kubernetes/typed/certificates/v1alpha1/fake
 k8s.io/client-go/kubernetes/typed/certificates/v1beta1
+k8s.io/client-go/kubernetes/typed/certificates/v1beta1/fake
 k8s.io/client-go/kubernetes/typed/coordination/v1
+k8s.io/client-go/kubernetes/typed/coordination/v1/fake
 k8s.io/client-go/kubernetes/typed/coordination/v1beta1
+k8s.io/client-go/kubernetes/typed/coordination/v1beta1/fake
 k8s.io/client-go/kubernetes/typed/core/v1
+k8s.io/client-go/kubernetes/typed/core/v1/fake
 k8s.io/client-go/kubernetes/typed/discovery/v1
+k8s.io/client-go/kubernetes/typed/discovery/v1/fake
 k8s.io/client-go/kubernetes/typed/discovery/v1beta1
+k8s.io/client-go/kubernetes/typed/discovery/v1beta1/fake
 k8s.io/client-go/kubernetes/typed/events/v1
+k8s.io/client-go/kubernetes/typed/events/v1/fake
 k8s.io/client-go/kubernetes/typed/events/v1beta1
+k8s.io/client-go/kubernetes/typed/events/v1beta1/fake
 k8s.io/client-go/kubernetes/typed/extensions/v1beta1
+k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake
 k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1
+k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/fake
 k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1
+k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/fake
 k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2
+k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/fake
 k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta3
+k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta3/fake
 k8s.io/client-go/kubernetes/typed/networking/v1
+k8s.io/client-go/kubernetes/typed/networking/v1/fake
 k8s.io/client-go/kubernetes/typed/networking/v1alpha1
+k8s.io/client-go/kubernetes/typed/networking/v1alpha1/fake
 k8s.io/client-go/kubernetes/typed/networking/v1beta1
+k8s.io/client-go/kubernetes/typed/networking/v1beta1/fake
 k8s.io/client-go/kubernetes/typed/node/v1
+k8s.io/client-go/kubernetes/typed/node/v1/fake
 k8s.io/client-go/kubernetes/typed/node/v1alpha1
+k8s.io/client-go/kubernetes/typed/node/v1alpha1/fake
 k8s.io/client-go/kubernetes/typed/node/v1beta1
+k8s.io/client-go/kubernetes/typed/node/v1beta1/fake
 k8s.io/client-go/kubernetes/typed/policy/v1
+k8s.io/client-go/kubernetes/typed/policy/v1/fake
 k8s.io/client-go/kubernetes/typed/policy/v1beta1
+k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake
 k8s.io/client-go/kubernetes/typed/rbac/v1
+k8s.io/client-go/kubernetes/typed/rbac/v1/fake
 k8s.io/client-go/kubernetes/typed/rbac/v1alpha1
+k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake
 k8s.io/client-go/kubernetes/typed/rbac/v1beta1
+k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake
 k8s.io/client-go/kubernetes/typed/resource/v1alpha2
+k8s.io/client-go/kubernetes/typed/resource/v1alpha2/fake
 k8s.io/client-go/kubernetes/typed/scheduling/v1
+k8s.io/client-go/kubernetes/typed/scheduling/v1/fake
 k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1
+k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/fake
 k8s.io/client-go/kubernetes/typed/scheduling/v1beta1
+k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/fake
 k8s.io/client-go/kubernetes/typed/storage/v1
+k8s.io/client-go/kubernetes/typed/storage/v1/fake
 k8s.io/client-go/kubernetes/typed/storage/v1alpha1
+k8s.io/client-go/kubernetes/typed/storage/v1alpha1/fake
 k8s.io/client-go/kubernetes/typed/storage/v1beta1
+k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake
 k8s.io/client-go/listers/admissionregistration/v1
 k8s.io/client-go/listers/admissionregistration/v1alpha1
 k8s.io/client-go/listers/admissionregistration/v1beta1
@@ -1862,6 +1852,7 @@ k8s.io/client-go/listers/storage/v1
 k8s.io/client-go/listers/storage/v1alpha1
 k8s.io/client-go/listers/storage/v1beta1
 k8s.io/client-go/metadata
+k8s.io/client-go/metadata/fake
 k8s.io/client-go/metadata/metadatainformer
 k8s.io/client-go/metadata/metadatalister
 k8s.io/client-go/openapi
@@ -1878,6 +1869,7 @@ k8s.io/client-go/plugin/pkg/client/auth/exec
 k8s.io/client-go/plugin/pkg/client/auth/gcp
 k8s.io/client-go/plugin/pkg/client/auth/oidc
 k8s.io/client-go/rest
+k8s.io/client-go/rest/fake
 k8s.io/client-go/rest/watch
 k8s.io/client-go/restmapper
 k8s.io/client-go/scale
@@ -2012,9 +2004,12 @@ k8s.io/kube-aggregator/pkg/apis/apiregistration
 k8s.io/kube-aggregator/pkg/apis/apiregistration/v1
 k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1
 k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset
+k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake
 k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme
 k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1
+k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/fake
 k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1
+k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/fake
 k8s.io/kube-aggregator/pkg/client/informers/externalversions
 k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration
 k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1
@@ -2079,7 +2074,7 @@ k8s.io/utils/path
 k8s.io/utils/pointer
 k8s.io/utils/strings/slices
 k8s.io/utils/trace
-# oras.land/oras-go v1.2.3
+# oras.land/oras-go v1.2.4
 ## explicit; go 1.18
 oras.land/oras-go/pkg/artifact
 oras.land/oras-go/pkg/auth
@@ -2093,6 +2088,8 @@ oras.land/oras-go/pkg/registry/remote/auth
 oras.land/oras-go/pkg/registry/remote/internal/errutil
 oras.land/oras-go/pkg/registry/remote/internal/syncutil
 oras.land/oras-go/pkg/target
+# rsc.io/letsencrypt v0.0.3
+## explicit
 # sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.1.2
 ## explicit; go 1.17
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client
@@ -2118,17 +2115,23 @@ sigs.k8s.io/controller-runtime/pkg/config/v1alpha1
 sigs.k8s.io/controller-runtime/pkg/controller
 sigs.k8s.io/controller-runtime/pkg/controller/controllerutil
 sigs.k8s.io/controller-runtime/pkg/conversion
+sigs.k8s.io/controller-runtime/pkg/envtest
 sigs.k8s.io/controller-runtime/pkg/event
 sigs.k8s.io/controller-runtime/pkg/handler
 sigs.k8s.io/controller-runtime/pkg/healthz
 sigs.k8s.io/controller-runtime/pkg/internal/controller
 sigs.k8s.io/controller-runtime/pkg/internal/controller/metrics
 sigs.k8s.io/controller-runtime/pkg/internal/field/selector
+sigs.k8s.io/controller-runtime/pkg/internal/flock
 sigs.k8s.io/controller-runtime/pkg/internal/httpserver
 sigs.k8s.io/controller-runtime/pkg/internal/log
 sigs.k8s.io/controller-runtime/pkg/internal/objectutil
 sigs.k8s.io/controller-runtime/pkg/internal/recorder
 sigs.k8s.io/controller-runtime/pkg/internal/source
+sigs.k8s.io/controller-runtime/pkg/internal/testing/addr
+sigs.k8s.io/controller-runtime/pkg/internal/testing/certs
+sigs.k8s.io/controller-runtime/pkg/internal/testing/controlplane
+sigs.k8s.io/controller-runtime/pkg/internal/testing/process
 sigs.k8s.io/controller-runtime/pkg/leaderelection
 sigs.k8s.io/controller-runtime/pkg/log
 sigs.k8s.io/controller-runtime/pkg/log/zap
@@ -2165,6 +2168,46 @@ sigs.k8s.io/controller-tools/pkg/webhook
 ## explicit; go 1.18
 sigs.k8s.io/json
 sigs.k8s.io/json/internal/golang/encoding/json
+# sigs.k8s.io/kind v0.20.0
+## explicit; go 1.16
+sigs.k8s.io/kind/pkg/apis/config/defaults
+sigs.k8s.io/kind/pkg/apis/config/v1alpha4
+sigs.k8s.io/kind/pkg/cluster
+sigs.k8s.io/kind/pkg/cluster/constants
+sigs.k8s.io/kind/pkg/cluster/internal/create
+sigs.k8s.io/kind/pkg/cluster/internal/create/actions
+sigs.k8s.io/kind/pkg/cluster/internal/create/actions/config
+sigs.k8s.io/kind/pkg/cluster/internal/create/actions/installcni
+sigs.k8s.io/kind/pkg/cluster/internal/create/actions/installstorage
+sigs.k8s.io/kind/pkg/cluster/internal/create/actions/kubeadminit
+sigs.k8s.io/kind/pkg/cluster/internal/create/actions/kubeadmjoin
+sigs.k8s.io/kind/pkg/cluster/internal/create/actions/loadbalancer
+sigs.k8s.io/kind/pkg/cluster/internal/create/actions/waitforready
+sigs.k8s.io/kind/pkg/cluster/internal/delete
+sigs.k8s.io/kind/pkg/cluster/internal/kubeadm
+sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig
+sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig
+sigs.k8s.io/kind/pkg/cluster/internal/loadbalancer
+sigs.k8s.io/kind/pkg/cluster/internal/logs
+sigs.k8s.io/kind/pkg/cluster/internal/providers
+sigs.k8s.io/kind/pkg/cluster/internal/providers/common
+sigs.k8s.io/kind/pkg/cluster/internal/providers/docker
+sigs.k8s.io/kind/pkg/cluster/internal/providers/podman
+sigs.k8s.io/kind/pkg/cluster/nodes
+sigs.k8s.io/kind/pkg/cluster/nodeutils
+sigs.k8s.io/kind/pkg/cmd
+sigs.k8s.io/kind/pkg/cmd/kind/version
+sigs.k8s.io/kind/pkg/errors
+sigs.k8s.io/kind/pkg/exec
+sigs.k8s.io/kind/pkg/fs
+sigs.k8s.io/kind/pkg/internal/apis/config
+sigs.k8s.io/kind/pkg/internal/apis/config/encoding
+sigs.k8s.io/kind/pkg/internal/cli
+sigs.k8s.io/kind/pkg/internal/env
+sigs.k8s.io/kind/pkg/internal/patch
+sigs.k8s.io/kind/pkg/internal/sets
+sigs.k8s.io/kind/pkg/internal/version
+sigs.k8s.io/kind/pkg/log
 # sigs.k8s.io/kustomize/api v0.13.2
 ## explicit; go 1.19
 sigs.k8s.io/kustomize/api/filters/annotations
@@ -2259,11 +2302,5 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 # google.golang.org/grpc => google.golang.org/grpc v1.40.0
-# github.com/docker/distribution => github.com/docker/distribution v0.0.0-20191216044856-a8371794149d
-# github.com/openshift/api => github.com/openshift/api v0.0.0-20210517065120-b325f58df679
-# github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0
-# github.com/operator-framework/api => ./staging/api
-# github.com/operator-framework/operator-lifecycle-manager => ./staging/operator-lifecycle-manager
-# github.com/operator-framework/operator-registry => ./staging/operator-registry
-# k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.25.0
-# sigs.k8s.io/structured-merge-diff => sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06
+# github.com/openshift/api => github.com/openshift/api v0.0.0-20221021112143-4226c2167e40
+# github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
@@ -346,6 +346,7 @@ func NewOperator(ctx context.Context, kubeconfigPath string, clock utilclock.Clo
 		subscription.WithAppendedReconcilers(subscription.ReconcilerFromLegacySyncHandler(op.syncSubscriptions, nil)),
 		subscription.WithRegistryReconcilerFactory(op.reconciler),
 		subscription.WithGlobalCatalogNamespace(op.namespace),
+		subscription.WithSourceProvider(resolverSourceProvider),
 	)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/subscription/config.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/subscription/config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler"
+	resolverCache "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubestate"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorlister"
 )
@@ -26,6 +27,7 @@ type syncerConfig struct {
 	reconcilers               kubestate.ReconcilerChain
 	registryReconcilerFactory reconciler.RegistryReconcilerFactory
 	globalCatalogNamespace    string
+	sourceProvider            resolverCache.SourceProvider
 }
 
 // SyncerOption is a configuration option for a subscription syncer.
@@ -125,6 +127,12 @@ func WithRegistryReconcilerFactory(r reconciler.RegistryReconcilerFactory) Synce
 func WithGlobalCatalogNamespace(namespace string) SyncerOption {
 	return func(config *syncerConfig) {
 		config.globalCatalogNamespace = namespace
+	}
+}
+
+func WithSourceProvider(provider resolverCache.SourceProvider) SyncerOption {
+	return func(config *syncerConfig) {
+		config.sourceProvider = provider
 	}
 }
 

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/subscription/syncer.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/subscription/syncer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/operator-framework/api/pkg/operators/install"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	listers "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
+	resolverCache "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubestate"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/metrics"
@@ -34,6 +35,7 @@ type subscriptionSyncer struct {
 	installPlanLister      listers.InstallPlanLister
 	globalCatalogNamespace string
 	notify                 kubestate.NotifyFunc
+	sourceProvider         resolverCache.SourceProvider
 }
 
 // now returns the Syncer's current time.
@@ -214,6 +216,7 @@ func newSyncerWithConfig(ctx context.Context, config *syncerConfig) (kubestate.S
 		reconcilers:       config.reconcilers,
 		subscriptionCache: config.subscriptionInformer.GetIndexer(),
 		installPlanLister: config.lister.OperatorsV1alpha1().InstallPlanLister(),
+		sourceProvider:    config.sourceProvider,
 		notify: func(event kubestate.ResourceEvent) {
 			// Notify Subscriptions by enqueuing to the Subscription queue.
 			config.subscriptionQueue.Add(event)
@@ -234,6 +237,7 @@ func newSyncerWithConfig(ctx context.Context, config *syncerConfig) (kubestate.S
 			catalogLister:             config.lister.OperatorsV1alpha1().CatalogSourceLister(),
 			registryReconcilerFactory: config.registryReconcilerFactory,
 			globalCatalogNamespace:    config.globalCatalogNamespace,
+			sourceProvider:            config.sourceProvider,
 		},
 	}
 	s.reconcilers = append(defaultReconcilers, s.reconcilers...)

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache/operators.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache/operators.go
@@ -140,11 +140,18 @@ type OperatorSourceInfo struct {
 	StartingCSV    string
 	Catalog        SourceKey
 	DefaultChannel bool
+	Deprecations   *Deprecations
 	Subscription   *v1alpha1.Subscription
 }
 
 func (i *OperatorSourceInfo) String() string {
 	return fmt.Sprintf("%s/%s in %s/%s", i.Package, i.Channel, i.Catalog.Name, i.Catalog.Namespace)
+}
+
+type Deprecations struct {
+	Package *api.Deprecation
+	Channel *api.Deprecation
+	Bundle  *api.Deprecation
 }
 
 type Entry struct {


### PR DESCRIPTION
Adds the `OperatorDeprecated` Condition to the status of Subscriptions when the bundle has been deprecated.

Upstream-repository: operator-lifecycle-manager
Upstream-commit: b9638dcaaa14d4005b12abe63feb2055a49ca793