### PR TITLE
[release-4.15] OCPBUGS-35229: Unblock CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ e2e/operator-registry: ## Run e2e registry tests
 	$(MAKE) e2e WHAT=operator-registry
 
 e2e/olm: ## Run e2e olm tests
-	$(MAKE) e2e WHAT=operator-lifecycle-manager E2E_CATALOG_NS=openshift-marketplace E2E_INSTALL_NS=openshift-operator-lifecycle-manager E2E_TEST_NS=openshift-operators E2E_TIMEOUT=120m KUBECTL=oc
+	$(MAKE) e2e WHAT=operator-lifecycle-manager E2E_FLAKE_ATTEMPTS=0 E2E_CATALOG_NS=openshift-marketplace E2E_INSTALL_NS=openshift-operator-lifecycle-manager E2E_TEST_NS=openshift-operators E2E_TIMEOUT=120m KUBECTL=oc E2E_OPTS="-communityOperators=quay.io/olmtest/test-catalog:v1.39.0"
 
 .PHONY: vendor
 vendor:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/operator-framework-olm
 
-go 1.19
+go 1.20
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/staging/operator-lifecycle-manager/.github/workflows/e2e-tests.yml
+++ b/staging/operator-lifecycle-manager/.github/workflows/e2e-tests.yml
@@ -20,9 +20,63 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: "go.mod"
-      - run: mkdir -p artifacts
-      - run: make e2e-local E2E_TEST_CHUNK=${{ matrix.parallel-id }} E2E_TEST_NUM_CHUNKS=${{ strategy.job-total }} E2E_NODES=2 ARTIFACT_DIR=./artifacts/ SKIP='\[FLAKE\]'
-      - name: Archive Test Artifacts # test results, failed or not, are always uploaded.
+
+      # load the olm image
+      - name: Load OLM Docker image
+        uses: actions/download-artifact@v4
+        with:
+          name: olm-image.tar
+          path: .
+      - run: docker load < olm-image.tar
+
+      # set e2e environment variables
+      # Set ginkgo output and parallelism
+      - run: echo "GINKGO_OPTS=-output-dir ${ARTIFACT_DIR} -junit-report junit_e2e.xml -nodes ${E2E_NODES}" >> $GITHUB_ENV
+
+      # Setting -kubeconfig-root tells the e2e test suite to look for kubeconfigs
+      # in <kubeconfig-root>/kubeconfig-<node-number>
+      # This is used to run tests in parallel on multiple clusters as the current e2e
+      # test suite does not support running tests in parallel on a single cluster
+      - run: echo "E2E_OPTS=-kubeconfig-root=${E2E_KUBECONFIG_ROOT}" >> $GITHUB_ENV
+
+      # run e2e tests
+      # create artifacts directory
+      - run: mkdir -p ${ARTIFACT_DIR}
+
+      # deploy test clusters
+      - name: Deploy test cluster(s)
+        # create kubeconfig root and store the kubeconfig for each cluster within it as you create the clusters
+        # Add kind and helm options to specify kubeconfig location
+        # Deploy the new cluster and helm install olm for testing
+        run: |
+          mkdir -p ${E2E_KUBECONFIG_ROOT}
+          for i in $(seq 1 ${E2E_NODES}); do
+            KIND_CLUSTER_NAME="kind-olmv0-${i}" \
+            KIND_CREATE_OPTS="--kubeconfig=${E2E_KUBECONFIG_ROOT}/kubeconfig-${i}" \
+            HELM_INSTALL_OPTS="--kubeconfig ${E2E_KUBECONFIG_ROOT}/kubeconfig-${i}" \
+            make kind-create deploy;
+          done
+
+      # run non-flakes if matrix-id is not 'flakes'
+      - name: Run e2e tests
+        if: ${{ matrix.parallel-id != 'flakes' }}
+        # calculate the number of chunks as the number of parallel jobs minus 1 (flakes job)
+        # use the split tool to split the test suite into chunks and run the chunk corresponding to the matrix-id
+        # focus on those tests and skip tests marked as FLAKE
+        run: |
+          E2E_TEST_NUM_CHUNKS=$(( ${{ strategy.job-total }} - 1 )) \
+          GINKGO_OPTS="${GINKGO_OPTS} -focus '$(go run ./test/e2e/split/... -chunks $E2E_TEST_NUM_CHUNKS -print-chunk $E2E_TEST_CHUNK ./test/e2e)' -skip '\[FLAKE\]'" \
+          make e2e;
+
+      # run e2e tests for flakes if matrix-id is 'flakes'
+      - name: Run flaky e2e tests
+        if: ${{ matrix.parallel-id == 'flakes' }}
+        # focus on tests marked as FLAKE
+        run: |
+          GINKGO_OPTS="${GINKGO_OPTS} -focus '\[FLAKE\]'" make e2e
+
+      # archive test results
+      - name: Archive Test Artifacts
         if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:

--- a/staging/operator-lifecycle-manager/Makefile
+++ b/staging/operator-lifecycle-manager/Makefile
@@ -34,6 +34,14 @@ ARCH := arm64
 else
 ARCH := 386
 endif
+
+# Take operator registry tag from operator registry version in go.mod
+export OPERATOR_REGISTRY_TAG ?= $(shell go list -m github.com/operator-framework/operator-registry | cut -d" " -f2)
+
+# Pin operator registry images to the OPERATOR_REGISTRY_TAG
+export OPERATOR_REGISTRY_IMAGE ?= quay.io/operator-framework/opm:$(OPERATOR_REGISTRY_TAG)
+export CONFIGMAP_SERVER_IMAGE ?= quay.io/operator-framework/configmap-operator-registry:$(OPERATOR_REGISTRY_TAG)
+
 # Phony prerequisite for targets that rely on the go build cache to determine staleness.
 .PHONY: build test clean vendor \
 	coverage coverage-html e2e \
@@ -123,29 +131,17 @@ deploy-local:
 e2e.namespace:
 	@printf "e2e-tests-$(shell date +%s)-$$RANDOM" > e2e.namespace
 
-# useful if running e2e directly with `go test -tags=bare`
-setup-bare: clean e2e.namespace
-	. ./scripts/build_bare.sh
-	. ./scripts/package_release.sh 1.0.0 test/e2e/resources test/e2e/e2e-bare-values.yaml
-	. ./scripts/install_bare.sh $(shell cat ./e2e.namespace) test/e2e/resources
-
-E2E_NODES ?= 1
-E2E_FLAKE_ATTEMPTS ?= 1
+.PHONY: e2e
 E2E_TIMEOUT ?= 90m
-# Optionally run an individual chunk of e2e test specs.
-# Do not use this from the CLI; this is intended to be used by CI only.
-E2E_TEST_CHUNK ?= all
-E2E_TEST_NUM_CHUNKS ?= 4
-ifneq (all,$(E2E_TEST_CHUNK))
-TEST := $(shell go run ./test/e2e/split/... -chunks $(E2E_TEST_NUM_CHUNKS) -print-chunk $(E2E_TEST_CHUNK) ./test/e2e)
-endif
-E2E_OPTS ?= $(if $(E2E_SEED),-seed '$(E2E_SEED)') $(if $(SKIP), -skip '$(SKIP)') $(if $(TEST),-focus '$(TEST)') $(if $(ARTIFACT_DIR), -output-dir $(ARTIFACT_DIR) -junit-report junit_e2e.xml) -flake-attempts $(E2E_FLAKE_ATTEMPTS) -nodes $(E2E_NODES) -timeout $(E2E_TIMEOUT) -v -randomize-suites -race -trace -progress
+E2E_TEST_NS ?= operators
 E2E_INSTALL_NS ?= operator-lifecycle-manager
 E2E_CATALOG_NS ?= $(E2E_INSTALL_NS)
-E2E_TEST_NS ?= operators
-
+GINKGO_OPTS += -v -randomize-suites -race -trace --show-node-events
 e2e:
-	$(GINKGO) $(E2E_OPTS) $(or $(run), ./test/e2e) $< -- -namespace=$(E2E_TEST_NS) -olmNamespace=$(E2E_INSTALL_NS) -catalogNamespace=$(E2E_CATALOG_NS) -dummyImage=bitnami/nginx:latest $(or $(extra_args), -kubeconfig=${KUBECONFIG})
+	$(GINKGO) -timeout $(E2E_TIMEOUT) $(GINKGO_OPTS) ./test/e2e -- -namespace=$(E2E_TEST_NS) -olmNamespace=$(E2E_INSTALL_NS) -catalogNamespace=$(E2E_CATALOG_NS) $(E2E_OPTS)
+
+.PHONY: e2e-local
+e2e-local: e2e-build kind-create deploy e2e
 
 # See workflows/e2e-tests.yml See test/e2e/README.md for details.
 .PHONY: e2e-local
@@ -161,15 +157,28 @@ e2e-local: e2e
 test/e2e/assets/chart/zz_chart.go: $(shell find deploy/chart -type f)
 	$(BINDATA) -o $@ -pkg chart -prefix deploy/chart/ $^
 
-# execute kind and helm end to end tests
-bin/e2e-local.test: FORCE test/e2e/assets/chart/zz_chart.go
-	$(GO) test -c -tags kind,helm -o $@ ./test/e2e
+.PHONY: deploy
+OLM_IMAGE := quay.io/operator-framework/olm:local
+deploy:
+	$(KIND) load docker-image $(OLM_IMAGE) --name $(KIND_CLUSTER_NAME); \
+	$(HELM) upgrade --install olm deploy/chart \
+		--set debug=true \
+		--set olm.image.ref=$(OLM_IMAGE) \
+		--set olm.image.pullPolicy=IfNotPresent \
+		--set catalog.image.ref=$(OLM_IMAGE) \
+		--set catalog.image.pullPolicy=IfNotPresent \
+		--set catalog.commandArgs=--configmapServerImage=$(CONFIGMAP_SERVER_IMAGE) \
+		--set catalog.opmImageArgs=--opmImage=$(OPERATOR_REGISTRY_IMAGE) \
+		--set package.image.ref=$(OLM_IMAGE) \
+		--set package.image.pullPolicy=IfNotPresent \
+		$(HELM_INSTALL_OPTS) \
+		--wait;
 
-# set go env and other vars, ensure that the dockerfile exists, and then build wait, cpb, and other command binaries and finally the kind image archive
-test/e2e-local.image.tar: export GOOS=linux
-test/e2e-local.image.tar: export GOARCH=386
-test/e2e-local.image.tar: build_cmd=build
-test/e2e-local.image.tar: e2e.Dockerfile bin/wait bin/cpb $(CMDS)
+.PHONY: e2e-build
+e2e-build: BUILD_TAGS="json1 e2e experimental_metrics"
+e2e-build: export GOOS=linux
+e2e-build: build_cmd=build
+e2e-build: e2e.Dockerfile bin/wait bin/cpb $(CMDS)
 	docker build -t quay.io/operator-framework/olm:local -f $< bin
 	docker save -o $@ quay.io/operator-framework/olm:local
 
@@ -230,15 +239,21 @@ verify-manifests: manifests
 
 verify: verify-codegen verify-mockgen verify-manifests
 
+.PHONY: pull-opm
+pull-opm:
+	docker pull $(OPERATOR_REGISTRY_IMAGE)
+
 # before running release, bump the version in OLM_VERSION and push to master,
 # then tag those builds in quay with the version in OLM_VERSION
 release: ver=v$(shell cat OLM_VERSION)
-release: manifests
+# pull the opm image to get the digest
+release: pull-opm manifests
 	@echo "Generating the $(ver) release"
 	docker pull $(IMAGE_REPO):$(ver)
 	$(MAKE) target=upstream ver=$(ver) quickstart=true package
 
 package: olmref=$(shell docker inspect --format='{{index .RepoDigests 0}}' $(IMAGE_REPO):$(ver))
+package: opmref=$(shell docker inspect --format='{{index .RepoDigests 0}}' $(OPERATOR_REGISTRY_IMAGE))
 package:
 ifndef target
 	$(error target is undefined)
@@ -246,9 +261,12 @@ endif
 ifndef ver
 	$(error ver is undefined)
 endif
+	@echo "Getting operator registry image"
+	docker pull $(OPERATOR_REGISTRY_IMAGE)
 	$(YQ_INTERNAL) w -i deploy/$(target)/values.yaml olm.image.ref $(olmref)
 	$(YQ_INTERNAL) w -i deploy/$(target)/values.yaml catalog.image.ref $(olmref)
 	$(YQ_INTERNAL) w -i deploy/$(target)/values.yaml package.image.ref $(olmref)
+	$(YQ_INTERNAL) w -i deploy/$(target)/values.yaml -- catalog.opmImageArgs "--opmImage=$(opmref)"
 	./scripts/package_release.sh $(ver) deploy/$(target)/manifests/$(ver) deploy/$(target)/values.yaml
 	ln -sfFn ./$(ver) deploy/$(target)/manifests/latest
 ifeq ($(quickstart), true)

--- a/staging/operator-lifecycle-manager/Makefile
+++ b/staging/operator-lifecycle-manager/Makefile
@@ -136,7 +136,8 @@ E2E_TIMEOUT ?= 90m
 E2E_TEST_NS ?= operators
 E2E_INSTALL_NS ?= operator-lifecycle-manager
 E2E_CATALOG_NS ?= $(E2E_INSTALL_NS)
-GINKGO_OPTS += -v -randomize-suites -race -trace --show-node-events
+E2E_FLAKE_ATTEMPTS ?= 0
+GINKGO_OPTS += -v -randomize-suites -race -trace --show-node-events --flake-attempts=$(E2E_FLAKE_ATTEMPTS) $(if $(E2E_SEED),-seed '$(E2E_SEED)') $(if $(TEST),-focus '$(TEST)',) $(if $(SKIP), -skip '$(SKIP)')
 e2e:
 	$(GINKGO) -timeout $(E2E_TIMEOUT) $(GINKGO_OPTS) ./test/e2e -- -namespace=$(E2E_TEST_NS) -olmNamespace=$(E2E_INSTALL_NS) -catalogNamespace=$(E2E_CATALOG_NS) $(E2E_OPTS)
 
