### PR TITLE
NO-ISSUE: Update verified directories for microshift-manifests

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-export KNOWN_GENERATED_PATHS=(':!vendor' ':!pkg/manifests' ':!manifests' ':!go.sum' ':!go.mod')
+export KNOWN_GENERATED_PATHS=(':!vendor' ':!pkg/manifests' ':!microshift-manifests' ':!manifests' ':!go.sum' ':!go.mod')
 # TODO(tflannag): This is hacky but works in the current setup.
-export ROOT_GENERATED_PATHS=( "vendor" "pkg/manifests" "manifests" "go.mod" "go.sum" )
+export ROOT_GENERATED_PATHS=( "vendor" "pkg/manifests" "microshift-manifests" "manifests" "go.mod" "go.sum" )
 export UPSTREAM_REMOTES=("api" "operator-registry" "operator-lifecycle-manager")

--- a/scripts/verify_commits.sh
+++ b/scripts/verify_commits.sh
@@ -24,7 +24,7 @@ function verify_staging_sync() {
     local outside_staging
     outside_staging="$(git show --name-only "${downstream_commit}" -- ":!${staging_dir}" "${KNOWN_GENERATED_PATHS[@]}")"
     if [[ -n "${outside_staging}" ]]; then
-        err "downstream staging commit ${downstream_commit} changes files outside of ${staging_dir}, vendor, and manifests directories"
+        err "downstream staging commit ${downstream_commit} changes files outside of ${staging_dir}, vendor, and [microshift-]manifests directories"
         err "${outside_staging}"
         err "hint: factor out changes to these directories into a standalone commit"
         return 1


### PR DESCRIPTION
Add `microshift-manifests` to the list of generated files/dirs scaned by `make verify`.