### PR TITLE
[release-4.14] OCPBUGS-36452: Can't install operator on 4.15 after uninstalling it on a prior version

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/bundle/bundle_unpacker.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/bundle/bundle_unpacker.go
@@ -663,6 +663,19 @@ func (c *ConfigMapUnpacker) ensureJob(cmRef *corev1.ObjectReference, bundlePath 
 	if err != nil {
 		return
 	}
+
+	// This is to ensure that we account for any existing unpack jobs that may be missing the label
+	jobWithoutLabel, err := c.jobLister.Jobs(fresh.GetNamespace()).Get(cmRef.Name)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return
+	}
+	if jobWithoutLabel != nil {
+		_, labelExists := jobWithoutLabel.Labels[bundleUnpackRefLabel]
+		if !labelExists {
+			jobs = append(jobs, jobWithoutLabel)
+		}
+	}
+
 	if len(jobs) == 0 {
 		job, err = c.client.BatchV1().Jobs(fresh.GetNamespace()).Create(context.TODO(), fresh, metav1.CreateOptions{})
 		return

--- a/staging/operator-lifecycle-manager/pkg/controller/bundle/bundle_unpacker_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/bundle/bundle_unpacker_test.go
@@ -1196,14 +1196,15 @@ func TestConfigMapUnpacker(t *testing.T) {
 			},
 		},
 		{
-			description: "CatalogSourcePresent/JobFailed/BundleLookupFailed/WithJobFailReason",
+			description: "CatalogSourcePresent/JobFailed/BundleLookupFailed/WithJobFailReasonNoLabel",
 			fields: fields{
 				objs: []runtime.Object{
 					&batchv1.Job{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      pathHash,
 							Namespace: "ns-a",
-							Labels:    map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue, bundleUnpackRefLabel: pathHash},
+							//omit the "operatorframework.io/bundle-unpack-ref" label
+							Labels: map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 							OwnerReferences: []metav1.OwnerReference{
 								{
 									APIVersion:         "v1",
@@ -1415,6 +1416,9 @@ func TestConfigMapUnpacker(t *testing.T) {
 				},
 			},
 			expected: expected{
+				// If job is not found due to missing "operatorframework.io/bundle-unpack-ref" label,
+				// we will get an 'AlreadyExists' error in this test when the new job is created
+				err: nil,
 				res: &BundleUnpackResult{
 					name: pathHash,
 					BundleLookup: &operatorsv1alpha1.BundleLookup{
@@ -1447,7 +1451,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      pathHash,
 							Namespace: "ns-a",
-							Labels:    map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue, bundleUnpackRefLabel: pathHash},
+							Labels:    map[string]string{install.OLMManagedLabelKey: install.OLMManagedLabelValue},
 							OwnerReferences: []metav1.OwnerReference{
 								{
 									APIVersion:         "v1",

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/bundle/bundle_unpacker.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/bundle/bundle_unpacker.go
@@ -663,6 +663,19 @@ func (c *ConfigMapUnpacker) ensureJob(cmRef *corev1.ObjectReference, bundlePath 
 	if err != nil {
 		return
 	}
+
+	// This is to ensure that we account for any existing unpack jobs that may be missing the label
+	jobWithoutLabel, err := c.jobLister.Jobs(fresh.GetNamespace()).Get(cmRef.Name)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return
+	}
+	if jobWithoutLabel != nil {
+		_, labelExists := jobWithoutLabel.Labels[bundleUnpackRefLabel]
+		if !labelExists {
+			jobs = append(jobs, jobWithoutLabel)
+		}
+	}
+
 	if len(jobs) == 0 {
 		job, err = c.client.BatchV1().Jobs(fresh.GetNamespace()).Create(context.TODO(), fresh, metav1.CreateOptions{})
 		return


### PR DESCRIPTION
Manual Cherry pick of commits from https://github.com/openshift/operator-framework-olm/pull/758