### PR TITLE
[release-4.15] OCPBUGS-25798: Fix snapshot failure, backport e2es

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
@@ -346,7 +346,7 @@ func NewOperator(ctx context.Context, kubeconfigPath string, clock utilclock.Clo
 		subscription.WithAppendedReconcilers(subscription.ReconcilerFromLegacySyncHandler(op.syncSubscriptions, nil)),
 		subscription.WithRegistryReconcilerFactory(op.reconciler),
 		subscription.WithGlobalCatalogNamespace(op.namespace),
-		subscription.WithSourceProvider(resolverSourceProvider),
+		subscription.WithSourceProvider(op.sourceInvalidator),
 	)
 	if err != nil {
 		return nil, err

--- a/staging/operator-lifecycle-manager/test/e2e/csv_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/csv_e2e_test.go
@@ -4441,6 +4441,7 @@ func fetchCSV(c versioned.Interface, namespace, name string, checker csvConditio
 	var lastPhase operatorsv1alpha1.ClusterServiceVersionPhase
 	var lastReason operatorsv1alpha1.ConditionReason
 	var lastMessage string
+	var lastError string
 	lastTime := time.Now()
 	var csv *operatorsv1alpha1.ClusterServiceVersion
 
@@ -4449,7 +4450,10 @@ func fetchCSV(c versioned.Interface, namespace, name string, checker csvConditio
 		var err error
 		csv, err = c.OperatorsV1alpha1().ClusterServiceVersions(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil || csv == nil {
-			ctx.Ctx().Logf("error getting csv %s/%s: %v", namespace, name, err)
+			if lastError != err.Error() {
+				ctx.Ctx().Logf("error getting csv %s/%s: %v", namespace, name, err)
+				lastError = err.Error()
+			}
 			return false, nil
 		}
 		phase, reason, message := csv.Status.Phase, csv.Status.Reason, csv.Status.Message

--- a/staging/operator-lifecycle-manager/test/e2e/subscription_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/subscription_e2e_test.go
@@ -328,7 +328,7 @@ var _ = Describe("Subscription", func() {
 		subscriptionCleanup, _ := createSubscription(GinkgoT(), crc, generatedNamespace.GetName(), "manual-subscription", testPackageName, stableChannel, operatorsv1alpha1.ApprovalManual)
 		defer subscriptionCleanup()
 
-		subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), "manual-subscription", subscriptionStateUpgradePendingChecker())
+		subscription, err := fetchSubscription(crc, generatedNamespace.GetName(), "manual-subscription", subscriptionHasCondition(operatorsv1alpha1.SubscriptionInstallPlanPending, corev1.ConditionTrue, string(operatorsv1alpha1.InstallPlanPhaseRequiresApproval), ""))
 		require.NoError(GinkgoT(), err)
 		require.NotNil(GinkgoT(), subscription)
 

--- a/staging/operator-lifecycle-manager/test/e2e/util.go
+++ b/staging/operator-lifecycle-manager/test/e2e/util.go
@@ -677,8 +677,10 @@ func createInternalCatalogSource(
 	ctx.Ctx().Logf("Catalog source %s created", name)
 
 	cleanupInternalCatalogSource := func() {
+		ctx.Ctx().Logf("Cleaning catalog source %s", name)
 		configMapCleanup()
 		buildCatalogSourceCleanupFunc(c, crc, namespace, catalogSource)()
+		ctx.Ctx().Logf("Done cleaning catalog source %s", name)
 	}
 	return catalogSource, cleanupInternalCatalogSource
 }

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
@@ -346,7 +346,7 @@ func NewOperator(ctx context.Context, kubeconfigPath string, clock utilclock.Clo
 		subscription.WithAppendedReconcilers(subscription.ReconcilerFromLegacySyncHandler(op.syncSubscriptions, nil)),
 		subscription.WithRegistryReconcilerFactory(op.reconciler),
 		subscription.WithGlobalCatalogNamespace(op.namespace),
-		subscription.WithSourceProvider(resolverSourceProvider),
+		subscription.WithSourceProvider(op.sourceInvalidator),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This pr fixes an issue with deprecation propogation with certain operatorgroup contexts

Additionally, this pr pulls in a set of e2e improvements to increase our signal for release backports