### PR TITLE
[release-4.14] OCPBUGS-27485: [CARRY] SSC RBAC

### DIFF
--- a/manifests/0000_50_olm_01-olm-operator.serviceaccount.yaml
+++ b/manifests/0000_50_olm_01-olm-operator.serviceaccount.yaml
@@ -26,6 +26,7 @@ rules:
       - securitycontextconstraints
     resourceNames:
       - restricted-v2
+      - anyuid
     verbs:
       - use
 ---

--- a/manifests/0000_50_olm_01-olm-operator.serviceaccount.yaml
+++ b/manifests/0000_50_olm_01-olm-operator.serviceaccount.yaml
@@ -17,7 +17,7 @@ metadata:
 rules:
   - apiGroups: ["*"]
     resources: ["*"]
-    verbs: ["*"]
+    verbs: ["watch", "list", "get", "create", "update", "patch", "delete", "deletecollection", "escalate", "bind"]
   - nonResourceURLs: ["*"]
     verbs: ["*"]
   - apiGroups:

--- a/manifests/0000_50_olm_01-olm-operator.serviceaccount.yaml
+++ b/manifests/0000_50_olm_01-olm-operator.serviceaccount.yaml
@@ -20,6 +20,14 @@ rules:
     verbs: ["*"]
   - nonResourceURLs: ["*"]
     verbs: ["*"]
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - restricted-v2
+    verbs:
+      - use
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/scripts/generate_crds_manifests.sh
+++ b/scripts/generate_crds_manifests.sh
@@ -85,6 +85,7 @@ add_ibm_managed_cloud_annotations() {
 }
 
 ${YQ} merge --inplace -d'*' manifests/0000_50_olm_00-namespace.yaml scripts/namespaces.patch.yaml
+${YQ} merge --inplace --arrays=append -d'1' manifests/0000_50_olm_01-olm-operator.serviceaccount.yaml scripts/olm-service.patch.yaml
 ${YQ} merge --inplace -d'0' manifests/0000_50_olm_00-namespace.yaml scripts/monitoring-namespace.patch.yaml
 ${YQ} write --inplace -s scripts/olm-deployment.patch.yaml manifests/0000_50_olm_07-olm-operator.deployment.yaml
 ${YQ} write --inplace -s scripts/catalog-deployment.patch.yaml manifests/0000_50_olm_08-catalog-operator.deployment.yaml

--- a/scripts/olm-service.patch.yaml
+++ b/scripts/olm-service.patch.yaml
@@ -1,0 +1,9 @@
+rules:
+  - apiGroups:
+    - security.openshift.io
+    resources:
+    - securitycontextconstraints
+    resourceNames:
+    - restricted-v2
+    verbs:
+    - use

--- a/scripts/olm-service.patch.yaml
+++ b/scripts/olm-service.patch.yaml
@@ -5,5 +5,6 @@ rules:
     - securitycontextconstraints
     resourceNames:
     - restricted-v2
+    - anyuid
     verbs:
     - use

--- a/staging/operator-lifecycle-manager/deploy/chart/templates/0000_50_olm_01-olm-operator.serviceaccount.yaml
+++ b/staging/operator-lifecycle-manager/deploy/chart/templates/0000_50_olm_01-olm-operator.serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
 rules:
 - apiGroups: ["*"]
   resources: ["*"]
-  verbs: ["*"]
+  verbs: ["watch", "list", "get", "create", "update", "patch", "delete", "deletecollection", "escalate", "bind"]
 - nonResourceURLs: ["*"]
   verbs: ["*"]
 ---


### PR DESCRIPTION
After reducing the RBAC granted to the OLM ServiceAccount in an earlier commit, this commit introduces RBAC so pods that use the OLM ServiceAccount will qualify to use the restricted-v2 SCC.