### PR TITLE
OCPBUGS-29553: Apply hypershift cluster-profile for ibm-cloud-managed

### DIFF
--- a/manifests/0000_50_olm_00-catalogsources.crd.yaml
+++ b/manifests/0000_50_olm_00-catalogsources.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   creationTimestamp: null

--- a/manifests/0000_50_olm_00-clusterserviceversions.crd.yaml
+++ b/manifests/0000_50_olm_00-clusterserviceversions.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   creationTimestamp: null

--- a/manifests/0000_50_olm_00-installplans.crd.yaml
+++ b/manifests/0000_50_olm_00-installplans.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   creationTimestamp: null

--- a/manifests/0000_50_olm_00-namespace.yaml
+++ b/manifests/0000_50_olm_00-namespace.yaml
@@ -11,6 +11,7 @@ metadata:
     openshift.io/node-selector: ""
     workload.openshift.io/allowed: "management"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 ---
@@ -26,5 +27,6 @@ metadata:
     openshift.io/node-selector: ""
     workload.openshift.io/allowed: "management"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"

--- a/manifests/0000_50_olm_00-olmconfigs.crd.yaml
+++ b/manifests/0000_50_olm_00-olmconfigs.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   creationTimestamp: null

--- a/manifests/0000_50_olm_00-operatorconditions.crd.yaml
+++ b/manifests/0000_50_olm_00-operatorconditions.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   creationTimestamp: null

--- a/manifests/0000_50_olm_00-operatorgroups.crd.yaml
+++ b/manifests/0000_50_olm_00-operatorgroups.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   creationTimestamp: null

--- a/manifests/0000_50_olm_00-operators.crd.yaml
+++ b/manifests/0000_50_olm_00-operators.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   creationTimestamp: null

--- a/manifests/0000_50_olm_00-packageserver.pdb.yaml
+++ b/manifests/0000_50_olm_00-packageserver.pdb.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 spec:

--- a/manifests/0000_50_olm_00-pprof-config.yaml
+++ b/manifests/0000_50_olm_00-pprof-config.yaml
@@ -3,6 +3,7 @@ kind: ConfigMap
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"

--- a/manifests/0000_50_olm_00-pprof-rbac.yaml
+++ b/manifests/0000_50_olm_00-pprof-rbac.yaml
@@ -3,6 +3,7 @@ kind: Role
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   name: collect-profiles
@@ -20,6 +21,7 @@ kind: RoleBinding
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   name: collect-profiles
@@ -38,6 +40,7 @@ kind: ServiceAccount
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   name: collect-profiles

--- a/manifests/0000_50_olm_00-pprof-secret.yaml
+++ b/manifests/0000_50_olm_00-pprof-secret.yaml
@@ -3,6 +3,7 @@ kind: Secret
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
     openshift.io/owning-component: "Operator Framework / operator-lifecycle-manager"

--- a/manifests/0000_50_olm_00-subscriptions.crd.yaml
+++ b/manifests/0000_50_olm_00-subscriptions.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   creationTimestamp: null

--- a/manifests/0000_50_olm_01-olm-operator.serviceaccount.yaml
+++ b/manifests/0000_50_olm_01-olm-operator.serviceaccount.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 ---
@@ -14,6 +15,7 @@ metadata:
   name: system:controller:operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 rules:
@@ -38,6 +40,7 @@ metadata:
   name: olm-operator-binding-openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 roleRef:

--- a/manifests/0000_50_olm_02-olmconfig.yaml
+++ b/manifests/0000_50_olm_02-olmconfig.yaml
@@ -5,5 +5,6 @@ metadata:
   annotations:
     release.openshift.io/create-only: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"

--- a/manifests/0000_50_olm_02-services.yaml
+++ b/manifests/0000_50_olm_02-services.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: olm-operator-serving-cert
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   labels:
@@ -28,6 +29,7 @@ metadata:
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: catalog-operator-serving-cert
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   labels:

--- a/manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
+++ b/manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
@@ -7,6 +7,7 @@ metadata:
     app: package-server-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 spec:
   strategy:

--- a/manifests/0000_50_olm_06-psm-operator.service.yaml
+++ b/manifests/0000_50_olm_06-psm-operator.service.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     service.alpha.openshift.io/serving-cert-secret-name: package-server-manager-serving-cert
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   name: package-server-manager-metrics
   namespace: openshift-operator-lifecycle-manager

--- a/manifests/0000_50_olm_06-psm-operator.servicemonitor.yaml
+++ b/manifests/0000_50_olm_06-psm-operator.servicemonitor.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 spec:
   endpoints:

--- a/manifests/0000_50_olm_07-collect-profiles.cronjob.yaml
+++ b/manifests/0000_50_olm_07-collect-profiles.cronjob.yaml
@@ -3,6 +3,7 @@ kind: CronJob
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   name: collect-profiles

