### PR TITLE
TEST! Fix generate CRD script by using copy

### DIFF
--- a/scripts/generate_crds_manifests.sh
+++ b/scripts/generate_crds_manifests.sh
@@ -35,7 +35,7 @@ fi
 
 cp -R "${ROOT_DIR}/staging/operator-lifecycle-manager/deploy/chart/" "${chartdir}"
 cp "${ROOT_DIR}"/values*.yaml "${tmpdir}"
-ln -snf $(realpath --relative-to ${tmpdir} ${ROOT_DIR}/staging/api/pkg/operators/) ${crdsrcdir}
+cp -R "${ROOT_DIR}/staging/api/pkg/operators/" ${crdsrcdir}
 rm -rf ./manifests/* ${crddir}/*
 
 trap "rm -rf ${tmpdir}" EXIT


### PR DESCRIPTION
Using a symlink to point inside the staging directories seems to confuse newer versions of sigs.k8s.io/controller-tools.

Specifically, the set up of a temporary directory for controller-gen uses a symlink into staging/api, which confuses _something_ in golang to use ${ROOT}/staging/api/go.mod rather than ${ROOT}/go.mod, causing it to return errors that indicate go.mod inconsistencies with vendor/modules.txt. This would normally be fixable via the `go mod` commands, but looking at the wrong go.mod is not a normal situation.