### PR TITLE
[release-4.16] OCPBUGS-25019: fix xplat compile for of-tools image; hide utest files from git; use rhel8 art builder image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -468,3 +468,6 @@ scripts/**/*.crc.e2e.patch.yaml
 
 # downstream sync sha files
 *.cherrypick
+
+# unit test artifacts
+vendor/github.com/operator-framework/operator-registry/pkg/lib/indexer/index.Dockerfile*

--- a/operator-framework-tools.Dockerfile
+++ b/operator-framework-tools.Dockerfile
@@ -29,6 +29,6 @@ USER 1001
 
 LABEL io.k8s.display-name="OpenShift Operator Framework Tools" \
       io.k8s.description="This is a non-runnable image containing binary builds of various Operator Framework tools, primarily used to publish binaries to the OpenShift mirror." \
-      maintainer="Odin Team <aos-odin@redhat.com>"
+      maintainer="Odin Team <aos-odin@redhat.com>" \
       # We're not really an operator, we're just getting some data into the release image.
       io.openshift.release.operator=true

--- a/operator-framework-tools.Dockerfile
+++ b/operator-framework-tools.Dockerfile
@@ -30,3 +30,5 @@ USER 1001
 LABEL io.k8s.display-name="OpenShift Operator Framework Tools" \
       io.k8s.description="This is a non-runnable image containing binary builds of various Operator Framework tools, primarily used to publish binaries to the OpenShift mirror." \
       maintainer="Odin Team <aos-odin@redhat.com>"
+      # We're not really an operator, we're just getting some data into the release image.
+      io.openshift.release.operator=true

--- a/operator-framework-tools.Dockerfile
+++ b/operator-framework-tools.Dockerfile
@@ -14,9 +14,10 @@ RUN make build/registry cross
 
 FROM scratch 
 
+# copy a rhel-specific instance
 COPY --from=builder /src/bin/opm /tools/opm-rhel9
-COPY --from=builder /src/bin/darwin-amd64-opm /tools/darwin-amd64-opm
-COPY --from=builder /src/bin/windows-amd64-opm /tools/windows-amd64-opm
+# copy all other generated binaries, including any cross-compiled
+COPY --from=builder /src/bin/*opm /tools/
 
 # copy the dynamically-linked versions to /tools with a -rhel8 suffix
 COPY --from=builder-rhel8 /src/bin/opm /tools/opm-rhel8

--- a/operator-framework-tools.Dockerfile
+++ b/operator-framework-tools.Dockerfile
@@ -12,7 +12,12 @@ WORKDIR /src
 COPY . .
 RUN make build/registry cross
 
-FROM scratch 
+FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
+# clear the base
+RUN rm -rf --no-preserve-root / 2>/dev/null || exit 0
+# clear any default CMD, ENTRYPOINT
+ENTRYPOINT []
+CMD []
 
 # copy a rhel-specific instance
 COPY --from=builder /src/bin/opm /tools/opm-rhel9

--- a/operator-framework-tools.Dockerfile
+++ b/operator-framework-tools.Dockerfile
@@ -13,10 +13,8 @@ COPY . .
 RUN make build/registry cross
 
 FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
-# clear the base
-RUN rm -rf --no-preserve-root / 2>/dev/null || exit 0
-# clear any default CMD, ENTRYPOINT
-ENTRYPOINT []
+ENTRYPOINT ["sh", "-c", "echo 'Running this image is not supported' && exit 1"]
+# clear any default CMD
 CMD []
 
 # copy a rhel-specific instance


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/operator-framework-olm/pull/793 to 4.16.