### PR TITLE
[release-4.16] OCPBUGS-36450: Can't install operator on 4.15 after uninstalling it on a prior version 

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/bundle/bundle_unpacker_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/bundle/bundle_unpacker_test.go
@@ -1218,14 +1218,15 @@ func TestConfigMapUnpacker(t *testing.T) {
 			},
 		},
 		{
-			description: "CatalogSourcePresent/JobFailed/BundleLookupFailed/WithJobFailReason",
+			description: "CatalogSourcePresent/JobFailed/BundleLookupFailed/WithJobFailReasonNoLabel",
 			fields: fields{
 				objs: []runtime.Object{
 					&batchv1.Job{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      pathHash,
 							Namespace: "ns-a",
-							Labels:    map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue, bundleUnpackRefLabel: pathHash},
+							//omit the "operatorframework.io/bundle-unpack-ref" label
+							Labels: map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 							OwnerReferences: []metav1.OwnerReference{
 								{
 									APIVersion:         "v1",
@@ -1442,6 +1443,9 @@ func TestConfigMapUnpacker(t *testing.T) {
 				},
 			},
 			expected: expected{
+				// If job is not found due to missing "operatorframework.io/bundle-unpack-ref" label,
+				// we will get an 'AlreadyExists' error in this test when the new job is created
+				err: nil,
 				res: &BundleUnpackResult{
 					name: pathHash,
 					BundleLookup: &operatorsv1alpha1.BundleLookup{
@@ -1474,7 +1478,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      pathHash,
 							Namespace: "ns-a",
-							Labels:    map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue, bundleUnpackRefLabel: pathHash},
+							Labels:    map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 							OwnerReferences: []metav1.OwnerReference{
 								{
 									APIVersion:         "v1",


### PR DESCRIPTION
Manual Cherry pick of commits from #758 

Awaiting verification for OCPBUGS-32439.
/hold 