@@ -188,10 +189,6 @@ e2e-bare: setup-bare
 e2e-local-docker:
 	. ./scripts/build_local.sh
 	. ./scripts/run_e2e_docker.sh $(TEST)
-
-vendor:
-	go mod tidy
-	go mod vendor
 
 container:
 	docker build -t $(IMAGE_REPO):$(IMAGE_TAG) .

--- a/staging/operator-lifecycle-manager/deploy/chart/values.yaml
+++ b/staging/operator-lifecycle-manager/deploy/chart/values.yaml
@@ -40,6 +40,7 @@ catalog:
   setWorkloadUserID: true
   replicaCount: 1
   commandArgs: --configmapServerImage=quay.io/operator-framework/configmap-operator-registry:latest
+  opmImageArgs: --opmImage=quay.io/operator-framework/opm:latest
   image:
     ref: quay.io/operator-framework/olm:master
     pullPolicy: Always

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operator_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operator_test.go
@@ -4030,7 +4030,7 @@ func TestUpdates(t *testing.T) {
 					csvsToSync = syncCSVs(csvsToSync, deletedCSVs(e.shouldBe))
 					current = csvsToSync[e.whenIn.name]
 					fmt.Printf("waiting for (when) %s to be %s\n", e.whenIn.name, e.whenIn.phase)
-					time.Sleep(1 * time.Millisecond)
+					time.Sleep(1 * time.Second)
 				}
 
 				// sync the other csvs until they're in the expected status

