### PR TITLE
OCPBUGS-29553: Apply hypershift cluster-profile for ibm-cloud-managed

### DIFF
--- a/pkg/manifests/csv.yaml
+++ b/pkg/manifests/csv.yaml
@@ -10,6 +10,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
 spec:
   displayName: Package Server
   description: Represents an Operator package that is available from a given CatalogSource which will resolve to a ClusterServiceVersion.

--- a/scripts/packageserver-deployment.patch.yaml
+++ b/scripts/packageserver-deployment.patch.yaml
@@ -21,6 +21,7 @@
   value:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/hypershift: "true"
 - command: update
   path: spec.install.spec.deployments[0].spec.template.spec.affinity
   value:


### PR DESCRIPTION
Follows https://github.com/openshift/operator-framework-olm/pull/697