### PR TITLE
[release-4.16] OCPBUGS-36138: perform operator apiService certificate validity checks directly

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/install/certresources.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/install/certresources.go
@@ -12,6 +12,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	rbacv1ac "k8s.io/client-go/applyconfigurations/rbac/v1"
 
@@ -161,6 +162,14 @@ func ServiceName(deploymentName string) string {
 	return deploymentName + "-service"
 }
 
+func HostnamesForService(serviceName, namespace string) []string {
+	return []string{
+		fmt.Sprintf("%s.%s", serviceName, namespace),
+		fmt.Sprintf("%s.%s.svc", serviceName, namespace),
+		fmt.Sprintf("%s.%s.svc.cluster.local", serviceName, namespace),
+	}
+}
+
 func (i *StrategyDeploymentInstaller) getCertResources() []certResource {
 	return append(i.apiServiceDescriptions, i.webhookDescriptions...)
 }
@@ -227,13 +236,72 @@ func (i *StrategyDeploymentInstaller) CertsRotated() bool {
 	return i.certificatesRotated
 }
 
-func ShouldRotateCerts(csv *v1alpha1.ClusterServiceVersion) bool {
+// shouldRotateCerts indicates whether an apiService cert should be rotated due to being
+// malformed, invalid, expired, inactive or within a specific freshness interval (DefaultCertMinFresh) before expiry.
+func shouldRotateCerts(certSecret *corev1.Secret, hosts []string) bool {
 	now := metav1.Now()
-	if !csv.Status.CertsRotateAt.IsZero() && csv.Status.CertsRotateAt.Before(&now) {
+	caPEM, ok := certSecret.Data[OLMCAPEMKey]
+	if !ok {
+		// missing CA cert in secret
+		return true
+	}
+	certPEM, ok := certSecret.Data["tls.crt"]
+	if !ok {
+		// missing cert in secret
 		return true
 	}
 
+	ca, err := certs.PEMToCert(caPEM)
+	if err != nil {
+		// malformed CA cert
+		return true
+	}
+	cert, err := certs.PEMToCert(certPEM)
+	if err != nil {
+		// malformed cert
+		return true
+	}
+
+	// check for cert freshness
+	if !certs.Active(ca) || now.Time.After(CalculateCertRotatesAt(ca.NotAfter)) ||
+		!certs.Active(cert) || now.Time.After(CalculateCertRotatesAt(cert.NotAfter)) {
+		return true
+	}
+
+	// Check validity of serving cert and if serving cert is trusted by the CA
+	for _, host := range hosts {
+		if err := certs.VerifyCert(ca, cert, host); err != nil {
+			return true
+		}
+	}
 	return false
+}
+
+func (i *StrategyDeploymentInstaller) ShouldRotateCerts(s Strategy) (bool, error) {
+	strategy, ok := s.(*v1alpha1.StrategyDetailsDeployment)
+	if !ok {
+		return false, fmt.Errorf("failed to install %s strategy with deployment installer: unsupported deployment install strategy", strategy.GetStrategyName())
+	}
+
+	hasCerts := sets.New[string]()
+	for _, c := range i.getCertResources() {
+		hasCerts.Insert(c.getDeploymentName())
+	}
+	for _, sddSpec := range strategy.DeploymentSpecs {
+		if hasCerts.Has(sddSpec.Name) {
+			certSecret, err := i.strategyClient.GetOpLister().CoreV1().SecretLister().Secrets(i.owner.GetNamespace()).Get(SecretName(ServiceName(sddSpec.Name)))
+			if err == nil {
+				if shouldRotateCerts(certSecret, HostnamesForService(ServiceName(sddSpec.Name), i.owner.GetNamespace())) {
+					return true, nil
+				}
+			} else if apierrors.IsNotFound(err) {
+				return true, nil
+			} else {
+				return false, err
+			}
+		}
+	}
+	return false, nil
 }
 
 func CalculateCertExpiration(startingFrom time.Time) time.Time {
@@ -271,10 +339,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 	}
 
 	// Create signed serving cert
-	hosts := []string{
-		fmt.Sprintf("%s.%s", serviceName, i.owner.GetNamespace()),
-		fmt.Sprintf("%s.%s.svc", serviceName, i.owner.GetNamespace()),
-	}
+	hosts := HostnamesForService(serviceName, i.owner.GetNamespace())
 	servingPair, err := certGenerator.Generate(expiration, Organization, ca, hosts)
 	if err != nil {
 		logger.Warnf("could not generate signed certs for hosts %v", hosts)
@@ -323,10 +388,10 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 
 		// Attempt an update
 		// TODO: Check that the secret was not modified
-		if existingCAPEM, ok := existingSecret.Data[OLMCAPEMKey]; ok && !ShouldRotateCerts(i.owner.(*v1alpha1.ClusterServiceVersion)) && existingSecret.Annotations[OpenShiftComponent] != "" {
+		if !shouldRotateCerts(existingSecret, HostnamesForService(serviceName, i.owner.GetNamespace())) {
 			logger.Warnf("reusing existing cert %s", secret.GetName())
 			secret = existingSecret
-			caPEM = existingCAPEM
+			caPEM = existingSecret.Data[OLMCAPEMKey]
 			caHash = certs.PEMSHA256(caPEM)
 		} else {
 			if _, err := i.strategyClient.GetOpClient().UpdateSecret(secret); err != nil {

--- a/staging/operator-lifecycle-manager/pkg/controller/install/resolver.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/install/resolver.go
@@ -21,6 +21,7 @@ type Strategy interface {
 type StrategyInstaller interface {
 	Install(strategy Strategy) error
 	CheckInstalled(strategy Strategy) (bool, error)
+	ShouldRotateCerts(strategy Strategy) (bool, error)
 	CertsRotateAt() time.Time
 	CertsRotated() bool
 }
@@ -78,4 +79,8 @@ func (i *NullStrategyInstaller) CertsRotateAt() time.Time {
 
 func (i *NullStrategyInstaller) CertsRotated() bool {
 	return false
+}
+
+func (i *NullStrategyInstaller) ShouldRotateCerts(s Strategy) (bool, error) {
+	return false, nil
 }

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
@@ -2242,7 +2242,10 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 		}
 
 		// Check if it's time to refresh owned APIService certs
-		if install.ShouldRotateCerts(out) {
+		if shouldRotate, err := installer.ShouldRotateCerts(strategy); err != nil {
+			logger.WithError(err).Info("cert validity check")
+			return
+		} else if shouldRotate {
 			logger.Debug("CSV owns resources that require a cert refresh")
 			out.SetPhaseWithEvent(v1alpha1.CSVPhasePending, v1alpha1.CSVReasonNeedsCertRotation, "CSV owns resources that require a cert refresh", now, a.recorder)
 			return
@@ -2352,7 +2355,10 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 		}
 
 		// Check if it's time to refresh owned APIService certs
-		if install.ShouldRotateCerts(out) {
+		if shouldRotate, err := installer.ShouldRotateCerts(strategy); err != nil {
+			logger.WithError(err).Info("cert validity check")
+			return
+		} else if shouldRotate {
 			logger.Debug("CSV owns resources that require a cert refresh")
 			out.SetPhaseWithEvent(v1alpha1.CSVPhasePending, v1alpha1.CSVReasonNeedsCertRotation, "owned APIServices need cert refresh", now, a.recorder)
 			return

--- a/staging/operator-lifecycle-manager/pkg/fakes/fake_strategy_installer.go
+++ b/staging/operator-lifecycle-manager/pkg/fakes/fake_strategy_installer.go
@@ -53,6 +53,19 @@ type FakeStrategyInstaller struct {
 	installReturnsOnCall map[int]struct {
 		result1 error
 	}
+	ShouldRotateCertsStub        func(install.Strategy) (bool, error)
+	shouldRotateCertsMutex       sync.RWMutex
+	shouldRotateCertsArgsForCall []struct {
+		arg1 install.Strategy
+	}
+	shouldRotateCertsReturns struct {
+		result1 bool
+		result2 error
+	}
+	shouldRotateCertsReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -288,6 +301,70 @@ func (fake *FakeStrategyInstaller) InstallReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeStrategyInstaller) ShouldRotateCerts(arg1 install.Strategy) (bool, error) {
+	fake.shouldRotateCertsMutex.Lock()
+	ret, specificReturn := fake.shouldRotateCertsReturnsOnCall[len(fake.shouldRotateCertsArgsForCall)]
+	fake.shouldRotateCertsArgsForCall = append(fake.shouldRotateCertsArgsForCall, struct {
+		arg1 install.Strategy
+	}{arg1})
+	stub := fake.ShouldRotateCertsStub
+	fakeReturns := fake.shouldRotateCertsReturns
+	fake.recordInvocation("ShouldRotateCerts", []interface{}{arg1})
+	fake.shouldRotateCertsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeStrategyInstaller) ShouldRotateCertsCallCount() int {
+	fake.shouldRotateCertsMutex.RLock()
+	defer fake.shouldRotateCertsMutex.RUnlock()
+	return len(fake.shouldRotateCertsArgsForCall)
+}
+
+func (fake *FakeStrategyInstaller) ShouldRotateCertsCalls(stub func(install.Strategy) (bool, error)) {
+	fake.shouldRotateCertsMutex.Lock()
+	defer fake.shouldRotateCertsMutex.Unlock()
+	fake.ShouldRotateCertsStub = stub
+}
+
+func (fake *FakeStrategyInstaller) ShouldRotateCertsArgsForCall(i int) install.Strategy {
+	fake.shouldRotateCertsMutex.RLock()
+	defer fake.shouldRotateCertsMutex.RUnlock()
+	argsForCall := fake.shouldRotateCertsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeStrategyInstaller) ShouldRotateCertsReturns(result1 bool, result2 error) {
+	fake.shouldRotateCertsMutex.Lock()
+	defer fake.shouldRotateCertsMutex.Unlock()
+	fake.ShouldRotateCertsStub = nil
+	fake.shouldRotateCertsReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeStrategyInstaller) ShouldRotateCertsReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.shouldRotateCertsMutex.Lock()
+	defer fake.shouldRotateCertsMutex.Unlock()
+	fake.ShouldRotateCertsStub = nil
+	if fake.shouldRotateCertsReturnsOnCall == nil {
+		fake.shouldRotateCertsReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.shouldRotateCertsReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeStrategyInstaller) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -299,6 +376,8 @@ func (fake *FakeStrategyInstaller) Invocations() map[string][][]interface{} {
 	defer fake.checkInstalledMutex.RUnlock()
 	fake.installMutex.RLock()
 	defer fake.installMutex.RUnlock()
+	fake.shouldRotateCertsMutex.RLock()
+	defer fake.shouldRotateCertsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/staging/operator-lifecycle-manager/test/e2e/csv_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/csv_e2e_test.go
@@ -1657,7 +1657,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 				<-deleted
 			}()
 
-			fetchedCSV, err := fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.Name, csvSucceededChecker)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			By("Should create Deployment")
@@ -1698,11 +1698,15 @@ var _ = Describe("ClusterServiceVersion", func() {
 			oldCAAnnotation, ok := dep.Spec.Template.GetAnnotations()[install.OLMCAHashAnnotationKey]
 			Expect(ok).Should(BeTrue(), "expected olm sha annotation not present on existing pod template")
 
-			By("Induce a cert rotation")
-			Eventually(Apply(fetchedCSV, func(csv *operatorsv1alpha1.ClusterServiceVersion) error {
-				now := metav1.Now()
-				csv.Status.CertsLastUpdated = &now
-				csv.Status.CertsRotateAt = &now
+			caSecret, err := c.KubernetesInterface().CoreV1().Secrets(generatedNamespace.GetName()).Get(context.TODO(), secretName, metav1.GetOptions{})
+			Expect(err).Should(BeNil())
+
+			caPEM, certPEM, privPEM := generateExpiredCerts(install.HostnamesForService(serviceName, generatedNamespace.GetName()))
+			By(`Induce a cert rotation`)
+			Eventually(Apply(caSecret, func(caSecret *corev1.Secret) error {
+				caSecret.Data[install.OLMCAPEMKey] = caPEM
+				caSecret.Data["tls.crt"] = certPEM
+				caSecret.Data["tls.key"] = privPEM
 				return nil
 			})).Should(Succeed())
 
@@ -1737,7 +1741,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			By("Wait for CSV success")
-			fetchedCSV, err = fetchCSV(crc, generatedNamespace.GetName(), csv.GetName(), func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
+			_, err = fetchCSV(crc, generatedNamespace.GetName(), csv.GetName(), func(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
 				By("Should create an APIService")
 				apiService, err := c.GetAPIService(apiServiceName)
 				if err != nil {

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install/certresources.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install/certresources.go
@@ -12,6 +12,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	rbacv1ac "k8s.io/client-go/applyconfigurations/rbac/v1"
 
@@ -161,6 +162,14 @@ func ServiceName(deploymentName string) string {
 	return deploymentName + "-service"
 }
 
+func HostnamesForService(serviceName, namespace string) []string {
+	return []string{
+		fmt.Sprintf("%s.%s", serviceName, namespace),
+		fmt.Sprintf("%s.%s.svc", serviceName, namespace),
+		fmt.Sprintf("%s.%s.svc.cluster.local", serviceName, namespace),
+	}
+}
+
 func (i *StrategyDeploymentInstaller) getCertResources() []certResource {
 	return append(i.apiServiceDescriptions, i.webhookDescriptions...)
 }
@@ -227,13 +236,72 @@ func (i *StrategyDeploymentInstaller) CertsRotated() bool {
 	return i.certificatesRotated
 }
 
-func ShouldRotateCerts(csv *v1alpha1.ClusterServiceVersion) bool {
+// shouldRotateCerts indicates whether an apiService cert should be rotated due to being
+// malformed, invalid, expired, inactive or within a specific freshness interval (DefaultCertMinFresh) before expiry.
+func shouldRotateCerts(certSecret *corev1.Secret, hosts []string) bool {
 	now := metav1.Now()
-	if !csv.Status.CertsRotateAt.IsZero() && csv.Status.CertsRotateAt.Before(&now) {
+	caPEM, ok := certSecret.Data[OLMCAPEMKey]
+	if !ok {
+		// missing CA cert in secret
+		return true
+	}
+	certPEM, ok := certSecret.Data["tls.crt"]
+	if !ok {
+		// missing cert in secret
 		return true
 	}
 
+	ca, err := certs.PEMToCert(caPEM)
+	if err != nil {
+		// malformed CA cert
+		return true
+	}
+	cert, err := certs.PEMToCert(certPEM)
+	if err != nil {
+		// malformed cert
+		return true
+	}
+
+	// check for cert freshness
+	if !certs.Active(ca) || now.Time.After(CalculateCertRotatesAt(ca.NotAfter)) ||
+		!certs.Active(cert) || now.Time.After(CalculateCertRotatesAt(cert.NotAfter)) {
+		return true
+	}
+
+	// Check validity of serving cert and if serving cert is trusted by the CA
+	for _, host := range hosts {
+		if err := certs.VerifyCert(ca, cert, host); err != nil {
+			return true
+		}
+	}
 	return false
+}
+
+func (i *StrategyDeploymentInstaller) ShouldRotateCerts(s Strategy) (bool, error) {
+	strategy, ok := s.(*v1alpha1.StrategyDetailsDeployment)
+	if !ok {
+		return false, fmt.Errorf("failed to install %s strategy with deployment installer: unsupported deployment install strategy", strategy.GetStrategyName())
+	}
+
+	hasCerts := sets.New[string]()
+	for _, c := range i.getCertResources() {
+		hasCerts.Insert(c.getDeploymentName())
+	}
+	for _, sddSpec := range strategy.DeploymentSpecs {
+		if hasCerts.Has(sddSpec.Name) {
+			certSecret, err := i.strategyClient.GetOpLister().CoreV1().SecretLister().Secrets(i.owner.GetNamespace()).Get(SecretName(ServiceName(sddSpec.Name)))
+			if err == nil {
+				if shouldRotateCerts(certSecret, HostnamesForService(ServiceName(sddSpec.Name), i.owner.GetNamespace())) {
+					return true, nil
+				}
+			} else if apierrors.IsNotFound(err) {
+				return true, nil
+			} else {
+				return false, err
+			}
+		}
+	}
+	return false, nil
 }
 
 func CalculateCertExpiration(startingFrom time.Time) time.Time {
@@ -271,10 +339,7 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 	}
 
 	// Create signed serving cert
-	hosts := []string{
-		fmt.Sprintf("%s.%s", serviceName, i.owner.GetNamespace()),
-		fmt.Sprintf("%s.%s.svc", serviceName, i.owner.GetNamespace()),
-	}
+	hosts := HostnamesForService(serviceName, i.owner.GetNamespace())
 	servingPair, err := certGenerator.Generate(expiration, Organization, ca, hosts)
 	if err != nil {
 		logger.Warnf("could not generate signed certs for hosts %v", hosts)
@@ -323,10 +388,10 @@ func (i *StrategyDeploymentInstaller) installCertRequirementsForDeployment(deplo
 
 		// Attempt an update
 		// TODO: Check that the secret was not modified
-		if existingCAPEM, ok := existingSecret.Data[OLMCAPEMKey]; ok && !ShouldRotateCerts(i.owner.(*v1alpha1.ClusterServiceVersion)) && existingSecret.Annotations[OpenShiftComponent] != "" {
+		if !shouldRotateCerts(existingSecret, HostnamesForService(serviceName, i.owner.GetNamespace())) {
 			logger.Warnf("reusing existing cert %s", secret.GetName())
 			secret = existingSecret
-			caPEM = existingCAPEM
+			caPEM = existingSecret.Data[OLMCAPEMKey]
 			caHash = certs.PEMSHA256(caPEM)
 		} else {
 			if _, err := i.strategyClient.GetOpClient().UpdateSecret(secret); err != nil {

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install/resolver.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install/resolver.go
@@ -21,6 +21,7 @@ type Strategy interface {
 type StrategyInstaller interface {
 	Install(strategy Strategy) error
 	CheckInstalled(strategy Strategy) (bool, error)
+	ShouldRotateCerts(strategy Strategy) (bool, error)
 	CertsRotateAt() time.Time
 	CertsRotated() bool
 }
@@ -78,4 +79,8 @@ func (i *NullStrategyInstaller) CertsRotateAt() time.Time {
 
 func (i *NullStrategyInstaller) CertsRotated() bool {
 	return false
+}
+
+func (i *NullStrategyInstaller) ShouldRotateCerts(s Strategy) (bool, error) {
+	return false, nil
 }

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
@@ -2242,7 +2242,10 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 		}
 
 		// Check if it's time to refresh owned APIService certs
-		if install.ShouldRotateCerts(out) {
+		if shouldRotate, err := installer.ShouldRotateCerts(strategy); err != nil {
+			logger.WithError(err).Info("cert validity check")
+			return
+		} else if shouldRotate {
 			logger.Debug("CSV owns resources that require a cert refresh")
 			out.SetPhaseWithEvent(v1alpha1.CSVPhasePending, v1alpha1.CSVReasonNeedsCertRotation, "CSV owns resources that require a cert refresh", now, a.recorder)
 			return
@@ -2352,7 +2355,10 @@ func (a *Operator) transitionCSVState(in v1alpha1.ClusterServiceVersion) (out *v
 		}
 
 		// Check if it's time to refresh owned APIService certs
-		if install.ShouldRotateCerts(out) {
+		if shouldRotate, err := installer.ShouldRotateCerts(strategy); err != nil {
+			logger.WithError(err).Info("cert validity check")
+			return
+		} else if shouldRotate {
 			logger.Debug("CSV owns resources that require a cert refresh")
 			out.SetPhaseWithEvent(v1alpha1.CSVPhasePending, v1alpha1.CSVReasonNeedsCertRotation, "owned APIServices need cert refresh", now, a.recorder)
 			return


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/operator-framework-olm/commit/56226d5893af4be48862a4d42375da09d90cc8a6 to 4.16