### PR TITLE
OCPBUGS-28230: enforce termination message policy on all platform pods

### DIFF
--- a/manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
+++ b/manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
@@ -52,7 +52,7 @@ spec:
               memory: 20Mi
               cpu: 10m
           terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
+          terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - mountPath: /etc/tls/private
               name: package-server-manager-serving-cert

--- a/manifests/0000_50_olm_06-psm-operator.deployment.yaml
+++ b/manifests/0000_50_olm_06-psm-operator.deployment.yaml
@@ -51,7 +51,7 @@ spec:
               memory: 20Mi
               cpu: 10m
           terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
+          terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - mountPath: /etc/tls/private
               name: package-server-manager-serving-cert

--- a/manifests/0000_50_olm_07-collect-profiles.cronjob.yaml
+++ b/manifests/0000_50_olm_07-collect-profiles.cronjob.yaml
@@ -52,6 +52,7 @@ spec:
                 requests:
                   cpu: 10m
                   memory: 80Mi
+              terminationMessagePolicy: FallbackToLogsOnError
           volumes:
             - name: config-volume
               configMap:

--- a/microshift-manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
+++ b/microshift-manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
@@ -52,7 +52,7 @@ spec:
               memory: 20Mi
               cpu: 10m
           terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
+          terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - mountPath: /etc/tls/private
               name: package-server-manager-serving-cert

--- a/microshift-manifests/0000_50_olm_06-psm-operator.deployment.yaml
+++ b/microshift-manifests/0000_50_olm_06-psm-operator.deployment.yaml
@@ -51,7 +51,7 @@ spec:
               memory: 20Mi
               cpu: 10m
           terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
+          terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - mountPath: /etc/tls/private
               name: package-server-manager-serving-cert

--- a/microshift-manifests/0000_50_olm_07-collect-profiles.cronjob.yaml
+++ b/microshift-manifests/0000_50_olm_07-collect-profiles.cronjob.yaml
@@ -52,6 +52,7 @@ spec:
                 requests:
                   cpu: 10m
                   memory: 80Mi
+              terminationMessagePolicy: FallbackToLogsOnError
           volumes:
             - name: config-volume
               configMap:

--- a/scripts/generate_crds_manifests.sh
+++ b/scripts/generate_crds_manifests.sh
@@ -168,7 +168,7 @@ spec:
               memory: 20Mi
               cpu: 10m
           terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
+          terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
           - mountPath: /etc/tls/private
             name: package-server-manager-serving-cert
@@ -416,6 +416,7 @@ spec:
               requests:
                 cpu: 10m
                 memory: 80Mi
+            terminationMessagePolicy: FallbackToLogsOnError
           volumes:
           - name: config-volume
             configMap:


### PR DESCRIPTION
This adds debugging information to the API when the containers crash.   First the terminationMessagePath is checked and if empty, the last few lines of the container log is added.