### PR TITLE
NO-ISSUE: Bump e2e timeout by 15 minutes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ e2e/operator-registry: ## Run e2e registry tests
 	$(MAKE) e2e WHAT=operator-registry
 
 e2e/olm: ## Run e2e olm tests
-	$(MAKE) e2e WHAT=operator-lifecycle-manager E2E_CATALOG_NS=openshift-marketplace E2E_INSTALL_NS=openshift-operator-lifecycle-manager E2E_TEST_NS=openshift-operators E2E_TIMEOUT=120m KUBECTL=oc
+	$(MAKE) e2e WHAT=operator-lifecycle-manager E2E_CATALOG_NS=openshift-marketplace E2E_INSTALL_NS=openshift-operator-lifecycle-manager E2E_TEST_NS=openshift-operators E2E_TIMEOUT=135m KUBECTL=oc
 
 .PHONY: vendor
 vendor:


### PR DESCRIPTION
We are experiencing e2e failures due to timeout. To improve signal I'm bumping the timeout by 15 minutes. We have an upstream PR that starts to move some of the fixtures to a local repo - maybe once that is complete we can get back to sub 2h.