--- a/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/resolver_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/resolver_test.go
@@ -53,17 +53,17 @@ func TestSolveOperators(t *testing.T) {
 	const namespace = "test-namespace"
 	catalog := cache.SourceKey{Name: "test-catalog", Namespace: namespace}
 
-	csv := existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil)
-	sub := existingSub(namespace, "packageA.v1", "packageA", "alpha", catalog)
-	newSub := newSub(namespace, "packageB", "alpha", catalog)
+	csv := existingOperator(namespace, "test-package.v1", "test-package", "alpha", "", Provides, nil, nil, nil)
+	sub := existingSub(namespace, "test-package.v1", "test-package", "alpha", catalog)
+	newSub := newSub(namespace, "another-package", "alpha", catalog)
 	subs := []*v1alpha1.Subscription{sub, newSub}
 
 	resolver := Resolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("packageA.v1", "0.0.1", "", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
-					genEntry("packageB.v1", "1.0.1", "", "packageB", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
+					genEntry("test-package.v1", "0.0.1", "", "test-package", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
+					genEntry("another-package.v1", "1.0.1", "", "another-package", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
 				},
 			},
 			cache.NewVirtualSourceKey(namespace): csvSnapshotOrPanic(namespace, subs, csv),
@@ -75,7 +75,7 @@ func TestSolveOperators(t *testing.T) {
 	assert.NoError(t, err)
 
 	expected := []*cache.Entry{
-		genEntry("packageB.v1", "1.0.1", "", "packageB", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
+		genEntry("another-package.v1", "1.0.1", "", "another-package", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
 	}
 	require.ElementsMatch(t, expected, operators)
 }
@@ -91,14 +91,14 @@ func TestSolveOperators_WithSystemConstraints(t *testing.T) {
 	const namespace = "test-namespace"
 	catalog := cache.SourceKey{Name: "test-catalog", Namespace: namespace}
 
-	packageASub := newSub(namespace, "packageA", "alpha", catalog)
+	packageASub := newSub(namespace, "test-package", "alpha", catalog)
 	packageDSub := existingSub(namespace, "packageD.v1", "packageD", "alpha", catalog)
 
 	APISet := cache.APISet{opregistry.APIKey{Group: "g", Version: "v", Kind: "k", Plural: "ks"}: struct{}{}}
 
-	// packageA requires an API that can be provided by B or C
-	packageA := genEntry("packageA.v1", "0.0.1", "", "packageA", "alpha", catalog.Name, catalog.Namespace, APISet, nil, nil, "", false)
-	packageB := genEntry("packageB.v1", "1.0.0", "", "packageB", "alpha", catalog.Name, catalog.Namespace, nil, APISet, nil, "", false)
+	// test-package requires an API that can be provided by B or C
+	testPackage := genEntry("test-package.v1", "0.0.1", "", "test-package", "alpha", catalog.Name, catalog.Namespace, APISet, nil, nil, "", false)
+	anotherPackage := genEntry("another-package.v1", "1.0.0", "", "another-package", "alpha", catalog.Name, catalog.Namespace, nil, APISet, nil, "", false)
 	packageC := genEntry("packageC.v1", "1.0.0", "", "packageC", "alpha", catalog.Name, catalog.Namespace, nil, APISet, nil, "", false)
 
 	// Existing operators
@@ -133,39 +133,39 @@ func TestSolveOperators_WithSystemConstraints(t *testing.T) {
 	}{
 		{
 			title:                     "No runtime constraints",
-			snapshotEntries:           []*cache.Entry{packageA, packageB, packageC, packageD},
+			snapshotEntries:           []*cache.Entry{testPackage, anotherPackage, packageC, packageD},
 			systemConstraintsProvider: nil,
-			expectedOperators:         []*cache.Entry{packageA, packageB},
+			expectedOperators:         []*cache.Entry{testPackage, anotherPackage},
 			csvs:                      nil,
 			subs:                      []*v1alpha1.Subscription{packageASub},
 			err:                       "",
 		},
 		{
 			title:                     "Runtime constraints only accept packages A and C",
-			snapshotEntries:           []*cache.Entry{packageA, packageB, packageC, packageD},
-			systemConstraintsProvider: whiteListConstraintProvider(packageA, packageC),
-			expectedOperators:         []*cache.Entry{packageA, packageC},
+			snapshotEntries:           []*cache.Entry{testPackage, anotherPackage, packageC, packageD},
+			systemConstraintsProvider: whiteListConstraintProvider(testPackage, packageC),
+			expectedOperators:         []*cache.Entry{testPackage, packageC},
 			csvs:                      nil,
 			subs:                      []*v1alpha1.Subscription{packageASub},
 			err:                       "",
 		},
 		{
 			title:                     "Existing packages are ignored",
-			snapshotEntries:           []*cache.Entry{packageA, packageB, packageC, packageD},
-			systemConstraintsProvider: whiteListConstraintProvider(packageA, packageC),
-			expectedOperators:         []*cache.Entry{packageA, packageC},
+			snapshotEntries:           []*cache.Entry{testPackage, anotherPackage, packageC, packageD},
+			systemConstraintsProvider: whiteListConstraintProvider(testPackage, packageC),
+			expectedOperators:         []*cache.Entry{testPackage, packageC},
 			csvs:                      []*v1alpha1.ClusterServiceVersion{existingPackageD},
 			subs:                      []*v1alpha1.Subscription{packageASub, packageDSub},
 			err:                       "",
 		},
 		{
 			title:                     "Runtime constraints don't allow A",
-			snapshotEntries:           []*cache.Entry{packageA, packageB, packageC, packageD},
-			systemConstraintsProvider: whiteListConstraintProvider(packageB, packageC, packageD),
+			snapshotEntries:           []*cache.Entry{testPackage, anotherPackage, packageC, packageD},
+			systemConstraintsProvider: whiteListConstraintProvider(anotherPackage, packageC, packageD),
 			expectedOperators:         nil,
 			csvs:                      nil,
 			subs:                      []*v1alpha1.Subscription{packageASub},
-			err:                       "packageA is not white listed",
+			err:                       "test-package is not white listed",
 		},
 	}
 
@@ -195,17 +195,17 @@ func TestDisjointChannelGraph(t *testing.T) {
 	const namespace = "test-namespace"
 	catalog := cache.SourceKey{Name: "test-catalog", Namespace: namespace}
 
-	newSub := newSub(namespace, "packageA", "alpha", catalog)
+	newSub := newSub(namespace, "test-package", "alpha", catalog)
 	subs := []*v1alpha1.Subscription{newSub}
 
 	resolver := Resolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("packageA.side1.v1", "0.0.1", "", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
-					genEntry("packageA.side1.v2", "0.0.2", "packageA.side1.v1", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
-					genEntry("packageA.side2.v1", "1.0.0", "", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
-					genEntry("packageA.side2.v2", "2.0.0", "packageA.side2.v1", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
+					genEntry("test-package.side1.v1", "0.0.1", "", "test-package", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
+					genEntry("test-package.side1.v2", "0.0.2", "test-package.side1.v1", "test-package", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
+					genEntry("test-package.side2.v1", "1.0.0", "", "test-package", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
+					genEntry("test-package.side2.v2", "2.0.0", "test-package.side2.v1", "test-package", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
 				},
 			},
 		}),
@@ -213,7 +213,7 @@ func TestDisjointChannelGraph(t *testing.T) {
 	}
 
 	_, err := resolver.Resolve([]string{namespace}, subs)
-	require.Error(t, err, "a unique replacement chain within a channel is required to determine the relative order between channel entries, but 2 replacement chains were found in channel \"alpha\" of package \"packageA\": packageA.side1.v2...packageA.side1.v1, packageA.side2.v2...packageA.side2.v1")
+	require.Error(t, err, "a unique replacement chain within a channel is required to determine the relative order between channel entries, but 2 replacement chains were found in channel \"alpha\" of package \"test-package\": test-package.side1.v2...test-package.side1.v1, test-package.side2.v2...test-package.side2.v1")
 }
 
 func TestSolveOperators_MultipleChannels(t *testing.T) {
@@ -223,18 +223,18 @@ func TestSolveOperators_MultipleChannels(t *testing.T) {
 	namespace := "olm"
 	catalog := cache.SourceKey{Name: "community", Namespace: namespace}
 
-	csv := existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil)
-	sub := existingSub(namespace, "packageA.v1", "packageA", "alpha", catalog)
-	newSub := newSub(namespace, "packageB", "alpha", catalog)
+	csv := existingOperator(namespace, "test-package.v1", "test-package", "alpha", "", Provides, nil, nil, nil)
+	sub := existingSub(namespace, "test-package.v1", "test-package", "alpha", catalog)
+	newSub := newSub(namespace, "another-package", "alpha", catalog)
 	subs := []*v1alpha1.Subscription{sub, newSub}
 
 	resolver := Resolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("packageA.v1", "0.0.1", "", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
-					genEntry("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
-					genEntry("packageB.v1", "1.0.0", "", "packageB", "beta", "community", "olm", nil, nil, nil, "", false),
+					genEntry("test-package.v1", "0.0.1", "", "test-package", "alpha", "community", "olm", nil, nil, nil, "", false),
+					genEntry("another-package.v1", "1.0.0", "", "another-package", "alpha", "community", "olm", nil, nil, nil, "", false),
+					genEntry("another-package.v1", "1.0.0", "", "another-package", "beta", "community", "olm", nil, nil, nil, "", false),
 				},
 			},
 			cache.NewVirtualSourceKey(namespace): csvSnapshotOrPanic(namespace, subs, csv),
@@ -245,7 +245,7 @@ func TestSolveOperators_MultipleChannels(t *testing.T) {
 	operators, err := resolver.Resolve([]string{"olm"}, subs)
 	assert.NoError(t, err)
 	expected := []*cache.Entry{
-		genEntry("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
+		genEntry("another-package.v1", "1.0.0", "", "another-package", "alpha", "community", "olm", nil, nil, nil, "", false),
 	}
 	assert.ElementsMatch(t, expected, operators)
 }
@@ -257,9 +257,9 @@ func TestSolveOperators_FindLatestVersion(t *testing.T) {
 	namespace := "olm"
 	catalog := cache.SourceKey{Name: "community", Namespace: namespace}
 
-	csv := existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil)
-	sub := existingSub(namespace, "packageA.v1", "packageA", "alpha", catalog)
-	newSub := newSub(namespace, "packageB", "alpha", catalog)
+	csv := existingOperator(namespace, "test-package.v1", "test-package", "alpha", "", Provides, nil, nil, nil)
+	sub := existingSub(namespace, "test-package.v1", "test-package", "alpha", catalog)
+	newSub := newSub(namespace, "another-package", "alpha", catalog)
 	subs := []*v1alpha1.Subscription{sub, newSub}
 
 	resolver := Resolver{
@@ -269,10 +269,10 @@ func TestSolveOperators_FindLatestVersion(t *testing.T) {
 				Name:      "community",
 			}: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("packageA.v1.0.1", "1.0.1", "packageA.v1", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
-					genEntry("packageB.v0.9.0", "0.9.0", "", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
-					genEntry("packageB.v1.0.0", "1.0.0", "packageB.v0.9.0", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
-					genEntry("packageB.v1.0.1", "1.0.1", "packageB.v1.0.0", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
+					genEntry("test-package.v1.0.1", "1.0.1", "test-package.v1", "test-package", "alpha", "community", "olm", nil, nil, nil, "", false),
+					genEntry("another-package.v0.9.0", "0.9.0", "", "another-package", "alpha", "community", "olm", nil, nil, nil, "", false),
+					genEntry("another-package.v1.0.0", "1.0.0", "another-package.v0.9.0", "another-package", "alpha", "community", "olm", nil, nil, nil, "", false),
+					genEntry("another-package.v1.0.1", "1.0.1", "another-package.v1.0.0", "another-package", "alpha", "community", "olm", nil, nil, nil, "", false),
 				},
 			},
 			cache.NewVirtualSourceKey(namespace): csvSnapshotOrPanic(namespace, subs, csv),
@@ -288,8 +288,8 @@ func TestSolveOperators_FindLatestVersion(t *testing.T) {
 	}
 
 	expected := []*cache.Entry{
-		genEntry("packageA.v1.0.1", "1.0.1", "packageA.v1", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
-		genEntry("packageB.v1.0.1", "1.0.1", "packageB.v1.0.0", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
+		genEntry("test-package.v1.0.1", "1.0.1", "test-package.v1", "test-package", "alpha", "community", "olm", nil, nil, nil, "", false),
+		genEntry("another-package.v1.0.1", "1.0.1", "another-package.v1.0.0", "another-package", "alpha", "community", "olm", nil, nil, nil, "", false),
 	}
 	assert.ElementsMatch(t, expected, operators)
 }
@@ -301,9 +301,9 @@ func TestSolveOperators_FindLatestVersionWithDependencies(t *testing.T) {
 	namespace := "olm"
 	catalog := cache.SourceKey{Name: "community", Namespace: namespace}
 
-	csv := existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil)
-	sub := existingSub(namespace, "packageA.v1", "packageA", "alpha", catalog)
-	newSub := newSub(namespace, "packageB", "alpha", catalog)
+	csv := existingOperator(namespace, "test-package.v1", "test-package", "alpha", "", Provides, nil, nil, nil)
+	sub := existingSub(namespace, "test-package.v1", "test-package", "alpha", catalog)
+	newSub := newSub(namespace, "another-package", "alpha", catalog)
 	subs := []*v1alpha1.Subscription{sub, newSub}
 
 	opToAddVersionDeps := []*api.Dependency{
@@ -321,10 +321,10 @@ func TestSolveOperators_FindLatestVersionWithDependencies(t *testing.T) {
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("packageA.v1.0.1", "1.0.1", "packageA.v1", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
-					genEntry("packageB.v0.9.0", "0.9.0", "", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
-					genEntry("packageB.v1.0.0", "1.0.0", "packageB.v0.9.0", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
-					genEntry("packageB.v1.0.1", "1.0.1", "packageB.v1.0.0", "packageB", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false),
+					genEntry("test-package.v1.0.1", "1.0.1", "test-package.v1", "test-package", "alpha", "community", "olm", nil, nil, nil, "", false),
+					genEntry("another-package.v0.9.0", "0.9.0", "", "another-package", "alpha", "community", "olm", nil, nil, nil, "", false),
+					genEntry("another-package.v1.0.0", "1.0.0", "another-package.v0.9.0", "another-package", "alpha", "community", "olm", nil, nil, nil, "", false),
+					genEntry("another-package.v1.0.1", "1.0.1", "another-package.v1.0.0", "another-package", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false),
 					genEntry("packageC.v1.0.0", "1.0.0", "", "packageC", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genEntry("packageC.v1.0.1", "1.0.1", "packageC.v1.0.0", "packageC", "alpha", "community", "olm", nil, nil, nil, "", false),
 					genEntry("packageD.v1.0.0", "1.0.0", "", "packageD", "alpha", "community", "olm", nil, nil, nil, "", false),
@@ -342,8 +342,8 @@ func TestSolveOperators_FindLatestVersionWithDependencies(t *testing.T) {
 	assert.Equal(t, 4, len(operators))
 
 	expected := []*cache.Entry{
-		genEntry("packageA.v1.0.1", "1.0.1", "packageA.v1", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
-		genEntry("packageB.v1.0.1", "1.0.1", "packageB.v1.0.0", "packageB", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false),
+		genEntry("test-package.v1.0.1", "1.0.1", "test-package.v1", "test-package", "alpha", "community", "olm", nil, nil, nil, "", false),
+		genEntry("another-package.v1.0.1", "1.0.1", "another-package.v1.0.0", "another-package", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false),
 		genEntry("packageC.v1.0.1", "1.0.1", "packageC.v1.0.0", "packageC", "alpha", "community", "olm", nil, nil, nil, "", false),
 		genEntry("packageD.v1.0.1", "1.0.1", "packageD.v1.0.0", "packageD", "alpha", "community", "olm", nil, nil, nil, "", false),
 	}
@@ -357,9 +357,9 @@ func TestSolveOperators_FindLatestVersionWithNestedDependencies(t *testing.T) {
 	namespace := "olm"
 	catalog := cache.SourceKey{Name: "community", Namespace: namespace}
 
-	csv := existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil)
-	sub := existingSub(namespace, "packageA.v1", "packageA", "alpha", catalog)
-	newSub := newSub(namespace, "packageB", "alpha", catalog)
+	csv := existingOperator(namespace, "test-package.v1", "test-package", "alpha", "", Provides, nil, nil, nil)
+	sub := existingSub(namespace, "test-package.v1", "test-package", "alpha", catalog)
+	newSub := newSub(namespace, "another-package", "alpha", catalog)
 	subs := []*v1alpha1.Subscription{sub, newSub}
 
 	opToAddVersionDeps := []*api.Dependency{
@@ -383,10 +383,10 @@ func TestSolveOperators_FindLatestVersionWithNestedDependencies(t *testing.T) {
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("packageA.v1.0.1", "1.0.1", "packageA.v1", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
-					genEntry("packageB.v0.9.0", "0.9.0", "", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
-					genEntry("packageB.v1.0.0", "1.0.0", "packageB.v0.9.0", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
-					genEntry("packageB.v1.0.1", "1.0.1", "packageB.v1.0.0", "packageB", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false),
+					genEntry("test-package.v1.0.1", "1.0.1", "test-package.v1", "test-package", "alpha", "community", "olm", nil, nil, nil, "", false),
+					genEntry("another-package.v0.9.0", "0.9.0", "", "another-package", "alpha", "community", "olm", nil, nil, nil, "", false),
+					genEntry("another-package.v1.0.0", "1.0.0", "another-package.v0.9.0", "another-package", "alpha", "community", "olm", nil, nil, nil, "", false),
+					genEntry("another-package.v1.0.1", "1.0.1", "another-package.v1.0.0", "another-package", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false),
 					genEntry("packageC.v1.0.0", "1.0.0", "", "packageC", "alpha", "community", "olm", nil, nil, nestedVersionDeps, "", false),
 					genEntry("packageC.v1.0.1", "1.0.1", "packageC.v1.0.0", "packageC", "alpha", "community", "olm", nil, nil, nestedVersionDeps, "", false),
 					genEntry("packageD.v1.0.1", "1.0.1", "", "packageD", "alpha", "community", "olm", nil, nil, nil, "", false),
@@ -403,8 +403,8 @@ func TestSolveOperators_FindLatestVersionWithNestedDependencies(t *testing.T) {
 	assert.NoError(t, err)
 
 	expected := []*cache.Entry{
-		genEntry("packageA.v1.0.1", "1.0.1", "packageA.v1", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
-		genEntry("packageB.v1.0.1", "1.0.1", "packageB.v1.0.0", "packageB", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false),
+		genEntry("test-package.v1.0.1", "1.0.1", "test-package.v1", "test-package", "alpha", "community", "olm", nil, nil, nil, "", false),
+		genEntry("another-package.v1.0.1", "1.0.1", "another-package.v1.0.0", "another-package", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false),
 		genEntry("packageC.v1.0.1", "1.0.1", "packageC.v1.0.0", "packageC", "alpha", "community", "olm", nil, nil, nestedVersionDeps, "", false),
 		genEntry("packageD.v1.0.1", "1.0.1", "", "packageD", "alpha", "community", "olm", nil, nil, nil, "", false),
 		genEntry("packageE.v1.0.1", "1.0.1", "packageE.v1.0.0", "packageE", "alpha", "community", "olm", nil, nil, nil, "", false),
@@ -422,31 +422,31 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 	opToAddVersionDeps := []*api.Dependency{
 		{
 			Type:  "olm.package",
-			Value: `{"packageName":"packageB","version":"0.0.1"}`,
+			Value: `{"packageName":"another-package","version":"0.0.1"}`,
 		},
 	}
 
 	namespace := "olm"
 	customCatalog := cache.SourceKey{Name: "community", Namespace: namespace}
-	newSub := newSub(namespace, "packageA", "alpha", customCatalog)
+	newSub := newSub(namespace, "test-package", "alpha", customCatalog)
 	subs := []*v1alpha1.Subscription{newSub}
 
 	ssp := cache.StaticSourceProvider{
 		cache.SourceKey{Namespace: "olm", Name: "community"}: &cache.Snapshot{
 			Entries: []*cache.Entry{
-				genEntry("packageA.v1", "0.0.1", "", "packageA", "alpha", "community", namespace, nil,
+				genEntry("test-package.v1", "0.0.1", "", "test-package", "alpha", "community", namespace, nil,
 					nil, opToAddVersionDeps, "", false),
 			},
 		},
 		cache.SourceKey{Namespace: "olm", Name: "community-operator"}: &cache.Snapshot{
 			Entries: []*cache.Entry{
-				genEntry("packageB.v1", "0.0.1", "", "packageB", "alpha", "community-operator",
+				genEntry("another-package.v1", "0.0.1", "", "another-package", "alpha", "community-operator",
 					namespace, nil, nil, nil, "", false),
 			},
 		},
 		cache.SourceKey{Namespace: "olm", Name: "high-priority-operator"}: &cache.Snapshot{
 			Entries: []*cache.Entry{
-				genEntry("packageB.v1", "0.0.1", "", "packageB", "alpha", "high-priority-operator",
+				genEntry("another-package.v1", "0.0.1", "", "another-package", "alpha", "high-priority-operator",
 					namespace, nil, nil, nil, "", false),
 			},
 		},
@@ -459,9 +459,9 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 	operators, err := resolver.Resolve([]string{"olm"}, subs)
 	assert.NoError(t, err)
 	expected := []*cache.Entry{
-		genEntry("packageA.v1", "0.0.1", "", "packageA", "alpha", "community", "olm",
+		genEntry("test-package.v1", "0.0.1", "", "test-package", "alpha", "community", "olm",
 			nil, nil, opToAddVersionDeps, "", false),
-		genEntry("packageB.v1", "0.0.1", "", "packageB", "alpha", "high-priority-operator", "olm",
+		genEntry("another-package.v1", "0.0.1", "", "another-package", "alpha", "high-priority-operator", "olm",
 			nil, nil, nil, "", false),
 	}
 	assert.ElementsMatch(t, expected, operators)
@@ -472,7 +472,7 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 		Name:      "community-operator",
 	}] = &cache.Snapshot{
 		Entries: []*cache.Entry{
-			genEntry("packageB.v1", "0.0.1", "", "packageB", "alpha", "community-operator",
+			genEntry("another-package.v1", "0.0.1", "", "another-package", "alpha", "community-operator",
 				namespace, nil, nil, nil, "", false),
 		},
 	}
@@ -487,9 +487,9 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 	operators, err = resolver.Resolve([]string{"olm"}, subs)
 	assert.NoError(t, err)
 	expected = []*cache.Entry{
-		genEntry("packageA.v1", "0.0.1", "", "packageA", "alpha", "community", "olm",
+		genEntry("test-package.v1", "0.0.1", "", "test-package", "alpha", "community", "olm",
 			nil, nil, opToAddVersionDeps, "", false),
-		genEntry("packageB.v1", "0.0.1", "", "packageB", "alpha", "community-operator", "olm",
+		genEntry("another-package.v1", "0.0.1", "", "another-package", "alpha", "community-operator", "olm",
 			nil, nil, nil, "", false),
 	}
 	assert.ElementsMatch(t, expected, operators)
@@ -500,9 +500,9 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 		Name:      "community",
 	}] = &cache.Snapshot{
 		Entries: []*cache.Entry{
-			genEntry("packageA.v1", "0.0.1", "", "packageA", "alpha", "community", namespace, nil,
+			genEntry("test-package.v1", "0.0.1", "", "test-package", "alpha", "community", namespace, nil,
 				nil, opToAddVersionDeps, "", false),
-			genEntry("packageB.v1", "0.0.1", "", "packageB", "alpha", "community",
+			genEntry("another-package.v1", "0.0.1", "", "another-package", "alpha", "community",
 				namespace, nil, nil, nil, "", false),
 		},
 	}
@@ -514,9 +514,9 @@ func TestSolveOperators_CatsrcPrioritySorting(t *testing.T) {
 	operators, err = resolver.Resolve([]string{"olm"}, subs)
 	assert.NoError(t, err)
 	expected = []*cache.Entry{
-		genEntry("packageA.v1", "0.0.1", "", "packageA", "alpha", "community", "olm",
+		genEntry("test-package.v1", "0.0.1", "", "test-package", "alpha", "community", "olm",
 			nil, nil, opToAddVersionDeps, "", false),
-		genEntry("packageB.v1", "0.0.1", "", "packageB", "alpha", "community", "olm",
+		genEntry("another-package.v1", "0.0.1", "", "another-package", "alpha", "community", "olm",
 			nil, nil, nil, "", false),
 	}
 	assert.ElementsMatch(t, expected, operators)
@@ -529,9 +529,9 @@ func TestSolveOperators_WithPackageDependencies(t *testing.T) {
 	namespace := "olm"
 	catalog := cache.SourceKey{Name: "community", Namespace: namespace}
 
-	csv := existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil)
-	sub := existingSub(namespace, "packageA.v1", "packageA", "alpha", catalog)
-	newSub := newSub(namespace, "packageB", "alpha", catalog)
+	csv := existingOperator(namespace, "test-package.v1", "test-package", "alpha", "", Provides, nil, nil, nil)
+	sub := existingSub(namespace, "test-package.v1", "test-package", "alpha", catalog)
+	newSub := newSub(namespace, "another-package", "alpha", catalog)
 	subs := []*v1alpha1.Subscription{sub, newSub}
 
 	opToAddVersionDeps := []*api.Dependency{
@@ -545,8 +545,8 @@ func TestSolveOperators_WithPackageDependencies(t *testing.T) {
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("packageA.v1.0.1", "1.0.1", "packageA.v1", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
-					genEntry("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false),
+					genEntry("test-package.v1.0.1", "1.0.1", "test-package.v1", "test-package", "alpha", "community", "olm", nil, nil, nil, "", false),
+					genEntry("another-package.v1", "1.0.0", "", "another-package", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false),
 					genEntry("packageC.v1", "0.1.0", "", "packageC", "alpha", "community", "olm", nil, nil, nil, "", false),
 				},
 			},
@@ -560,8 +560,8 @@ func TestSolveOperators_WithPackageDependencies(t *testing.T) {
 	assert.Equal(t, 3, len(operators))
 
 	expected := []*cache.Entry{
-		genEntry("packageA.v1.0.1", "1.0.1", "packageA.v1", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
-		genEntry("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false),
+		genEntry("test-package.v1.0.1", "1.0.1", "test-package.v1", "test-package", "alpha", "community", "olm", nil, nil, nil, "", false),
+		genEntry("another-package.v1", "1.0.0", "", "another-package", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false),
 		genEntry("packageC.v1", "0.1.0", "", "packageC", "alpha", "community", "olm", nil, nil, nil, "", false),
 	}
 	assert.ElementsMatch(t, expected, operators)
@@ -575,8 +575,8 @@ func TestSolveOperators_WithGVKDependencies(t *testing.T) {
 	community := cache.SourceKey{Name: "community", Namespace: namespace}
 
 	subs := []*v1alpha1.Subscription{
-		existingSub(namespace, "packageA.v1", "packageA", "alpha", community),
-		newSub(namespace, "packageB", "alpha", community),
+		existingSub(namespace, "test-package.v1", "test-package", "alpha", community),
+		newSub(namespace, "another-package", "alpha", community),
 	}
 
 	deps := []*api.Dependency{
@@ -590,15 +590,15 @@ func TestSolveOperators_WithGVKDependencies(t *testing.T) {
 		cache: cache.New(cache.StaticSourceProvider{
 			community: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("packageA.v1", "0.0.1", "", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
-					genEntry("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", Provides, nil, deps, "", false),
+					genEntry("test-package.v1", "0.0.1", "", "test-package", "alpha", "community", "olm", nil, nil, nil, "", false),
+					genEntry("another-package.v1", "1.0.0", "", "another-package", "alpha", "community", "olm", Provides, nil, deps, "", false),
 					genEntry("packageC.v1", "0.1.0", "", "packageC", "alpha", "community", "olm", nil, Provides, nil, "", false),
 				},
 			},
 			cache.NewVirtualSourceKey(namespace): csvSnapshotOrPanic(
 				namespace,
 				subs,
-				existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", nil, nil, nil, nil),
+				existingOperator(namespace, "test-package.v1", "test-package", "alpha", "", nil, nil, nil, nil),
 			),
 		}),
 		log: logrus.New(),
@@ -608,7 +608,7 @@ func TestSolveOperators_WithGVKDependencies(t *testing.T) {
 	assert.NoError(t, err)
 
 	expected := []*cache.Entry{
-		genEntry("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", Provides, nil, deps, "", false),
+		genEntry("another-package.v1", "1.0.0", "", "another-package", "alpha", "community", "olm", Provides, nil, deps, "", false),
 		genEntry("packageC.v1", "0.1.0", "", "packageC", "alpha", "community", "olm", nil, Provides, nil, "", false),
 	}
 	assert.ElementsMatch(t, expected, operators)
@@ -618,7 +618,7 @@ func TestSolveOperators_WithLabelDependencies(t *testing.T) {
 	namespace := "olm"
 	catalog := cache.SourceKey{Name: "community", Namespace: namespace}
 
-	newSub := newSub(namespace, "packageA", "alpha", catalog)
+	newSub := newSub(namespace, "test-package", "alpha", catalog)
 	subs := []*v1alpha1.Subscription{newSub}
 
 	deps := []*api.Dependency{
@@ -635,14 +635,14 @@ func TestSolveOperators_WithLabelDependencies(t *testing.T) {
 		},
 	}
 
-	operatorBv1 := genEntry("packageB.v1", "1.0.0", "", "packageB", "beta", "community", "olm", nil, nil, nil, "", false)
+	operatorBv1 := genEntry("another-package.v1", "1.0.0", "", "another-package", "beta", "community", "olm", nil, nil, nil, "", false)
 	operatorBv1.Properties = append(operatorBv1.Properties, props...)
 
 	resolver := Resolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("packageA", "0.0.1", "", "packageA", "alpha", "community", "olm", nil, nil, deps, "", false),
+					genEntry("test-package", "0.0.1", "", "test-package", "alpha", "community", "olm", nil, nil, deps, "", false),
 					operatorBv1,
 				},
 			},
@@ -654,7 +654,7 @@ func TestSolveOperators_WithLabelDependencies(t *testing.T) {
 	assert.Equal(t, 2, len(operators))
 
 	expected := []*cache.Entry{
-		genEntry("packageA", "0.0.1", "", "packageA", "alpha", "community", "olm", nil, nil, deps, "", false),
+		genEntry("test-package", "0.0.1", "", "test-package", "alpha", "community", "olm", nil, nil, deps, "", false),
 		operatorBv1,
 	}
 	assert.ElementsMatch(t, expected, operators)
@@ -664,7 +664,7 @@ func TestSolveOperators_WithUnsatisfiableLabelDependencies(t *testing.T) {
 	namespace := "olm"
 	catalog := cache.SourceKey{Name: "community", Namespace: namespace}
 
-	newSub := newSub(namespace, "packageA", "alpha", catalog)
+	newSub := newSub(namespace, "test-package", "alpha", catalog)
 	subs := []*v1alpha1.Subscription{newSub}
 
 	deps := []*api.Dependency{
@@ -678,8 +678,8 @@ func TestSolveOperators_WithUnsatisfiableLabelDependencies(t *testing.T) {
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("packageA", "0.0.1", "", "packageA", "alpha", "community", "olm", nil, nil, deps, "", false),
-					genEntry("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", nil, nil, nil, "", false),
+					genEntry("test-package", "0.0.1", "", "test-package", "alpha", "community", "olm", nil, nil, deps, "", false),
+					genEntry("another-package.v1", "1.0.0", "", "another-package", "alpha", "community", "olm", nil, nil, nil, "", false),
 				},
 			},
 		}),
@@ -697,9 +697,9 @@ func TestSolveOperators_WithNestedGVKDependencies(t *testing.T) {
 	namespace := "olm"
 	catalog := cache.SourceKey{Name: "community", Namespace: namespace}
 
-	csv := existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil)
-	sub := existingSub(namespace, "packageA.v1", "packageA", "alpha", catalog)
-	newSub := newSub(namespace, "packageB", "alpha", catalog)
+	csv := existingOperator(namespace, "test-package.v1", "test-package", "alpha", "", Provides, nil, nil, nil)
+	sub := existingSub(namespace, "test-package.v1", "test-package", "alpha", catalog)
+	newSub := newSub(namespace, "another-package", "alpha", catalog)
 	subs := []*v1alpha1.Subscription{sub, newSub}
 
 	deps := []*api.Dependency{
@@ -723,9 +723,9 @@ func TestSolveOperators_WithNestedGVKDependencies(t *testing.T) {
 				Name:      "community",
 			}: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("packageA.v1.0.1", "1.0.1", "packageA.v1", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
-					genEntry("packageB.v1.0.0", "1.0.0", "", "packageB", "alpha", "community", "olm", Provides, nil, deps, "", false),
-					genEntry("packageB.v1.0.1", "1.0.1", "packageB.v1.0.0", "packageB", "alpha", "community", "olm", Provides, nil, deps, "", false),
+					genEntry("test-package.v1.0.1", "1.0.1", "test-package.v1", "test-package", "alpha", "community", "olm", nil, nil, nil, "", false),
+					genEntry("another-package.v1.0.0", "1.0.0", "", "another-package", "alpha", "community", "olm", Provides, nil, deps, "", false),
+					genEntry("another-package.v1.0.1", "1.0.1", "another-package.v1.0.0", "another-package", "alpha", "community", "olm", Provides, nil, deps, "", false),
 					genEntry("packageC.v1.0.0", "1.0.0", "", "packageC", "alpha", "community", "olm", Provides2, Provides, deps2, "", false),
 					genEntry("packageC.v1.0.1", "1.0.1", "packageC.v1.0.0", "packageC", "alpha", "community", "olm", Provides2, Provides, deps2, "", false),
 					genEntry("packageD.v1.0.1", "1.0.1", "", "packageD", "alpha", "community", "olm", nil, Provides2, deps2, "", false),
@@ -749,8 +749,8 @@ func TestSolveOperators_WithNestedGVKDependencies(t *testing.T) {
 	operators, err := resolver.Resolve([]string{"olm"}, subs)
 	assert.NoError(t, err)
 	expected := []*cache.Entry{
-		genEntry("packageA.v1.0.1", "1.0.1", "packageA.v1", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
-		genEntry("packageB.v1.0.1", "1.0.1", "packageB.v1.0.0", "packageB", "alpha", "community", "olm", Provides, nil, deps, "", false),
+		genEntry("test-package.v1.0.1", "1.0.1", "test-package.v1", "test-package", "alpha", "community", "olm", nil, nil, nil, "", false),
+		genEntry("another-package.v1.0.1", "1.0.1", "another-package.v1.0.0", "another-package", "alpha", "community", "olm", Provides, nil, deps, "", false),
 		genEntry("packageC.v1.0.1", "1.0.1", "packageC.v1.0.0", "packageC", "alpha", "community", "olm", Provides2, Provides, deps2, "", false),
 		genEntry("packageD.v1.0.1", "1.0.1", "", "packageD", "alpha", "community", "olm", nil, Provides2, deps2, "", false),
 	}
@@ -1053,8 +1053,8 @@ func TestSolveOperators_IgnoreUnsatisfiableDependencies(t *testing.T) {
 	community := cache.SourceKey{Name: "community", Namespace: namespace}
 
 	subs := []*v1alpha1.Subscription{
-		existingSub(namespace, "packageA.v1", "packageA", "alpha", community),
-		newSub(namespace, "packageB", "alpha", community),
+		existingSub(namespace, "test-package.v1", "test-package", "alpha", community),
+		newSub(namespace, "another-package", "alpha", community),
 	}
 
 	opToAddVersionDeps := []*api.Dependency{
@@ -1074,22 +1074,22 @@ func TestSolveOperators_IgnoreUnsatisfiableDependencies(t *testing.T) {
 		cache: cache.New(cache.StaticSourceProvider{
 			community: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("packageA.v1", "0.0.1", "", "packageA", "alpha", "community", "olm", nil, nil, nil, "", false),
-					genEntry("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false),
+					genEntry("test-package.v1", "0.0.1", "", "test-package", "alpha", "community", "olm", nil, nil, nil, "", false),
+					genEntry("another-package.v1", "1.0.0", "", "another-package", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false),
 					genEntry("packageC.v1", "0.1.0", "", "packageC", "alpha", "community", "olm", nil, nil, unsatisfiableVersionDeps, "", false),
 				},
 			},
 			{Namespace: "olm", Name: "certified"}: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("packageA.v1", "0.0.1", "", "packageA", "alpha", "certified", "olm", nil, nil, nil, "", false),
-					genEntry("packageB.v1", "1.0.0", "", "packageB", "alpha", "certified", "olm", nil, nil, opToAddVersionDeps, "", false),
+					genEntry("test-package.v1", "0.0.1", "", "test-package", "alpha", "certified", "olm", nil, nil, nil, "", false),
+					genEntry("another-package.v1", "1.0.0", "", "another-package", "alpha", "certified", "olm", nil, nil, opToAddVersionDeps, "", false),
 					genEntry("packageC.v1", "0.1.0", "", "packageC", "alpha", "certified", "olm", nil, nil, nil, "", false),
 				},
 			},
 			cache.NewVirtualSourceKey(namespace): csvSnapshotOrPanic(
 				namespace,
 				subs,
-				existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil),
+				existingOperator(namespace, "test-package.v1", "test-package", "alpha", "", Provides, nil, nil, nil),
 			),
 		}),
 		log: logrus.New(),
@@ -1098,7 +1098,7 @@ func TestSolveOperators_IgnoreUnsatisfiableDependencies(t *testing.T) {
 	operators, err := resolver.Resolve([]string{"olm"}, subs)
 	assert.NoError(t, err)
 	expected := []*cache.Entry{
-		genEntry("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false),
+		genEntry("another-package.v1", "1.0.0", "", "another-package", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false),
 		genEntry("packageC.v1", "0.1.0", "", "packageC", "alpha", "certified", "olm", nil, nil, nil, "", false),
 	}
 	assert.ElementsMatch(t, expected, operators)
@@ -1115,20 +1115,20 @@ func TestSolveOperators_PreferCatalogInSameNamespace(t *testing.T) {
 	catalog := cache.SourceKey{Name: "community", Namespace: namespace}
 	altnsCatalog := cache.SourceKey{Name: "alt-community", Namespace: altNamespace}
 
-	csv := existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil)
-	sub := existingSub(namespace, "packageA.v1", "packageA", "alpha", catalog)
+	csv := existingOperator(namespace, "test-package.v1", "test-package", "alpha", "", Provides, nil, nil, nil)
+	sub := existingSub(namespace, "test-package.v1", "test-package", "alpha", catalog)
 	subs := []*v1alpha1.Subscription{sub}
 
 	resolver := Resolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("packageA.v0.0.1", "0.0.1", "packageA.v1", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, Provides, nil, "", false),
+					genEntry("test-package.v0.0.1", "0.0.1", "test-package.v1", "test-package", "alpha", catalog.Name, catalog.Namespace, nil, Provides, nil, "", false),
 				},
 			},
 			altnsCatalog: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("packageA.v0.0.1", "0.0.1", "packageA.v1", "packageA", "alpha", altnsCatalog.Name, altnsCatalog.Namespace, nil, Provides, nil, "", false),
+					genEntry("test-package.v0.0.1", "0.0.1", "test-package.v1", "test-package", "alpha", altnsCatalog.Name, altnsCatalog.Namespace, nil, Provides, nil, "", false),
 				},
 			},
 			cache.NewVirtualSourceKey(namespace): csvSnapshotOrPanic(namespace, subs, csv),
@@ -1140,7 +1140,7 @@ func TestSolveOperators_PreferCatalogInSameNamespace(t *testing.T) {
 	assert.NoError(t, err)
 
 	expected := []*cache.Entry{
-		genEntry("packageA.v0.0.1", "0.0.1", "packageA.v1", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, Provides, nil, "", false),
+		genEntry("test-package.v0.0.1", "0.0.1", "test-package.v1", "test-package", "alpha", catalog.Name, catalog.Namespace, nil, Provides, nil, "", false),
 	}
 	require.ElementsMatch(t, expected, operators)
 }
@@ -1155,15 +1155,15 @@ func TestSolveOperators_ResolveOnlyInCachedNamespaces(t *testing.T) {
 	catalog := cache.SourceKey{Name: "community", Namespace: namespace}
 	otherCatalog := cache.SourceKey{Name: "secret", Namespace: "secret"}
 
-	csv := existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil)
-	newSub := newSub(namespace, "packageA", "alpha", catalog)
+	csv := existingOperator(namespace, "test-package.v1", "test-package", "alpha", "", Provides, nil, nil, nil)
+	newSub := newSub(namespace, "test-package", "alpha", catalog)
 	subs := []*v1alpha1.Subscription{newSub}
 
 	resolver := Resolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("packageA.v0.0.1", "0.0.1", "packageA.v1", "packageA", "alpha", otherCatalog.Name, otherCatalog.Namespace, nil, Provides, nil, "", false),
+					genEntry("test-package.v0.0.1", "0.0.1", "test-package.v1", "test-package", "alpha", otherCatalog.Name, otherCatalog.Namespace, nil, Provides, nil, "", false),
 				},
 			},
 			cache.NewVirtualSourceKey(namespace): csvSnapshotOrPanic(namespace, subs, csv),
@@ -1187,7 +1187,7 @@ func TestSolveOperators_PreferDefaultChannelInResolution(t *testing.T) {
 
 	const defaultChannel = "stable"
 	// do not specify a channel explicitly on the subscription
-	newSub := newSub(namespace, "packageA", "", catalog)
+	newSub := newSub(namespace, "test-package", "", catalog)
 	subs := []*v1alpha1.Subscription{newSub}
 
 	resolver := Resolver{
@@ -1195,8 +1195,8 @@ func TestSolveOperators_PreferDefaultChannelInResolution(t *testing.T) {
 			catalog: &cache.Snapshot{
 				Entries: []*cache.Entry{
 					// Default channel is stable in this case
-					genEntry("packageA.v0.0.2", "0.0.2", "packageA.v1", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, Provides, nil, defaultChannel, false),
-					genEntry("packageA.v0.0.1", "0.0.1", "packageA.v1", "packageA", "stable", catalog.Name, catalog.Namespace, nil, Provides, nil, defaultChannel, false),
+					genEntry("test-package.v0.0.2", "0.0.2", "test-package.v1", "test-package", "alpha", catalog.Name, catalog.Namespace, nil, Provides, nil, defaultChannel, false),
+					genEntry("test-package.v0.0.1", "0.0.1", "test-package.v1", "test-package", "stable", catalog.Name, catalog.Namespace, nil, Provides, nil, defaultChannel, false),
 				},
 			},
 		}),
@@ -1208,7 +1208,7 @@ func TestSolveOperators_PreferDefaultChannelInResolution(t *testing.T) {
 
 	// operator should be from the default stable channel
 	expected := []*cache.Entry{
-		genEntry("packageA.v0.0.1", "0.0.1", "packageA.v1", "packageA", "stable", catalog.Name, catalog.Namespace, nil, Provides, nil, defaultChannel, false),
+		genEntry("test-package.v0.0.1", "0.0.1", "test-package.v1", "test-package", "stable", catalog.Name, catalog.Namespace, nil, Provides, nil, defaultChannel, false),
 	}
 	require.ElementsMatch(t, expected, operators)
 }
@@ -1221,7 +1221,7 @@ func TestSolveOperators_PreferDefaultChannelInResolutionForTransitiveDependencie
 	namespace := "olm"
 	catalog := cache.SourceKey{Name: "community", Namespace: namespace}
 
-	newSub := newSub(namespace, "packageA", "alpha", catalog)
+	newSub := newSub(namespace, "test-package", "alpha", catalog)
 	subs := []*v1alpha1.Subscription{newSub}
 
 	const defaultChannel = "stable"
@@ -1230,9 +1230,9 @@ func TestSolveOperators_PreferDefaultChannelInResolutionForTransitiveDependencie
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("packageA.v0.0.1", "0.0.1", "packageA.v1", "packageA", "alpha", catalog.Name, catalog.Namespace, Provides, nil, apiSetToDependencies(nil, Provides), defaultChannel, false),
-					genEntry("packageB.v0.0.1", "0.0.1", "packageB.v1", "packageB", defaultChannel, catalog.Name, catalog.Namespace, nil, Provides, nil, defaultChannel, false),
-					genEntry("packageB.v0.0.2", "0.0.2", "packageB.v0.0.1", "packageB", "alpha", catalog.Name, catalog.Namespace, nil, Provides, nil, defaultChannel, false),
+					genEntry("test-package.v0.0.1", "0.0.1", "test-package.v1", "test-package", "alpha", catalog.Name, catalog.Namespace, Provides, nil, apiSetToDependencies(nil, Provides), defaultChannel, false),
+					genEntry("another-package.v0.0.1", "0.0.1", "another-package.v1", "another-package", defaultChannel, catalog.Name, catalog.Namespace, nil, Provides, nil, defaultChannel, false),
+					genEntry("another-package.v0.0.2", "0.0.2", "another-package.v0.0.1", "another-package", "alpha", catalog.Name, catalog.Namespace, nil, Provides, nil, defaultChannel, false),
 				},
 			},
 		}),
@@ -1244,8 +1244,8 @@ func TestSolveOperators_PreferDefaultChannelInResolutionForTransitiveDependencie
 
 	// operator should be from the default stable channel
 	expected := []*cache.Entry{
-		genEntry("packageA.v0.0.1", "0.0.1", "packageA.v1", "packageA", "alpha", catalog.Name, catalog.Namespace, Provides, nil, apiSetToDependencies(nil, Provides), defaultChannel, false),
-		genEntry("packageB.v0.0.1", "0.0.1", "packageB.v1", "packageB", defaultChannel, catalog.Name, catalog.Namespace, nil, Provides, nil, defaultChannel, false),
+		genEntry("test-package.v0.0.1", "0.0.1", "test-package.v1", "test-package", "alpha", catalog.Name, catalog.Namespace, Provides, nil, apiSetToDependencies(nil, Provides), defaultChannel, false),
+		genEntry("another-package.v0.0.1", "0.0.1", "another-package.v1", "another-package", defaultChannel, catalog.Name, catalog.Namespace, nil, Provides, nil, defaultChannel, false),
 	}
 	require.ElementsMatch(t, expected, operators)
 }
@@ -1257,8 +1257,8 @@ func TestSolveOperators_SubscriptionlessOperatorsSatisfyDependencies(t *testing.
 	namespace := "olm"
 	catalog := cache.SourceKey{Name: "community", Namespace: namespace}
 
-	csv := existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil)
-	newSub := newSub(namespace, "packageB", "alpha", catalog)
+	csv := existingOperator(namespace, "test-package.v1", "test-package", "alpha", "", Provides, nil, nil, nil)
+	newSub := newSub(namespace, "another-package", "alpha", catalog)
 	subs := []*v1alpha1.Subscription{newSub}
 
 	deps := []*api.Dependency{
@@ -1272,8 +1272,8 @@ func TestSolveOperators_SubscriptionlessOperatorsSatisfyDependencies(t *testing.
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("packageB.v1.0.0", "1.0.0", "", "packageB", "alpha", "community", "olm", Provides, nil, deps, "", false),
-					genEntry("packageB.v1.0.1", "1.0.1", "packageB.v1.0.0", "packageB", "alpha", "community", "olm", Provides, nil, deps, "", false),
+					genEntry("another-package.v1.0.0", "1.0.0", "", "another-package", "alpha", "community", "olm", Provides, nil, deps, "", false),
+					genEntry("another-package.v1.0.1", "1.0.1", "another-package.v1.0.0", "another-package", "alpha", "community", "olm", Provides, nil, deps, "", false),
 				},
 			},
 			cache.NewVirtualSourceKey(namespace): csvSnapshotOrPanic(namespace, subs, csv),
@@ -1284,7 +1284,7 @@ func TestSolveOperators_SubscriptionlessOperatorsSatisfyDependencies(t *testing.
 	operators, err := resolver.Resolve([]string{"olm"}, subs)
 	assert.NoError(t, err)
 	expected := []*cache.Entry{
-		genEntry("packageB.v1.0.1", "1.0.1", "packageB.v1.0.0", "packageB", "alpha", catalog.Name, catalog.Namespace, Provides, nil, apiSetToDependencies(Provides, nil), "", false),
+		genEntry("another-package.v1.0.1", "1.0.1", "another-package.v1.0.0", "another-package", "alpha", catalog.Name, catalog.Namespace, Provides, nil, apiSetToDependencies(Provides, nil), "", false),
 	}
 	assert.ElementsMatch(t, expected, operators)
 }
@@ -1296,16 +1296,16 @@ func TestSolveOperators_SubscriptionlessOperatorsCanConflict(t *testing.T) {
 	namespace := "olm"
 	catalog := cache.SourceKey{Name: "community", Namespace: namespace}
 
-	csv := existingOperator(namespace, "packageA.v1", "packageA", "alpha", "", Provides, nil, nil, nil)
-	newSub := newSub(namespace, "packageB", "alpha", catalog)
+	csv := existingOperator(namespace, "test-package.v1", "test-package", "alpha", "", Provides, nil, nil, nil)
+	newSub := newSub(namespace, "another-package", "alpha", catalog)
 	subs := []*v1alpha1.Subscription{newSub}
 
 	resolver := Resolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("packageB.v1.0.0", "1.0.0", "", "packageB", "alpha", "community", "olm", nil, Provides, nil, "", false),
-					genEntry("packageB.v1.0.1", "1.0.1", "packageB.v1.0.0", "packageB", "alpha", "community", "olm", nil, Provides, nil, "", false),
+					genEntry("another-package.v1.0.0", "1.0.0", "", "another-package", "alpha", "community", "olm", nil, Provides, nil, "", false),
+					genEntry("another-package.v1.0.1", "1.0.1", "another-package.v1.0.0", "another-package", "alpha", "community", "olm", nil, Provides, nil, "", false),
 				},
 			},
 			cache.NewVirtualSourceKey(namespace): csvSnapshotOrPanic(namespace, subs, csv),
@@ -1329,24 +1329,24 @@ func TestSolveOperators_PackageCannotSelfSatisfy(t *testing.T) {
 	catalog := cache.SourceKey{Name: "community", Namespace: namespace}
 	secondaryCatalog := cache.SourceKey{Namespace: "olm", Name: "secondary"}
 
-	newSub := newSub(namespace, "packageA", "stable", catalog)
+	newSub := newSub(namespace, "test-package", "stable", catalog)
 	subs := []*v1alpha1.Subscription{newSub}
 
 	resolver := Resolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("opA.v1.0.0", "1.0.0", "", "packageA", "stable", catalog.Name, catalog.Namespace, RequiresBoth, nil, nil, "", false),
+					genEntry("opA.v1.0.0", "1.0.0", "", "test-package", "stable", catalog.Name, catalog.Namespace, RequiresBoth, nil, nil, "", false),
 					// Despite satisfying dependencies of opA, this is not chosen because it is in the same package
-					genEntry("opABC.v1.0.0", "1.0.0", "", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, ProvidesBoth, nil, "", false),
+					genEntry("opABC.v1.0.0", "1.0.0", "", "test-package", "alpha", catalog.Name, catalog.Namespace, nil, ProvidesBoth, nil, "", false),
 
-					genEntry("opB.v1.0.0", "1.0.0", "", "packageB", "stable", catalog.Name, catalog.Namespace, nil, Provides1, nil, "stable", false),
-					genEntry("opD.v1.0.0", "1.0.0", "", "packageB", "alpha", catalog.Name, catalog.Namespace, nil, Provides1, nil, "stable", false),
+					genEntry("opB.v1.0.0", "1.0.0", "", "another-package", "stable", catalog.Name, catalog.Namespace, nil, Provides1, nil, "stable", false),
+					genEntry("opD.v1.0.0", "1.0.0", "", "another-package", "alpha", catalog.Name, catalog.Namespace, nil, Provides1, nil, "stable", false),
 				},
 			},
 			secondaryCatalog: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("opC.v1.0.0", "1.0.0", "", "packageB", "stable", secondaryCatalog.Name, secondaryCatalog.Namespace, nil, Provides2, nil, "stable", false),
+					genEntry("opC.v1.0.0", "1.0.0", "", "another-package", "stable", secondaryCatalog.Name, secondaryCatalog.Namespace, nil, Provides2, nil, "stable", false),
 
 					genEntry("opE.v1.0.0", "1.0.0", "", "packageC", "stable", secondaryCatalog.Name, secondaryCatalog.Namespace, nil, Provides2, nil, "", false),
 				},
@@ -1358,8 +1358,8 @@ func TestSolveOperators_PackageCannotSelfSatisfy(t *testing.T) {
 	operators, err := resolver.Resolve([]string{"olm"}, subs)
 	assert.NoError(t, err)
 	expected := []*cache.Entry{
-		genEntry("opA.v1.0.0", "1.0.0", "", "packageA", "stable", catalog.Name, catalog.Namespace, RequiresBoth, nil, nil, "", false),
-		genEntry("opB.v1.0.0", "1.0.0", "", "packageB", "stable", catalog.Name, catalog.Namespace, nil, Provides1, nil, "stable", false),
+		genEntry("opA.v1.0.0", "1.0.0", "", "test-package", "stable", catalog.Name, catalog.Namespace, RequiresBoth, nil, nil, "", false),
+		genEntry("opB.v1.0.0", "1.0.0", "", "another-package", "stable", catalog.Name, catalog.Namespace, nil, Provides1, nil, "stable", false),
 		genEntry("opE.v1.0.0", "1.0.0", "", "packageC", "stable", secondaryCatalog.Name, secondaryCatalog.Namespace, nil, Provides2, nil, "", false),
 	}
 	assert.ElementsMatch(t, expected, operators)
@@ -1386,29 +1386,29 @@ func TestSolveOperators_TransferApiOwnership(t *testing.T) {
 		expected []*cache.Entry
 	}{
 		{
-			subs: []*v1alpha1.Subscription{newSub(namespace, "packageB", "stable", catalog)},
+			subs: []*v1alpha1.Subscription{newSub(namespace, "another-package", "stable", catalog)},
 			catalog: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("opA.v1.0.0", "1.0.0", "", "packageA", "stable", catalog.Name, catalog.Namespace, nil, Provides1, nil, "", false),
-					genEntry("opB.v1.0.0", "1.0.0", "", "packageB", "stable", catalog.Name, catalog.Namespace, Requires1, Provides2, nil, "stable", false),
+					genEntry("opA.v1.0.0", "1.0.0", "", "test-package", "stable", catalog.Name, catalog.Namespace, nil, Provides1, nil, "", false),
+					genEntry("opB.v1.0.0", "1.0.0", "", "another-package", "stable", catalog.Name, catalog.Namespace, Requires1, Provides2, nil, "stable", false),
 				},
 			},
 			expected: []*cache.Entry{
-				genEntry("opA.v1.0.0", "1.0.0", "", "packageA", "stable", catalog.Name, catalog.Namespace, nil, Provides1, nil, "", false),
-				genEntry("opB.v1.0.0", "1.0.0", "", "packageB", "stable", catalog.Name, catalog.Namespace, Requires1, Provides2, nil, "stable", false),
+				genEntry("opA.v1.0.0", "1.0.0", "", "test-package", "stable", catalog.Name, catalog.Namespace, nil, Provides1, nil, "", false),
+				genEntry("opB.v1.0.0", "1.0.0", "", "another-package", "stable", catalog.Name, catalog.Namespace, Requires1, Provides2, nil, "stable", false),
 			},
 		},
 		{
 			// will have two existing subs after resolving once
 			subs: []*v1alpha1.Subscription{
-				existingSub(namespace, "opA.v1.0.0", "packageA", "stable", catalog),
-				existingSub(namespace, "opB.v1.0.0", "packageB", "stable", catalog),
+				existingSub(namespace, "opA.v1.0.0", "test-package", "stable", catalog),
+				existingSub(namespace, "opB.v1.0.0", "another-package", "stable", catalog),
 			},
 			catalog: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("opA.v1.0.0", "1.0.0", "", "packageA", "stable", catalog.Name, catalog.Namespace, nil, Provides1, nil, "", false),
-					genEntry("opA.v1.0.1", "1.0.1", "opA.v1.0.0", "packageA", "stable", catalog.Name, catalog.Namespace, Requires1, nil, nil, "", false),
-					genEntry("opB.v1.0.0", "1.0.0", "", "packageB", "stable", catalog.Name, catalog.Namespace, Requires1, Provides2, nil, "stable", false),
+					genEntry("opA.v1.0.0", "1.0.0", "", "test-package", "stable", catalog.Name, catalog.Namespace, nil, Provides1, nil, "", false),
+					genEntry("opA.v1.0.1", "1.0.1", "opA.v1.0.0", "test-package", "stable", catalog.Name, catalog.Namespace, Requires1, nil, nil, "", false),
+					genEntry("opB.v1.0.0", "1.0.0", "", "another-package", "stable", catalog.Name, catalog.Namespace, Requires1, Provides2, nil, "stable", false),
 				},
 			},
 			// nothing new to do here
@@ -1417,20 +1417,20 @@ func TestSolveOperators_TransferApiOwnership(t *testing.T) {
 		{
 			// will have two existing subs after resolving once
 			subs: []*v1alpha1.Subscription{
-				existingSub(namespace, "opA.v1.0.0", "packageA", "stable", catalog),
-				existingSub(namespace, "opB.v1.0.0", "packageB", "stable", catalog),
+				existingSub(namespace, "opA.v1.0.0", "test-package", "stable", catalog),
+				existingSub(namespace, "opB.v1.0.0", "another-package", "stable", catalog),
 			},
 			catalog: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("opA.v1.0.0", "1.0.0", "", "packageA", "stable", catalog.Name, catalog.Namespace, nil, Provides1, nil, "", false),
-					genEntry("opA.v1.0.1", "1.0.1", "opA.v1.0.0", "packageA", "stable", catalog.Name, catalog.Namespace, Requires1, nil, nil, "", false),
-					genEntry("opB.v1.0.0", "1.0.0", "", "packageB", "stable", catalog.Name, catalog.Namespace, Requires1, Provides2, nil, "stable", false),
-					genEntry("opB.v1.0.1", "1.0.1", "opB.v1.0.0", "packageB", "stable", catalog.Name, catalog.Namespace, nil, ProvidesBoth, nil, "stable", false),
+					genEntry("opA.v1.0.0", "1.0.0", "", "test-package", "stable", catalog.Name, catalog.Namespace, nil, Provides1, nil, "", false),
+					genEntry("opA.v1.0.1", "1.0.1", "opA.v1.0.0", "test-package", "stable", catalog.Name, catalog.Namespace, Requires1, nil, nil, "", false),
+					genEntry("opB.v1.0.0", "1.0.0", "", "another-package", "stable", catalog.Name, catalog.Namespace, Requires1, Provides2, nil, "stable", false),
+					genEntry("opB.v1.0.1", "1.0.1", "opB.v1.0.0", "another-package", "stable", catalog.Name, catalog.Namespace, nil, ProvidesBoth, nil, "stable", false),
 				},
 			},
 			expected: []*cache.Entry{
-				genEntry("opA.v1.0.1", "1.0.1", "opA.v1.0.0", "packageA", "stable", catalog.Name, catalog.Namespace, Requires1, nil, nil, "", false),
-				genEntry("opB.v1.0.1", "1.0.1", "opB.v1.0.0", "packageB", "stable", catalog.Name, catalog.Namespace, nil, ProvidesBoth, nil, "stable", false),
+				genEntry("opA.v1.0.1", "1.0.1", "opA.v1.0.0", "test-package", "stable", catalog.Name, catalog.Namespace, Requires1, nil, nil, "", false),
+				genEntry("opB.v1.0.1", "1.0.1", "opB.v1.0.0", "another-package", "stable", catalog.Name, catalog.Namespace, nil, ProvidesBoth, nil, "stable", false),
 			},
 		},
 	}
@@ -1530,14 +1530,14 @@ func TestSolveOperators_WithoutDeprecated(t *testing.T) {
 	catalog := cache.SourceKey{Name: "catalog", Namespace: "namespace"}
 
 	subs := []*v1alpha1.Subscription{
-		newSub(catalog.Namespace, "packageA", "alpha", catalog),
+		newSub(catalog.Namespace, "test-package", "alpha", catalog),
 	}
 
 	resolver := Resolver{
 		cache: cache.New(cache.StaticSourceProvider{
 			catalog: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("packageA.v1", "0.0.1", "", "packageA", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", true),
+					genEntry("test-package.v1", "0.0.1", "", "test-package", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", true),
 				},
 			},
 		}),
@@ -1581,7 +1581,7 @@ func TestSolveOperators_WithSkipsAndStartingCSV(t *testing.T) {
 	namespace := "olm"
 	catalog := cache.SourceKey{Name: "community", Namespace: namespace}
 
-	newSub := newSub(namespace, "packageB", "alpha", catalog, withStartingCSV("packageB.v1"))
+	newSub := newSub(namespace, "another-package", "alpha", catalog, withStartingCSV("another-package.v1"))
 	subs := []*v1alpha1.Subscription{newSub}
 
 	opToAddVersionDeps := []*api.Dependency{
@@ -1591,17 +1591,17 @@ func TestSolveOperators_WithSkipsAndStartingCSV(t *testing.T) {
 		},
 	}
 
-	opB := genEntry("packageB.v1", "1.0.0", "", "packageB", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false)
-	opB2 := genEntry("packageB.v2", "2.0.0", "", "packageB", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false)
-	opB2.Skips = []string{"packageB.v1"}
-	op1 := genEntry("packageA.v1", "1.0.0", "", "packageA", "alpha", "community", "olm", nil, Provides, nil, "", false)
-	op2 := genEntry("packageA.v2", "2.0.0", "packageA.v1", "packageA", "alpha", "community", "olm", nil, Provides, nil, "", false)
-	op3 := genEntry("packageA.v3", "3.0.0", "packageA.v2", "packageA", "alpha", "community", "olm", nil, Provides, nil, "", false)
-	op4 := genEntry("packageA.v4", "4.0.0", "packageA.v3", "packageA", "alpha", "community", "olm", nil, Provides, nil, "", false)
-	op4.Skips = []string{"packageA.v3"}
-	op5 := genEntry("packageA.v5", "5.0.0", "packageA.v4", "packageA", "alpha", "community", "olm", nil, Provides, nil, "", false)
-	op5.Skips = []string{"packageA.v2", "packageA.v3", "packageA.v4"}
-	op6 := genEntry("packageA.v6", "6.0.0", "packageA.v5", "packageA", "alpha", "community", "olm", nil, Provides, nil, "", false)
+	opB := genEntry("another-package.v1", "1.0.0", "", "another-package", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false)
+	opB2 := genEntry("another-package.v2", "2.0.0", "", "another-package", "alpha", "community", "olm", nil, nil, opToAddVersionDeps, "", false)
+	opB2.Skips = []string{"another-package.v1"}
+	op1 := genEntry("test-package.v1", "1.0.0", "", "test-package", "alpha", "community", "olm", nil, Provides, nil, "", false)
+	op2 := genEntry("test-package.v2", "2.0.0", "test-package.v1", "test-package", "alpha", "community", "olm", nil, Provides, nil, "", false)
+	op3 := genEntry("test-package.v3", "3.0.0", "test-package.v2", "test-package", "alpha", "community", "olm", nil, Provides, nil, "", false)
+	op4 := genEntry("test-package.v4", "4.0.0", "test-package.v3", "test-package", "alpha", "community", "olm", nil, Provides, nil, "", false)
+	op4.Skips = []string{"test-package.v3"}
+	op5 := genEntry("test-package.v5", "5.0.0", "test-package.v4", "test-package", "alpha", "community", "olm", nil, Provides, nil, "", false)
+	op5.Skips = []string{"test-package.v2", "test-package.v3", "test-package.v4"}
+	op6 := genEntry("test-package.v6", "6.0.0", "test-package.v5", "test-package", "alpha", "community", "olm", nil, Provides, nil, "", false)
 
 	resolver := Resolver{
 		cache: cache.New(cache.StaticSourceProvider{
@@ -1616,7 +1616,7 @@ func TestSolveOperators_WithSkipsAndStartingCSV(t *testing.T) {
 
 	operators, err := resolver.Resolve([]string{"olm"}, subs)
 	assert.NoError(t, err)
-	opB.SourceInfo.StartingCSV = "packageB.v1"
+	opB.SourceInfo.StartingCSV = "another-package.v1"
 	expected := []*cache.Entry{opB, op6}
 	require.ElementsMatch(t, expected, operators)
 }
@@ -1625,12 +1625,12 @@ func TestSolveOperators_WithSkips(t *testing.T) {
 	const namespace = "test-namespace"
 	catalog := cache.SourceKey{Name: "test-catalog", Namespace: namespace}
 
-	newSub := newSub(namespace, "packageB", "alpha", catalog)
+	newSub := newSub(namespace, "another-package", "alpha", catalog)
 	subs := []*v1alpha1.Subscription{newSub}
 
-	opB := genEntry("packageB.v1", "1.0.0", "", "packageB", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false)
-	opB2 := genEntry("packageB.v2", "2.0.0", "", "packageB", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false)
-	opB2.Skips = []string{"packageB.v1"}
+	opB := genEntry("another-package.v1", "1.0.0", "", "another-package", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false)
+	opB2 := genEntry("another-package.v2", "2.0.0", "", "another-package", "alpha", catalog.Name, catalog.Namespace, nil, nil, nil, "", false)
+	opB2.Skips = []string{"another-package.v1"}
 
 	resolver := Resolver{
 		cache: cache.New(cache.StaticSourceProvider{
@@ -1951,7 +1951,7 @@ func TestSolveOperators_GenericConstraint(t *testing.T) {
 		{
 			Type: "olm.constraint",
 			Value: `{"failureMessage":"package-constraint",
-				"cel":{"rule":"properties.exists(p, p.type == 'olm.package' && p.value.packageName == 'packageB' && (semver_compare(p.value.version, '1.0.1') == 0))"}}`,
+				"cel":{"rule":"properties.exists(p, p.type == 'olm.package' && p.value.packageName == 'another-package' && (semver_compare(p.value.version, '1.0.1') == 0))"}}`,
 		},
 	}
 
@@ -1968,17 +1968,17 @@ func TestSolveOperators_GenericConstraint(t *testing.T) {
 			name:  "Generic Constraint/Satisfiable GVK Dependency",
 			isErr: false,
 			subs: []*v1alpha1.Subscription{
-				newSub(namespace, "packageA", "stable", catalog),
+				newSub(namespace, "test-package", "stable", catalog),
 			},
 			catalog: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("opA.v1.0.0", "1.0.0", "", "packageA", "stable", catalog.Name, catalog.Namespace, nil, nil, deps1, "", false),
-					genEntry("opB.v1.0.0", "1.0.0", "", "packageB", "stable", catalog.Name, catalog.Namespace, nil, Provides1, nil, "stable", false),
+					genEntry("opA.v1.0.0", "1.0.0", "", "test-package", "stable", catalog.Name, catalog.Namespace, nil, nil, deps1, "", false),
+					genEntry("opB.v1.0.0", "1.0.0", "", "another-package", "stable", catalog.Name, catalog.Namespace, nil, Provides1, nil, "stable", false),
 				},
 			},
 			expected: []*cache.Entry{
-				genEntry("opA.v1.0.0", "1.0.0", "", "packageA", "stable", catalog.Name, catalog.Namespace, nil, nil, deps1, "", false),
-				genEntry("opB.v1.0.0", "1.0.0", "", "packageB", "stable", catalog.Name, catalog.Namespace, nil, Provides1, nil, "stable", false),
+				genEntry("opA.v1.0.0", "1.0.0", "", "test-package", "stable", catalog.Name, catalog.Namespace, nil, nil, deps1, "", false),
+				genEntry("opB.v1.0.0", "1.0.0", "", "another-package", "stable", catalog.Name, catalog.Namespace, nil, Provides1, nil, "stable", false),
 			},
 		},
 		{
@@ -1986,12 +1986,12 @@ func TestSolveOperators_GenericConstraint(t *testing.T) {
 			name:  "Generic Constraint/NotSatisfiable GVK Dependency",
 			isErr: true,
 			subs: []*v1alpha1.Subscription{
-				newSub(namespace, "packageA", "stable", catalog),
+				newSub(namespace, "test-package", "stable", catalog),
 			},
 			catalog: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("opA.v1.0.0", "1.0.0", "", "packageA", "stable", catalog.Name, catalog.Namespace, nil, nil, deps2, "", false),
-					genEntry("opB.v1.0.0", "1.0.0", "", "packageB", "stable", catalog.Name, catalog.Namespace, nil, Provides1, nil, "", false),
+					genEntry("opA.v1.0.0", "1.0.0", "", "test-package", "stable", catalog.Name, catalog.Namespace, nil, nil, deps2, "", false),
+					genEntry("opB.v1.0.0", "1.0.0", "", "another-package", "stable", catalog.Name, catalog.Namespace, nil, Provides1, nil, "", false),
 				},
 			},
 			// unable to find satisfiable gvk dependency
@@ -2004,19 +2004,19 @@ func TestSolveOperators_GenericConstraint(t *testing.T) {
 			name:  "Generic Constraint/Satisfiable Package Dependency",
 			isErr: false,
 			subs: []*v1alpha1.Subscription{
-				newSub(namespace, "packageA", "stable", catalog),
+				newSub(namespace, "test-package", "stable", catalog),
 			},
 			catalog: &cache.Snapshot{
 				Entries: []*cache.Entry{
-					genEntry("opA.v1.0.0", "1.0.0", "", "packageA", "stable", catalog.Name, catalog.Namespace, nil, nil, deps3, "", false),
-					genEntry("opB.v1.0.0", "1.0.0", "", "packageB", "stable", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
-					genEntry("opB.v1.0.1", "1.0.1", "opB.v1.0.0", "packageB", "stable", catalog.Name, catalog.Namespace, nil, nil, nil, "stable", false),
-					genEntry("opB.v1.0.2", "1.0.2", "opB.v1.0.1", "packageB", "stable", catalog.Name, catalog.Namespace, nil, nil, nil, "stable", false),
+					genEntry("opA.v1.0.0", "1.0.0", "", "test-package", "stable", catalog.Name, catalog.Namespace, nil, nil, deps3, "", false),
+					genEntry("opB.v1.0.0", "1.0.0", "", "another-package", "stable", catalog.Name, catalog.Namespace, nil, nil, nil, "", false),
+					genEntry("opB.v1.0.1", "1.0.1", "opB.v1.0.0", "another-package", "stable", catalog.Name, catalog.Namespace, nil, nil, nil, "stable", false),
+					genEntry("opB.v1.0.2", "1.0.2", "opB.v1.0.1", "another-package", "stable", catalog.Name, catalog.Namespace, nil, nil, nil, "stable", false),
 				},
 			},
 			expected: []*cache.Entry{
-				genEntry("opA.v1.0.0", "1.0.0", "", "packageA", "stable", catalog.Name, catalog.Namespace, nil, nil, deps3, "", false),
-				genEntry("opB.v1.0.1", "1.0.1", "opB.v1.0.0", "packageB", "stable", catalog.Name, catalog.Namespace, nil, nil, nil, "stable", false),
+				genEntry("opA.v1.0.0", "1.0.0", "", "test-package", "stable", catalog.Name, catalog.Namespace, nil, nil, deps3, "", false),
+				genEntry("opB.v1.0.1", "1.0.1", "opB.v1.0.0", "another-package", "stable", catalog.Name, catalog.Namespace, nil, nil, nil, "stable", false),
 			},
 		},
 	}

--- a/staging/operator-lifecycle-manager/pkg/lib/filemonitor/monitor/loaded.crt
+++ b/staging/operator-lifecycle-manager/pkg/lib/filemonitor/monitor/loaded.crt
@@ -1,0 +1,1 @@
+../testdata/server-new.crt

--- a/staging/operator-lifecycle-manager/pkg/lib/filemonitor/monitor/loaded.key
+++ b/staging/operator-lifecycle-manager/pkg/lib/filemonitor/monitor/loaded.key
@@ -1,0 +1,1 @@
+../testdata/server-new.key

--- a/staging/operator-lifecycle-manager/test/e2e/catalog_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/catalog_e2e_test.go
@@ -1453,7 +1453,7 @@ var _ = Describe("Starting CatalogSource e2e tests", func() {
 						CatalogSource:          catalogSourceName,
 						CatalogSourceNamespace: generatedNamespace.GetName(),
 						Channel:                "stable",
-						Package:                "packageA",
+						Package:                "test-package",
 					},
 				}
 				Expect(c.Create(context.Background(), subscription)).To(BeNil())

--- a/staging/operator-lifecycle-manager/test/e2e/catalog_exclusion_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/catalog_exclusion_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Global Catalog Exclusion", func() {
 				Spec: &v1alpha1.SubscriptionSpec{
 					CatalogSource:          localCatalog.GetName(),
 					CatalogSourceNamespace: localCatalog.GetNamespace(),
-					Package:                "packageA",
+					Package:                "test-package",
 					Channel:                "stable",
 					InstallPlanApproval:    v1alpha1.ApprovalAutomatic,
 				},

--- a/staging/operator-lifecycle-manager/test/e2e/data/catalog.new.yaml
+++ b/staging/operator-lifecycle-manager/test/e2e/data/catalog.new.yaml
@@ -1,4 +1,4 @@
-# Contains PackageB (Updated), PackageC (new)
+# Contains another-package (Updated), PackageC (new)
 kind: ConfigMap
 apiVersion: v1
 metadata:

--- a/staging/operator-lifecycle-manager/test/e2e/data/catalog.old.yaml
+++ b/staging/operator-lifecycle-manager/test/e2e/data/catalog.old.yaml
@@ -1,4 +1,4 @@
-# Contains PackageA, PackageB
+# Contains test-package, another-package
 kind: ConfigMap
 apiVersion: v1
 metadata:

--- a/staging/operator-lifecycle-manager/test/e2e/fail_forward_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/fail_forward_e2e_test.go
@@ -183,7 +183,7 @@ var _ = Describe("Fail Forward Upgrades", func() {
 					CatalogSource:          catalogSourceName,
 					CatalogSourceNamespace: generatedNamespace.GetName(),
 					Channel:                "stable",
-					Package:                "packageA",
+					Package:                "test-package",
 				},
 			}
 			Expect(c.Create(context.Background(), subscription)).To(BeNil())
@@ -348,7 +348,7 @@ var _ = Describe("Fail Forward Upgrades", func() {
 					CatalogSource:          catalogSourceName,
 					CatalogSourceNamespace: generatedNamespace.GetName(),
 					Channel:                "stable",
-					Package:                "packageA",
+					Package:                "test-package",
 				},
 			}
 			Expect(c.Create(context.Background(), subscription)).To(BeNil())

--- a/staging/operator-lifecycle-manager/test/e2e/magic_catalog.go
+++ b/staging/operator-lifecycle-manager/test/e2e/magic_catalog.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
 
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -257,11 +258,15 @@ func (c *MagicCatalog) makeCatalogSource() *operatorsv1alpha1.CatalogSource {
 func (c *MagicCatalog) makeCatalogSourcePod() *corev1.Pod {
 
 	const (
-		image                  = "quay.io/operator-framework/opm"
 		readinessDelay  int32  = 5
 		livenessDelay   int32  = 10
 		volumeMountName string = "fbc-catalog"
 	)
+
+	var image = "quay.io/operator-framework/opm"
+	if os.Getenv("OPERATOR_REGISTRY_TAG") != "" {
+		image = fmt.Sprintf("quay.io/operator-framework/opm:%s", os.Getenv("OPERATOR_REGISTRY_TAG"))
+	}
 
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/staging/operator-lifecycle-manager/test/e2e/magic_catalog_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/magic_catalog_test.go
@@ -90,11 +90,11 @@ var _ = Describe("MagicCatalog", func() {
 					return data
 				}, ContainSubstring(`---
 schema: olm.package
-name: packageA
+name: test-package
 defaultChannel: stable
 ---
 schema: olm.channel
-package: packageA
+package: test-package
 name: stable
 entries:
   - name: busybox.v2.0.0
@@ -102,7 +102,7 @@ entries:
 ---
 schema: olm.bundle
 name: busybox.v2.0.0
-package: packageA
+package: test-package
 image: quay.io/olmtest/busybox-bundle:2.0.0
 properties:
   - type: olm.gvk
@@ -112,7 +112,7 @@ properties:
       version: v1alpha1
   - type: olm.package
     value:
-      packageName: packageA
+      packageName: test-package
       version: 1.0.0
 `)),
 			))

--- a/staging/operator-lifecycle-manager/test/e2e/subscription_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/subscription_e2e_test.go
@@ -2609,14 +2609,23 @@ var _ = Describe("Subscription", func() {
 					),
 				)
 
+				By("waiting for the subscription to have v0.3.0 installed without a bundle deprecated condition")
+				sub, err = fetchSubscription(crc, generatedNamespace.GetName(), subName,
+					subscriptionHasCondition(
+						operatorsv1alpha1.SubscriptionBundleDeprecated,
+						corev1.ConditionUnknown,
+						"",
+						"",
+					),
+				)
+				Expect(err).Should(BeNil())
+
 				By("checking for the deprecated conditions")
 				By(`Operator is deprecated at only Package and Channel levels`)
 				packageCondition := sub.Status.GetCondition(operatorsv1alpha1.SubscriptionPackageDeprecated)
 				Expect(packageCondition.Status).To(Equal(corev1.ConditionTrue))
 				channelCondition := sub.Status.GetCondition(operatorsv1alpha1.SubscriptionChannelDeprecated)
 				Expect(channelCondition.Status).To(Equal(corev1.ConditionTrue))
-				bundleCondition = sub.Status.GetCondition(operatorsv1alpha1.SubscriptionBundleDeprecated)
-				Expect(bundleCondition.Status).To(Equal(corev1.ConditionUnknown))
 
 				By("verifying that a roll-up condition is present not containing bundle deprecation condition")
 				By(`Roll-up condition should be present and contain deprecation messages from Package and Channel levels`)

--- a/staging/operator-lifecycle-manager/test/e2e/subscription_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/subscription_e2e_test.go
@@ -2595,13 +2595,19 @@ var _ = Describe("Subscription", func() {
 				err = magicCatalog.UpdateCatalog(context.Background(), provider)
 				Expect(err).To(BeNil())
 
-				By("waiting for the subscription to have v0.3.0 installed with a Package deprecated condition")
-				sub, err = fetchSubscription(crc, generatedNamespace.GetName(), subName, subscriptionHasCondition(
-					v1alpha1.SubscriptionPackageDeprecated,
-					corev1.ConditionTrue,
-					"",
-					"olm.package/test-package: test-package has been deprecated. Please switch to another-package."))
+				By("waiting for the subscription to have v0.3.0 installed")
+				sub, err = fetchSubscription(crc, generatedNamespace.GetName(), subName, subscriptionHasCurrentCSV("example-operator.v0.3.0"))
 				Expect(err).Should(BeNil())
+
+				By("waiting for the subscription to have v0.3.0 installed with a Package deprecated condition")
+				sub, err = fetchSubscription(crc, generatedNamespace.GetName(), subName,
+					subscriptionHasCondition(
+						operatorsv1alpha1.SubscriptionPackageDeprecated,
+						corev1.ConditionTrue,
+						"",
+						"olm.package/test-package: test-package has been deprecated. Please switch to another-package.",
+					),
+				)
 
 				By("checking for the deprecated conditions")
 				By(`Operator is deprecated at only Package and Channel levels`)

--- a/staging/operator-lifecycle-manager/test/e2e/testdata/bad-csv/bad-csv.yaml
+++ b/staging/operator-lifecycle-manager/test/e2e/testdata/bad-csv/bad-csv.yaml
@@ -1,17 +1,17 @@
 ---
 schema: olm.package
-name: packageA
+name: test-package
 defaultChannel: stable
 ---
 schema: olm.channel
-package: packageA
+package: test-package
 name: stable
 entries:
   - name: bad-csv
 ---
 schema: olm.bundle
 name: bad-csv
-package: packageA
+package: test-package
 image: quay.io/olmtest/missing_api_version:latest
 properties:
   - type: olm.gvk
@@ -21,5 +21,5 @@ properties:
       version: v1alpha1
   - type: olm.package
     value:
-      packageName: packageA
+      packageName: test-package
       version: 1.0.0

--- a/staging/operator-lifecycle-manager/test/e2e/testdata/fail-forward/v0.1.0/packagemanifest.yaml
+++ b/staging/operator-lifecycle-manager/test/e2e/testdata/fail-forward/v0.1.0/packagemanifest.yaml
@@ -1,4 +1,4 @@
-packageName: packageA
+packageName: test-package
 channels:
   - name: stable
     currentCSV: example-operator.v0.1.0

--- a/staging/operator-lifecycle-manager/test/e2e/testdata/fail-forward/v0.2.0-invalid-csv/packagemanifest.yaml
+++ b/staging/operator-lifecycle-manager/test/e2e/testdata/fail-forward/v0.2.0-invalid-csv/packagemanifest.yaml
@@ -1,4 +1,4 @@
-packageName: packageA
+packageName: test-package
 channels:
   - name: stable
     currentCSV: example-operator.v0.2.0&invalid

--- a/staging/operator-lifecycle-manager/test/e2e/testdata/fail-forward/v0.2.0-invalid-deployment/packagemanifest.yaml
+++ b/staging/operator-lifecycle-manager/test/e2e/testdata/fail-forward/v0.2.0-invalid-deployment/packagemanifest.yaml
@@ -1,4 +1,4 @@
-packageName: packageA
+packageName: test-package
 channels:
   - name: stable
     currentCSV: example-operator.v0.2.0

--- a/staging/operator-lifecycle-manager/test/e2e/testdata/fail-forward/v0.2.1-invalid-csv/packagemanifest.yaml
+++ b/staging/operator-lifecycle-manager/test/e2e/testdata/fail-forward/v0.2.1-invalid-csv/packagemanifest.yaml
@@ -1,4 +1,4 @@
-packageName: packageA
+packageName: test-package
 channels:
   - name: stable
     currentCSV: example-operator.v0.2.1&invalid

--- a/staging/operator-lifecycle-manager/test/e2e/testdata/fail-forward/v0.3.0-replaces-invalid-csv/packagemanifest.yaml
+++ b/staging/operator-lifecycle-manager/test/e2e/testdata/fail-forward/v0.3.0-replaces-invalid-csv/packagemanifest.yaml
@@ -1,4 +1,4 @@
-packageName: packageA
+packageName: test-package
 channels:
   - name: stable
     currentCSV: example-operator.v0.3.0

--- a/staging/operator-lifecycle-manager/test/e2e/testdata/fail-forward/v0.3.0-replaces-invalid-deployment/packagemanifest.yaml
+++ b/staging/operator-lifecycle-manager/test/e2e/testdata/fail-forward/v0.3.0-replaces-invalid-deployment/packagemanifest.yaml
@@ -1,4 +1,4 @@
-packageName: packageA
+packageName: test-package
 channels:
   - name: stable
     currentCSV: example-operator.v0.3.0

--- a/staging/operator-lifecycle-manager/test/e2e/testdata/fail-forward/v0.3.0-skip-range/packagemanifest.yaml
+++ b/staging/operator-lifecycle-manager/test/e2e/testdata/fail-forward/v0.3.0-skip-range/packagemanifest.yaml
@@ -1,4 +1,4 @@
-packageName: packageA
+packageName: test-package
 channels:
   - name: stable
     currentCSV: example-operator.v0.3.0

--- a/staging/operator-lifecycle-manager/test/e2e/testdata/fail-forward/v0.3.0-skips/packagemanifest.yaml
+++ b/staging/operator-lifecycle-manager/test/e2e/testdata/fail-forward/v0.3.0-skips/packagemanifest.yaml
@@ -1,4 +1,4 @@
-packageName: packageA
+packageName: test-package
 channels:
   - name: stable
     currentCSV: example-operator.v0.3.0

--- a/staging/operator-lifecycle-manager/test/e2e/testdata/magiccatalog/fbc_catalog.json
+++ b/staging/operator-lifecycle-manager/test/e2e/testdata/magiccatalog/fbc_catalog.json
@@ -1,23 +1,23 @@
 {
   "schema": "olm.package",
-  "name": "packageA",
+  "name": "test-package",
   "defaultChannel": "stable"
 }
 {
   "schema": "olm.channel",
   "name": "stable",
-  "package": "packageA",
+  "package": "test-package",
   "entries": [
     {
-      "name": "packageA.v1.0.0"
+      "name": "test-package.v1.0.0"
     }
   ]
 }
 {
   "schema": "olm.bundle",
-  "name": "packageA.v1.0.0",
-  "package": "packageA",
-  "image": "packageA:v1.0.0",
+  "name": "test-package.v1.0.0",
+  "package": "test-package",
+  "image": "test-package:v1.0.0",
   "properties": [
     {
       "type": "olm.gvk",
@@ -30,7 +30,7 @@
     {
       "type": "olm.package",
       "value": {
-        "packageName": "packageA",
+        "packageName": "test-package",
         "version": "1.0.0"
       }
     }

--- a/staging/operator-lifecycle-manager/test/e2e/testdata/magiccatalog/fbc_initial.yaml
+++ b/staging/operator-lifecycle-manager/test/e2e/testdata/magiccatalog/fbc_initial.yaml
@@ -1,17 +1,17 @@
 ---
 schema: olm.package
-name: packageA
+name: test-package
 defaultChannel: stable
 ---
 schema: olm.channel
-package: packageA
+package: test-package
 name: stable
 entries:
   - name: busybox.v1.0.0
 ---
 schema: olm.bundle
 name: busybox.v1.0.0
-package: packageA
+package: test-package
 image: quay.io/olmtest/busybox-bundle:1.0.0
 properties:
   - type: olm.gvk
@@ -21,5 +21,5 @@ properties:
       version: v1alpha1
   - type: olm.package
     value:
-      packageName: packageA
+      packageName: test-package
       version: 1.0.0

--- a/staging/operator-lifecycle-manager/test/e2e/testdata/magiccatalog/fbc_updated.yaml
+++ b/staging/operator-lifecycle-manager/test/e2e/testdata/magiccatalog/fbc_updated.yaml
@@ -1,10 +1,10 @@
 ---
 schema: olm.package
-name: packageA
+name: test-package
 defaultChannel: stable
 ---
 schema: olm.channel
-package: packageA
+package: test-package
 name: stable
 entries:
   - name: busybox.v2.0.0
@@ -12,7 +12,7 @@ entries:
 ---
 schema: olm.bundle
 name: busybox.v2.0.0
-package: packageA
+package: test-package
 image: quay.io/olmtest/busybox-bundle:2.0.0
 properties:
   - type: olm.gvk
@@ -22,5 +22,5 @@ properties:
       version: v1alpha1
   - type: olm.package
     value:
-      packageName: packageA
+      packageName: test-package
       version: 1.0.0

--- a/staging/operator-lifecycle-manager/test/e2e/testdata/subscription/example-operator.v0.1.0.yaml
+++ b/staging/operator-lifecycle-manager/test/e2e/testdata/subscription/example-operator.v0.1.0.yaml
@@ -1,17 +1,17 @@
 ---
 schema: olm.package
-name: packageA
+name: test-package
 defaultChannel: stable
 ---
 schema: olm.channel
-package: packageA
+package: test-package
 name: stable
 entries:
   - name: example-operator.v0.1.0
 ---
 schema: olm.bundle
 name: example-operator.v0.1.0
-package: packageA
+package: test-package
 image: quay.io/olmtest/example-operator-bundle:0.1.0
 properties:
   - type: olm.gvk
@@ -21,5 +21,5 @@ properties:
       version: v1alpha1
   - type: olm.package
     value:
-      packageName: packageA
+      packageName: test-package
       version: 1.0.0

--- a/staging/operator-lifecycle-manager/test/e2e/testdata/subscription/example-operator.v0.2.0-deprecations.yaml
+++ b/staging/operator-lifecycle-manager/test/e2e/testdata/subscription/example-operator.v0.2.0-deprecations.yaml
@@ -1,10 +1,10 @@
 ---
 schema: olm.package
-name: packageA
+name: test-package
 defaultChannel: stable
 ---
 schema: olm.channel
-package: packageA
+package: test-package
 name: stable
 entries:
   - name: example-operator.v0.2.0
@@ -12,7 +12,7 @@ entries:
 ---
 schema: olm.bundle
 name: example-operator.v0.2.0
-package: packageA
+package: test-package
 image: quay.io/olmtest/example-operator-bundle:0.2.0
 properties:
   - type: olm.gvk
@@ -22,15 +22,15 @@ properties:
       version: v1alpha1
   - type: olm.package
     value:
-      packageName: packageA
+      packageName: test-package
       version: 1.0.1
 ---
 schema: olm.deprecations
-package: packageA
+package: test-package
 entries:
   - reference:
       schema: olm.package
-    message: packageA has been deprecated. Please switch to packageB.
+    message: test-package has been deprecated. Please switch to another-package.
   - reference:
       schema: olm.channel
       name: stable

--- a/staging/operator-lifecycle-manager/test/e2e/testdata/subscription/example-operator.v0.2.0-invalid-csv.yaml
+++ b/staging/operator-lifecycle-manager/test/e2e/testdata/subscription/example-operator.v0.2.0-invalid-csv.yaml
@@ -1,10 +1,10 @@
 ---
 schema: olm.package
-name: packageA
+name: test-package
 defaultChannel: stable
 ---
 schema: olm.channel
-package: packageA
+package: test-package
 name: stable
 entries:
   - name: example-operator.v0.2.0
@@ -12,7 +12,7 @@ entries:
 ---
 schema: olm.bundle
 name: example-operator.v0.2.0
-package: packageA
+package: test-package
 image: quay.io/olmtest/example-operator-bundle:0.2.0-invalid-csv
 properties:
   - type: olm.gvk
@@ -22,5 +22,5 @@ properties:
       version: v1alpha1
   - type: olm.package
     value:
-      packageName: packageA
+      packageName: test-package
       version: 1.0.1

--- a/staging/operator-lifecycle-manager/test/e2e/testdata/subscription/example-operator.v0.2.0-non-existent-tag.yaml
+++ b/staging/operator-lifecycle-manager/test/e2e/testdata/subscription/example-operator.v0.2.0-non-existent-tag.yaml
@@ -1,10 +1,10 @@
 ---
 schema: olm.package
-name: packageA
+name: test-package
 defaultChannel: stable
 ---
 schema: olm.channel
-package: packageA
+package: test-package
 name: stable
 entries:
   - name: example-operator.v0.2.0
@@ -12,7 +12,7 @@ entries:
 ---
 schema: olm.bundle
 name: example-operator.v0.2.0
-package: packageA
+package: test-package
 image: quay.io/olmtest/example-operator-bundle:non-existent-tag
 properties:
   - type: olm.gvk
@@ -22,5 +22,5 @@ properties:
       version: v1alpha1
   - type: olm.package
     value:
-      packageName: packageA
+      packageName: test-package
       version: 1.0.1

--- a/staging/operator-lifecycle-manager/test/e2e/testdata/subscription/example-operator.v0.2.0.yaml
+++ b/staging/operator-lifecycle-manager/test/e2e/testdata/subscription/example-operator.v0.2.0.yaml
@@ -1,10 +1,10 @@
 ---
 schema: olm.package
-name: packageA
+name: test-package
 defaultChannel: stable
 ---
 schema: olm.channel
-package: packageA
+package: test-package
 name: stable
 entries:
   - name: example-operator.v0.2.0
@@ -12,7 +12,7 @@ entries:
 ---
 schema: olm.bundle
 name: example-operator.v0.2.0
-package: packageA
+package: test-package
 image: quay.io/olmtest/example-operator-bundle:0.2.0
 properties:
   - type: olm.gvk
@@ -22,5 +22,5 @@ properties:
       version: v1alpha1
   - type: olm.package
     value:
-      packageName: packageA
+      packageName: test-package
       version: 1.0.1

--- a/staging/operator-lifecycle-manager/test/e2e/testdata/subscription/example-operator.v0.3.0-deprecations.yaml
+++ b/staging/operator-lifecycle-manager/test/e2e/testdata/subscription/example-operator.v0.3.0-deprecations.yaml
@@ -1,10 +1,10 @@
 ---
 schema: olm.package
-name: packageA
+name: test-package
 defaultChannel: stable
 ---
 schema: olm.channel
-package: packageA
+package: test-package
 name: stable
 entries:
   - name: example-operator.v0.3.0
@@ -12,7 +12,7 @@ entries:
 ---
 schema: olm.bundle
 name: example-operator.v0.3.0
-package: packageA
+package: test-package
 image: quay.io/olmtest/example-operator-bundle:0.3.0
 properties:
   - type: olm.gvk
@@ -22,15 +22,15 @@ properties:
       version: v1alpha1
   - type: olm.package
     value:
-      packageName: packageA
+      packageName: test-package
       version: 0.3.0
 ---
 schema: olm.deprecations
-package: packageA
+package: test-package
 entries:
   - reference:
       schema: olm.package
-    message: packageA has been deprecated. Please switch to packageB.
+    message: test-package has been deprecated. Please switch to another-package.
   - reference:
       schema: olm.channel
       name: stable

--- a/staging/operator-lifecycle-manager/test/e2e/testdata/subscription/example-operator.v0.3.0.yaml
+++ b/staging/operator-lifecycle-manager/test/e2e/testdata/subscription/example-operator.v0.3.0.yaml
@@ -1,10 +1,10 @@
 ---
 schema: olm.package
-name: packageA
+name: test-package
 defaultChannel: stable
 ---
 schema: olm.channel
-package: packageA
+package: test-package
 name: stable
 entries:
   - name: example-operator.v0.3.0
@@ -12,7 +12,7 @@ entries:
 ---
 schema: olm.bundle
 name: example-operator.v0.3.0
-package: packageA
+package: test-package
 image: quay.io/olmtest/example-operator-bundle:0.3.0
 properties:
   - type: olm.gvk
@@ -22,5 +22,5 @@ properties:
       version: v1alpha1
   - type: olm.package
     value:
-      packageName: packageA
+      packageName: test-package
       version: 0.3.0


### PR DESCRIPTION
### Description
This PR unblocks the 4.15 pipeline by:
 * refactoring some of our test packages to conform to the new validation from opm (url type format, no capitals, etc.)
 * parameterizing the e2e job and pinning the opm image to the dependency version in go.mod
 * updating the skopeo test to handle some changes in the secret annotations (username/password no longer there - have to use the secret as an authfile now
 * pinning one of the test catalog images to the compatible version (given the operator-registry version in go.mod)
 * slipping in some flake patches for extra greeness and an update to go1.20

### Notes

I manually created and pushed quay.io/olmtest/test-catalog:v1.39.0 and it is statically pinned in the e2e command:

```
E2E_OPTS="-communityOperators=quay.io/olmtest/test-catalog:v1.39.0"
```

I'm currently fixing up the upstream jobs to automagically manage the e2e test fixture images [ref](https://github.com/operator-framework/operator-lifecycle-manager/pull/3310). So, I'll need to follow up with that to make it :chefs-kiss: