### PR TITLE
OCPBUGS-35970: add io.openshift.release.operator label to image

### DIFF
--- a/operator-framework-tools.Dockerfile
+++ b/operator-framework-tools.Dockerfile
@@ -29,6 +29,6 @@ USER 1001
 
 LABEL io.k8s.display-name="OpenShift Operator Framework Tools" \
       io.k8s.description="This is a non-runnable image containing binary builds of various Operator Framework tools, primarily used to publish binaries to the OpenShift mirror." \
-      maintainer="Odin Team <aos-odin@redhat.com>"
+      maintainer="Odin Team <aos-odin@redhat.com>" \
       # We're not really an operator, we're just getting some data into the release image.
       io.openshift.release.operator=true

--- a/operator-framework-tools.Dockerfile
+++ b/operator-framework-tools.Dockerfile
@@ -30,3 +30,5 @@ USER 1001
 LABEL io.k8s.display-name="OpenShift Operator Framework Tools" \
       io.k8s.description="This is a non-runnable image containing binary builds of various Operator Framework tools, primarily used to publish binaries to the OpenShift mirror." \
       maintainer="Odin Team <aos-odin@redhat.com>"
+      # We're not really an operator, we're just getting some data into the release image.
+      io.openshift.release.operator=true


### PR DESCRIPTION
we want to make the image shows up in release payload
Ref https://docs.ci.openshift.org/docs/how-tos/onboarding-a-new-component/#product-builds-and-becoming-part-of-an-openshift-release