### PR TITLE
OPRUN-3221: 🌱 fix xplat compile for of-tools image; hide utest files from git; use rhel8 art builder image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -468,3 +468,6 @@ scripts/**/*.crc.e2e.patch.yaml
 
 # downstream sync sha files
 *.cherrypick
+
+# unit test artifacts
+vendor/github.com/operator-framework/operator-registry/pkg/lib/indexer/index.Dockerfile*


### PR DESCRIPTION
This change enables multi-platform image build. 

opm compile is a bit of an odd duck because it requires clang for sqlite integration, and is dependent on the linux/amd64 builder image to generate darwin/windows binaries.  Because of that dependency, the `cross` make target is only triggered for linux/amd64-based platforms. 

Instead of re-plumbing the entire build process for these binaries, this will use a wildcard to copy all opm binaries.  This is analogous to how [operator-registry](https://github.com/openshift/operator-framework-olm/blob/e45e646787c45749617a91aaa93f4b062beec131/operator-registry.Dockerfile#L16) does it, but restricting to just the opm binaries.

This results in linux/amd64 output:
```tree
└── tools                                           
    ├── darwin-amd64-opm                            
    ├── opm                                         
    ├── opm-rhel8                                   
    ├── opm-rhel9                                   
    └── windows-amd64-opm     
```

The cross-compiled binaries will still require ARCH/OS-specific [unpacking](https://github.com/openshift-eng/art-tools/blob/218243482ae5e7d6dd401a3e784d9f93e0c3f245/pyartcd/pyartcd/pipelines/promote.py#L762-L764) for mirrors.openshift.com