### PR TITLE
Add relatedObjects to the initially created ClusterOperator

### DIFF
--- a/manifests/0000_50_olm_99-operatorstatus.yaml
+++ b/manifests/0000_50_olm_99-operatorstatus.yaml
@@ -10,6 +10,11 @@ status:
   versions:
     - name: operator
       version: "0.0.1-snapshot"
+  relatedObjects:
+    - group: operators.coreos.com
+      name: packageserver
+      namespace: openshift-operator-lifecycle-manager
+      resource: clusterserviceversions
 ---
 apiVersion: config.openshift.io/v1
 kind: ClusterOperator
@@ -23,6 +28,10 @@ status:
   versions:
     - name: operator
       version: "0.0.1-snapshot"
+  relatedObjects:
+    - group: ""
+      name: openshift-operator-lifecycle-manager
+      resource: namespaces
 ---
 apiVersion: config.openshift.io/v1
 kind: ClusterOperator
@@ -36,3 +45,11 @@ status:
   versions:
     - name: operator
       version: "0.0.1-snapshot"
+  relatedObjects:
+    - group: ""
+      name: openshift-operator-lifecycle-manager
+      resource: namespaces
+    - group: operators.coreos.com
+      name: packageserver
+      namespace: openshift-operator-lifecycle-manager
+      resource: clusterserviceversions

--- a/microshift-manifests/0000_50_olm_99-operatorstatus.yaml
+++ b/microshift-manifests/0000_50_olm_99-operatorstatus.yaml
@@ -10,6 +10,11 @@ status:
   versions:
     - name: operator
       version: "0.0.1-snapshot"
+  relatedObjects:
+    - group: operators.coreos.com
+      name: packageserver
+      namespace: openshift-operator-lifecycle-manager
+      resource: clusterserviceversions
 ---
 apiVersion: config.openshift.io/v1
 kind: ClusterOperator
@@ -23,6 +28,10 @@ status:
   versions:
     - name: operator
       version: "0.0.1-snapshot"
+  relatedObjects:
+    - group: ""
+      name: openshift-operator-lifecycle-manager
+      resource: namespaces
 ---
 apiVersion: config.openshift.io/v1
 kind: ClusterOperator
@@ -36,3 +45,11 @@ status:
   versions:
     - name: operator
       version: "0.0.1-snapshot"
+  relatedObjects:
+    - group: ""
+      name: openshift-operator-lifecycle-manager
+      resource: namespaces
+    - group: operators.coreos.com
+      name: packageserver
+      namespace: openshift-operator-lifecycle-manager
+      resource: clusterserviceversions

--- a/staging/operator-lifecycle-manager/deploy/chart/templates/0000_50_olm_99-operatorstatus.yaml
+++ b/staging/operator-lifecycle-manager/deploy/chart/templates/0000_50_olm_99-operatorstatus.yaml
@@ -7,6 +7,11 @@ status:
   versions:
     - name: operator
       version: "0.0.1-snapshot"
+  relatedObjects:
+    - group: operators.coreos.com
+      name: packageserver
+      namespace: openshift-operator-lifecycle-manager
+      resource: clusterserviceversions
 ---
 apiVersion: config.openshift.io/v1
 kind: ClusterOperator
@@ -16,6 +21,10 @@ status:
   versions:
     - name: operator
       version: "0.0.1-snapshot"
+  relatedObjects:
+    - group: ""
+      name: openshift-operator-lifecycle-manager
+      resource: namespaces
 {{- if .Values.writePackageServerStatusName }}
 ---
 apiVersion: config.openshift.io/v1
@@ -26,5 +35,13 @@ status:
   versions:
     - name: operator
       version: "0.0.1-snapshot"
-{{- end }}      
+  relatedObjects:
+    - group: ""
+      name: openshift-operator-lifecycle-manager
+      resource: namespaces
+    - group: operators.coreos.com
+      name: packageserver
+      namespace: openshift-operator-lifecycle-manager
+      resource: clusterserviceversions
+{{- end }}
 {{- end }}


### PR DESCRIPTION
This allows for oc adm inspect and must-gather to collected debugging infomation in cases where the operator fails to run properly.