--- a/manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
+++ b/manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
@@ -7,6 +7,7 @@ metadata:
     app: olm-operator
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 spec:
   strategy:

--- a/manifests/0000_50_olm_08-catalog-operator.deployment.ibm-cloud-managed.yaml
+++ b/manifests/0000_50_olm_08-catalog-operator.deployment.ibm-cloud-managed.yaml
@@ -7,6 +7,7 @@ metadata:
     app: catalog-operator
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 spec:
   strategy:

--- a/manifests/0000_50_olm_09-aggregated.clusterrole.yaml
+++ b/manifests/0000_50_olm_09-aggregated.clusterrole.yaml
@@ -8,6 +8,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 rules:
@@ -29,6 +30,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 rules:

--- a/manifests/0000_50_olm_11-olm-operators.configmap.removed.yaml
+++ b/manifests/0000_50_olm_11-olm-operators.configmap.removed.yaml
@@ -6,5 +6,6 @@ metadata:
   annotations:
     release.openshift.io/delete: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"

--- a/manifests/0000_50_olm_12-olm-operators.catalogsource.removed.yaml
+++ b/manifests/0000_50_olm_12-olm-operators.catalogsource.removed.yaml
@@ -6,5 +6,6 @@ metadata:
   annotations:
     release.openshift.io/delete: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"

--- a/manifests/0000_50_olm_13-operatorgroup-default.yaml
+++ b/manifests/0000_50_olm_13-operatorgroup-default.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-operators
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 ---
@@ -15,6 +16,7 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 spec:

--- a/manifests/0000_50_olm_14-packageserver.subscription.removed.yaml
+++ b/manifests/0000_50_olm_14-packageserver.subscription.removed.yaml
@@ -6,5 +6,6 @@ metadata:
   annotations:
     release.openshift.io/delete: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"

--- a/manifests/0000_50_olm_15-csv-viewer.rbac.yaml
+++ b/manifests/0000_50_olm_15-csv-viewer.rbac.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     rbac.authorization.kubernetes.io/autoupdate: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   name: copied-csv-viewer
@@ -24,6 +25,7 @@ metadata:
   annotations:
     rbac.authorization.kubernetes.io/autoupdate: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   name: copied-csv-viewers

--- a/manifests/0000_50_olm_99-operatorstatus.yaml
+++ b/manifests/0000_50_olm_99-operatorstatus.yaml
@@ -4,6 +4,7 @@ metadata:
   name: operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 status:
@@ -17,6 +18,7 @@ metadata:
   name: operator-lifecycle-manager-catalog
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 status:
@@ -30,6 +32,7 @@ metadata:
   name: operator-lifecycle-manager-packageserver
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 status:

--- a/manifests/0000_90_olm_00-service-monitor.yaml
+++ b/manifests/0000_90_olm_00-service-monitor.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 rules:
@@ -26,6 +27,7 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 roleRef:
@@ -46,6 +48,7 @@ metadata:
     app: olm-operator
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 spec:
@@ -79,6 +82,7 @@ metadata:
     app: catalog-operator
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 spec:

--- a/manifests/0000_90_olm_01-prometheus-rule.yaml
+++ b/manifests/0000_90_olm_01-prometheus-rule.yaml
@@ -8,6 +8,7 @@ metadata:
     role: alert-rules
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 spec:

--- a/microshift-manifests/0000_50_olm_00-catalogsources.crd.yaml
+++ b/microshift-manifests/0000_50_olm_00-catalogsources.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   creationTimestamp: null

--- a/microshift-manifests/0000_50_olm_00-clusterserviceversions.crd.yaml
+++ b/microshift-manifests/0000_50_olm_00-clusterserviceversions.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   creationTimestamp: null

--- a/microshift-manifests/0000_50_olm_00-installplans.crd.yaml
+++ b/microshift-manifests/0000_50_olm_00-installplans.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   creationTimestamp: null

--- a/microshift-manifests/0000_50_olm_00-namespace.yaml
+++ b/microshift-manifests/0000_50_olm_00-namespace.yaml
@@ -11,6 +11,7 @@ metadata:
     openshift.io/node-selector: ""
     workload.openshift.io/allowed: "management"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 ---
@@ -26,5 +27,6 @@ metadata:
     openshift.io/node-selector: ""
     workload.openshift.io/allowed: "management"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"

--- a/microshift-manifests/0000_50_olm_00-olmconfigs.crd.yaml
+++ b/microshift-manifests/0000_50_olm_00-olmconfigs.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   creationTimestamp: null

--- a/microshift-manifests/0000_50_olm_00-operatorconditions.crd.yaml
+++ b/microshift-manifests/0000_50_olm_00-operatorconditions.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   creationTimestamp: null

