### PR TITLE
[release-4.14] OCPBUGS-27314: Don't sync namespaces that have no subscriptions

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
@@ -938,6 +938,12 @@ func (o *Operator) syncResolvingNamespace(obj interface{}) error {
 		return err
 	}
 
+	// If there are no subscriptions, don't attempt to sync the namespace.
+	if len(subs) == 0 {
+		logger.Debug(fmt.Sprintf("No subscriptions were found in namespace %v", namespace))
+		return nil
+	}
+
 	ogLister := o.lister.OperatorsV1().OperatorGroupLister().OperatorGroups(namespace)
 	failForwardEnabled, err := resolver.IsFailForwardEnabled(ogLister)
 	if err != nil {

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
@@ -938,6 +938,12 @@ func (o *Operator) syncResolvingNamespace(obj interface{}) error {
 		return err
 	}
 
+	// If there are no subscriptions, don't attempt to sync the namespace.
+	if len(subs) == 0 {
+		logger.Debug(fmt.Sprintf("No subscriptions were found in namespace %v", namespace))
+		return nil
+	}
+
 	ogLister := o.lister.OperatorsV1().OperatorGroupLister().OperatorGroups(namespace)
 	failForwardEnabled, err := resolver.IsFailForwardEnabled(ogLister)
 	if err != nil {


### PR DESCRIPTION
Problem: The catalog operator is logging many errors regarding missing operator groups in namespaces that have no operators installed.

Solution: If a namespace has no subscriptions in it, do not check if an operator group is present in the namespace.


Upstream-repository: operator-lifecycle-manager
Upstream-commit: 2625ded47cc8260b4a620fd45c2d440bb864413f