### PR TITLE
NO-ISSUE: Update e2e call to generate junit report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ e2e/operator-registry: ## Run e2e registry tests
 	$(MAKE) e2e WHAT=operator-registry
 
 e2e/olm: ## Run e2e olm tests
-	$(MAKE) e2e WHAT=operator-lifecycle-manager E2E_CATALOG_NS=openshift-marketplace E2E_INSTALL_NS=openshift-operator-lifecycle-manager E2E_TEST_NS=openshift-operators E2E_TIMEOUT=135m KUBECTL=oc
+	$(MAKE) e2e WHAT=operator-lifecycle-manager E2E_CATALOG_NS=openshift-marketplace E2E_INSTALL_NS=openshift-operator-lifecycle-manager E2E_TEST_NS=openshift-operators E2E_TIMEOUT=135m KUBECTL=oc GINKGO_OPTS="${GINKGO_OPTS} --junit-report olm-e2e-junit.xml "
 
 .PHONY: vendor
 vendor:


### PR DESCRIPTION
Modifies the olm e2e target to ask ginkgo to generate the junit report for the e2e run