--- a/microshift-manifests/0000_50_olm_00-operatorgroups.crd.yaml
+++ b/microshift-manifests/0000_50_olm_00-operatorgroups.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   creationTimestamp: null

--- a/microshift-manifests/0000_50_olm_00-operators.crd.yaml
+++ b/microshift-manifests/0000_50_olm_00-operators.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   creationTimestamp: null

--- a/microshift-manifests/0000_50_olm_00-packageserver.pdb.yaml
+++ b/microshift-manifests/0000_50_olm_00-packageserver.pdb.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 spec:

--- a/microshift-manifests/0000_50_olm_00-pprof-config.yaml
+++ b/microshift-manifests/0000_50_olm_00-pprof-config.yaml
@@ -3,6 +3,7 @@ kind: ConfigMap
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"

--- a/microshift-manifests/0000_50_olm_00-pprof-rbac.yaml
+++ b/microshift-manifests/0000_50_olm_00-pprof-rbac.yaml
@@ -3,6 +3,7 @@ kind: Role
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   name: collect-profiles
@@ -20,6 +21,7 @@ kind: RoleBinding
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   name: collect-profiles
@@ -38,6 +40,7 @@ kind: ServiceAccount
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   name: collect-profiles

--- a/microshift-manifests/0000_50_olm_00-pprof-secret.yaml
+++ b/microshift-manifests/0000_50_olm_00-pprof-secret.yaml
@@ -3,6 +3,7 @@ kind: Secret
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
     openshift.io/owning-component: "Operator Framework / operator-lifecycle-manager"

--- a/microshift-manifests/0000_50_olm_00-subscriptions.crd.yaml
+++ b/microshift-manifests/0000_50_olm_00-subscriptions.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   creationTimestamp: null

--- a/microshift-manifests/0000_50_olm_01-olm-operator.serviceaccount.yaml
+++ b/microshift-manifests/0000_50_olm_01-olm-operator.serviceaccount.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 ---
@@ -14,6 +15,7 @@ metadata:
   name: system:controller:operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 rules:
@@ -38,6 +40,7 @@ metadata:
   name: olm-operator-binding-openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 roleRef:

--- a/microshift-manifests/0000_50_olm_02-olmconfig.yaml
+++ b/microshift-manifests/0000_50_olm_02-olmconfig.yaml
@@ -5,5 +5,6 @@ metadata:
   annotations:
     release.openshift.io/create-only: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"

--- a/microshift-manifests/0000_50_olm_02-services.yaml
+++ b/microshift-manifests/0000_50_olm_02-services.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: olm-operator-serving-cert
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   labels:
@@ -28,6 +29,7 @@ metadata:
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: catalog-operator-serving-cert
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   labels:

--- a/microshift-manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
+++ b/microshift-manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
@@ -7,6 +7,7 @@ metadata:
     app: package-server-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 spec:
   strategy:

--- a/microshift-manifests/0000_50_olm_06-psm-operator.service.yaml
+++ b/microshift-manifests/0000_50_olm_06-psm-operator.service.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     service.alpha.openshift.io/serving-cert-secret-name: package-server-manager-serving-cert
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   name: package-server-manager-metrics
   namespace: openshift-operator-lifecycle-manager

--- a/microshift-manifests/0000_50_olm_06-psm-operator.servicemonitor.yaml
+++ b/microshift-manifests/0000_50_olm_06-psm-operator.servicemonitor.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 spec:
   endpoints:

--- a/microshift-manifests/0000_50_olm_07-collect-profiles.cronjob.yaml
+++ b/microshift-manifests/0000_50_olm_07-collect-profiles.cronjob.yaml
@@ -3,6 +3,7 @@ kind: CronJob
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   name: collect-profiles

--- a/microshift-manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
+++ b/microshift-manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
@@ -7,6 +7,7 @@ metadata:
     app: olm-operator
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 spec:
   strategy:

--- a/microshift-manifests/0000_50_olm_08-catalog-operator.deployment.ibm-cloud-managed.yaml
+++ b/microshift-manifests/0000_50_olm_08-catalog-operator.deployment.ibm-cloud-managed.yaml
@@ -7,6 +7,7 @@ metadata:
     app: catalog-operator
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 spec:
   strategy:

--- a/microshift-manifests/0000_50_olm_09-aggregated.clusterrole.yaml
+++ b/microshift-manifests/0000_50_olm_09-aggregated.clusterrole.yaml
@@ -8,6 +8,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 rules:
@@ -29,6 +30,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 rules:

--- a/microshift-manifests/0000_50_olm_11-olm-operators.configmap.removed.yaml
+++ b/microshift-manifests/0000_50_olm_11-olm-operators.configmap.removed.yaml
@@ -6,5 +6,6 @@ metadata:
   annotations:
     release.openshift.io/delete: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"

--- a/microshift-manifests/0000_50_olm_12-olm-operators.catalogsource.removed.yaml
+++ b/microshift-manifests/0000_50_olm_12-olm-operators.catalogsource.removed.yaml
@@ -6,5 +6,6 @@ metadata:
   annotations:
     release.openshift.io/delete: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"

--- a/microshift-manifests/0000_50_olm_13-operatorgroup-default.yaml
+++ b/microshift-manifests/0000_50_olm_13-operatorgroup-default.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-operators
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 ---
@@ -15,6 +16,7 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 spec:

--- a/microshift-manifests/0000_50_olm_14-packageserver.subscription.removed.yaml
+++ b/microshift-manifests/0000_50_olm_14-packageserver.subscription.removed.yaml
@@ -6,5 +6,6 @@ metadata:
   annotations:
     release.openshift.io/delete: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"

--- a/microshift-manifests/0000_50_olm_15-csv-viewer.rbac.yaml
+++ b/microshift-manifests/0000_50_olm_15-csv-viewer.rbac.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     rbac.authorization.kubernetes.io/autoupdate: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   name: copied-csv-viewer
@@ -24,6 +25,7 @@ metadata:
   annotations:
     rbac.authorization.kubernetes.io/autoupdate: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   name: copied-csv-viewers

--- a/microshift-manifests/0000_50_olm_99-operatorstatus.yaml
+++ b/microshift-manifests/0000_50_olm_99-operatorstatus.yaml
@@ -4,6 +4,7 @@ metadata:
   name: operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 status:
@@ -17,6 +18,7 @@ metadata:
   name: operator-lifecycle-manager-catalog
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 status:
@@ -30,6 +32,7 @@ metadata:
   name: operator-lifecycle-manager-packageserver
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 status:

--- a/microshift-manifests/0000_90_olm_00-service-monitor.yaml
+++ b/microshift-manifests/0000_90_olm_00-service-monitor.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 rules:
@@ -26,6 +27,7 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 roleRef:
@@ -46,6 +48,7 @@ metadata:
     app: olm-operator
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 spec:
@@ -79,6 +82,7 @@ metadata:
     app: catalog-operator
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 spec:

--- a/microshift-manifests/0000_90_olm_01-prometheus-rule.yaml
+++ b/microshift-manifests/0000_90_olm_01-prometheus-rule.yaml
@@ -8,6 +8,7 @@ metadata:
     role: alert-rules
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 spec:

--- a/scripts/generate_crds_manifests.sh
+++ b/scripts/generate_crds_manifests.sh
@@ -73,10 +73,12 @@ add_ibm_managed_cloud_annotations() {
    for f in "${manifests_dir}"/*.yaml; do
       if [[ ! "$(basename "${f}")" =~ .*\.deployment\..* ]]; then
          ${YQ} w -d'*' --inplace --style=double "$f" 'metadata.annotations['include.release.openshift.io/ibm-cloud-managed']' true
+         ${YQ} w -d'*' --inplace --style=double "$f" 'metadata.annotations['include.release.openshift.io/hypershift']' true
       else
          g="${f/%.yaml/.ibm-cloud-managed.yaml}"
          cp "${f}" "${g}"
          ${YQ} w -d'*' --inplace --style=double "$g" 'metadata.annotations['include.release.openshift.io/ibm-cloud-managed']' true
+         ${YQ} w -d'*' --inplace --style=double "$g" 'metadata.annotations['include.release.openshift.io/hypershift']' true
          ${YQ} w -d'*' --inplace --style=double "$g" 'metadata.annotations['capability.openshift.io/name']' OperatorLifecycleManager
          ${YQ} d -d'*' --inplace "$g" 'spec.template.spec.nodeSelector."node-role.kubernetes.io/master"'
       fi
@@ -285,6 +287,7 @@ kind: ConfigMap
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
   name: collect-profiles-config
@@ -300,6 +303,7 @@ kind: Role
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: collect-profiles
   namespace: openshift-operator-lifecycle-manager
@@ -316,6 +320,7 @@ kind: RoleBinding
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: collect-profiles
   namespace: openshift-operator-lifecycle-manager
@@ -333,6 +338,7 @@ kind: ServiceAccount
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: collect-profiles
   namespace: openshift-operator-lifecycle-manager
@@ -344,6 +350,7 @@ kind: Secret
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
     openshift.io/owning-component: "Operator Framework / operator-lifecycle-manager"
@@ -361,6 +368,7 @@ kind: CronJob
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: collect-profiles
   namespace: openshift-operator-lifecycle-manager


### PR DESCRIPTION
Since HyperShift / Hosted Control Plane have adopted include.release.openshift.io/ibm-cloud-managed, to tailor the resources of clusters running in the ROKS IBM environment, the include.release.openshift.io/hypershift addition will allow Hypershift to express different profile choices than ROKS

