### PR TITLE
OCPBUGS-36500: remove cvo hypershift profile annotation from psm-operator manifests

### DIFF
--- a/manifests/0000_50_olm_00-catalogsources.crd.yaml
+++ b/manifests/0000_50_olm_00-catalogsources.crd.yaml
@@ -4,9 +4,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
   name: catalogsources.operators.coreos.com
 spec:
   group: operators.coreos.com

--- a/manifests/0000_50_olm_00-clusterserviceversions.crd.yaml
+++ b/manifests/0000_50_olm_00-clusterserviceversions.crd.yaml
@@ -4,9 +4,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
   name: clusterserviceversions.operators.coreos.com
 spec:
   group: operators.coreos.com

--- a/manifests/0000_50_olm_00-installplans.crd.yaml
+++ b/manifests/0000_50_olm_00-installplans.crd.yaml
@@ -4,9 +4,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
   name: installplans.operators.coreos.com
 spec:
   group: operators.coreos.com

--- a/manifests/0000_50_olm_00-namespace.yaml
+++ b/manifests/0000_50_olm_00-namespace.yaml
@@ -11,9 +11,9 @@ metadata:
     openshift.io/node-selector: ""
     workload.openshift.io/allowed: "management"
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 ---
 apiVersion: v1
 kind: Namespace
@@ -27,6 +27,6 @@ metadata:
     openshift.io/node-selector: ""
     workload.openshift.io/allowed: "management"
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"

--- a/manifests/0000_50_olm_00-olmconfigs.crd.yaml
+++ b/manifests/0000_50_olm_00-olmconfigs.crd.yaml
@@ -4,9 +4,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
   name: olmconfigs.operators.coreos.com
 spec:
   group: operators.coreos.com

--- a/manifests/0000_50_olm_00-operatorconditions.crd.yaml
+++ b/manifests/0000_50_olm_00-operatorconditions.crd.yaml
@@ -4,9 +4,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
   name: operatorconditions.operators.coreos.com
 spec:
   group: operators.coreos.com

--- a/manifests/0000_50_olm_00-operatorgroups.crd.yaml
+++ b/manifests/0000_50_olm_00-operatorgroups.crd.yaml
@@ -4,9 +4,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
   name: operatorgroups.operators.coreos.com
 spec:
   group: operators.coreos.com

--- a/manifests/0000_50_olm_00-operators.crd.yaml
+++ b/manifests/0000_50_olm_00-operators.crd.yaml
@@ -4,9 +4,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
   name: operators.operators.coreos.com
 spec:
   group: operators.coreos.com

--- a/manifests/0000_50_olm_00-packageserver.pdb.yaml
+++ b/manifests/0000_50_olm_00-packageserver.pdb.yaml
@@ -5,9 +5,9 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 spec:
   maxUnavailable: 1
   selector:

--- a/manifests/0000_50_olm_00-subscriptions.crd.yaml
+++ b/manifests/0000_50_olm_00-subscriptions.crd.yaml
@@ -4,9 +4,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
   name: subscriptions.operators.coreos.com
 spec:
   group: operators.coreos.com

--- a/manifests/0000_50_olm_01-olm-operator.serviceaccount.yaml
+++ b/manifests/0000_50_olm_01-olm-operator.serviceaccount.yaml
@@ -5,9 +5,9 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -15,9 +15,9 @@ metadata:
   name: system:controller:operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 rules:
   - apiGroups: ["*"]
     resources: ["*"]
@@ -40,9 +40,9 @@ metadata:
   name: olm-operator-binding-openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/0000_50_olm_02-olmconfig.yaml
+++ b/manifests/0000_50_olm_02-olmconfig.yaml
@@ -5,6 +5,6 @@ metadata:
   annotations:
     release.openshift.io/create-only: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"

--- a/manifests/0000_50_olm_02-services.yaml
+++ b/manifests/0000_50_olm_02-services.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: olm-operator-serving-cert
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
   labels:
     app: olm-operator
 spec:
@@ -29,9 +29,9 @@ metadata:
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: catalog-operator-serving-cert
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
   labels:
     app: catalog-operator
 spec:

--- a/manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
+++ b/manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
@@ -7,7 +7,6 @@ metadata:
     app: package-server-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 spec:
   strategy:

--- a/manifests/0000_50_olm_06-psm-operator.service.yaml
+++ b/manifests/0000_50_olm_06-psm-operator.service.yaml
@@ -5,7 +5,6 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     service.alpha.openshift.io/serving-cert-secret-name: package-server-manager-serving-cert
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   name: package-server-manager-metrics
   namespace: openshift-operator-lifecycle-manager

--- a/manifests/0000_50_olm_06-psm-operator.servicemonitor.yaml
+++ b/manifests/0000_50_olm_06-psm-operator.servicemonitor.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 spec:
   endpoints:

--- a/manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
+++ b/manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
@@ -7,8 +7,8 @@ metadata:
     app: olm-operator
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 spec:
   strategy:
     type: Recreate

--- a/manifests/0000_50_olm_08-catalog-operator.deployment.ibm-cloud-managed.yaml
+++ b/manifests/0000_50_olm_08-catalog-operator.deployment.ibm-cloud-managed.yaml
@@ -7,8 +7,8 @@ metadata:
     app: catalog-operator
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 spec:
   strategy:
     type: Recreate

--- a/manifests/0000_50_olm_09-aggregated.clusterrole.yaml
+++ b/manifests/0000_50_olm_09-aggregated.clusterrole.yaml
@@ -8,9 +8,9 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 rules:
   - apiGroups: ["operators.coreos.com"]
     resources: ["subscriptions"]
@@ -30,9 +30,9 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 rules:
   - apiGroups: ["operators.coreos.com"]
     resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions", "operatorgroups"]

--- a/manifests/0000_50_olm_11-olm-operators.configmap.removed.yaml
+++ b/manifests/0000_50_olm_11-olm-operators.configmap.removed.yaml
@@ -6,6 +6,6 @@ metadata:
   annotations:
     release.openshift.io/delete: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"

--- a/manifests/0000_50_olm_12-olm-operators.catalogsource.removed.yaml
+++ b/manifests/0000_50_olm_12-olm-operators.catalogsource.removed.yaml
@@ -6,6 +6,6 @@ metadata:
   annotations:
     release.openshift.io/delete: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"

--- a/manifests/0000_50_olm_13-operatorgroup-default.yaml
+++ b/manifests/0000_50_olm_13-operatorgroup-default.yaml
@@ -5,9 +5,9 @@ metadata:
   namespace: openshift-operators
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 ---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
@@ -16,9 +16,9 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 spec:
   targetNamespaces:
     - openshift-operator-lifecycle-manager

--- a/manifests/0000_50_olm_14-packageserver.subscription.removed.yaml
+++ b/manifests/0000_50_olm_14-packageserver.subscription.removed.yaml
@@ -6,6 +6,6 @@ metadata:
   annotations:
     release.openshift.io/delete: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"

--- a/manifests/0000_50_olm_15-csv-viewer.rbac.yaml
+++ b/manifests/0000_50_olm_15-csv-viewer.rbac.yaml
@@ -4,9 +4,9 @@ metadata:
   annotations:
     rbac.authorization.kubernetes.io/autoupdate: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
   name: copied-csv-viewer
   namespace: openshift
 rules:
@@ -25,9 +25,9 @@ metadata:
   annotations:
     rbac.authorization.kubernetes.io/autoupdate: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
   name: copied-csv-viewers
   namespace: openshift
 roleRef:

--- a/manifests/0000_50_olm_99-operatorstatus.yaml
+++ b/manifests/0000_50_olm_99-operatorstatus.yaml
@@ -4,9 +4,9 @@ metadata:
   name: operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 status:
   versions:
     - name: operator
@@ -23,9 +23,9 @@ metadata:
   name: operator-lifecycle-manager-catalog
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 status:
   versions:
     - name: operator
@@ -41,9 +41,9 @@ metadata:
   name: operator-lifecycle-manager-packageserver
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 status:
   versions:
     - name: operator

--- a/manifests/0000_90_olm_00-service-monitor.yaml
+++ b/manifests/0000_90_olm_00-service-monitor.yaml
@@ -5,9 +5,9 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 rules:
   - apiGroups:
       - ""
@@ -27,9 +27,9 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -48,9 +48,9 @@ metadata:
     app: olm-operator
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -82,9 +82,9 @@ metadata:
     app: catalog-operator
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/manifests/0000_90_olm_01-prometheus-rule.yaml
+++ b/manifests/0000_90_olm_01-prometheus-rule.yaml
@@ -8,9 +8,9 @@ metadata:
     role: alert-rules
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 spec:
   groups:
     - name: olm.csv_abnormal.rules

--- a/microshift-manifests/0000_50_olm_00-catalogsources.crd.yaml
+++ b/microshift-manifests/0000_50_olm_00-catalogsources.crd.yaml
@@ -4,9 +4,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
   name: catalogsources.operators.coreos.com
 spec:
   group: operators.coreos.com

--- a/microshift-manifests/0000_50_olm_00-clusterserviceversions.crd.yaml
+++ b/microshift-manifests/0000_50_olm_00-clusterserviceversions.crd.yaml
@@ -4,9 +4,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
   name: clusterserviceversions.operators.coreos.com
 spec:
   group: operators.coreos.com

--- a/microshift-manifests/0000_50_olm_00-installplans.crd.yaml
+++ b/microshift-manifests/0000_50_olm_00-installplans.crd.yaml
@@ -4,9 +4,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
   name: installplans.operators.coreos.com
 spec:
   group: operators.coreos.com

--- a/microshift-manifests/0000_50_olm_00-namespace.yaml
+++ b/microshift-manifests/0000_50_olm_00-namespace.yaml
@@ -11,9 +11,9 @@ metadata:
     openshift.io/node-selector: ""
     workload.openshift.io/allowed: "management"
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 ---
 apiVersion: v1
 kind: Namespace
@@ -27,6 +27,6 @@ metadata:
     openshift.io/node-selector: ""
     workload.openshift.io/allowed: "management"
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"

--- a/microshift-manifests/0000_50_olm_00-olmconfigs.crd.yaml
+++ b/microshift-manifests/0000_50_olm_00-olmconfigs.crd.yaml
@@ -4,9 +4,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
   name: olmconfigs.operators.coreos.com
 spec:
   group: operators.coreos.com

--- a/microshift-manifests/0000_50_olm_00-operatorconditions.crd.yaml
+++ b/microshift-manifests/0000_50_olm_00-operatorconditions.crd.yaml
@@ -4,9 +4,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
   name: operatorconditions.operators.coreos.com
 spec:
   group: operators.coreos.com

--- a/microshift-manifests/0000_50_olm_00-operatorgroups.crd.yaml
+++ b/microshift-manifests/0000_50_olm_00-operatorgroups.crd.yaml
@@ -4,9 +4,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
   name: operatorgroups.operators.coreos.com
 spec:
   group: operators.coreos.com

--- a/microshift-manifests/0000_50_olm_00-operators.crd.yaml
+++ b/microshift-manifests/0000_50_olm_00-operators.crd.yaml
@@ -4,9 +4,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
   name: operators.operators.coreos.com
 spec:
   group: operators.coreos.com

--- a/microshift-manifests/0000_50_olm_00-packageserver.pdb.yaml
+++ b/microshift-manifests/0000_50_olm_00-packageserver.pdb.yaml
@@ -5,9 +5,9 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 spec:
   maxUnavailable: 1
   selector:

--- a/microshift-manifests/0000_50_olm_00-subscriptions.crd.yaml
+++ b/microshift-manifests/0000_50_olm_00-subscriptions.crd.yaml
@@ -4,9 +4,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
   name: subscriptions.operators.coreos.com
 spec:
   group: operators.coreos.com

--- a/microshift-manifests/0000_50_olm_01-olm-operator.serviceaccount.yaml
+++ b/microshift-manifests/0000_50_olm_01-olm-operator.serviceaccount.yaml
@@ -5,9 +5,9 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -15,9 +15,9 @@ metadata:
   name: system:controller:operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 rules:
   - apiGroups: ["*"]
     resources: ["*"]
@@ -40,9 +40,9 @@ metadata:
   name: olm-operator-binding-openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/microshift-manifests/0000_50_olm_02-olmconfig.yaml
+++ b/microshift-manifests/0000_50_olm_02-olmconfig.yaml
@@ -5,6 +5,6 @@ metadata:
   annotations:
     release.openshift.io/create-only: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"

--- a/microshift-manifests/0000_50_olm_02-services.yaml
+++ b/microshift-manifests/0000_50_olm_02-services.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: olm-operator-serving-cert
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
   labels:
     app: olm-operator
 spec:
@@ -29,9 +29,9 @@ metadata:
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: catalog-operator-serving-cert
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
   labels:
     app: catalog-operator
 spec:

--- a/microshift-manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
+++ b/microshift-manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
@@ -7,7 +7,6 @@ metadata:
     app: package-server-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 spec:
   strategy:

--- a/microshift-manifests/0000_50_olm_06-psm-operator.service.yaml
+++ b/microshift-manifests/0000_50_olm_06-psm-operator.service.yaml
@@ -5,7 +5,6 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     service.alpha.openshift.io/serving-cert-secret-name: package-server-manager-serving-cert
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
   name: package-server-manager-metrics
   namespace: openshift-operator-lifecycle-manager

--- a/microshift-manifests/0000_50_olm_06-psm-operator.servicemonitor.yaml
+++ b/microshift-manifests/0000_50_olm_06-psm-operator.servicemonitor.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
 spec:
   endpoints:

--- a/microshift-manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
+++ b/microshift-manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
@@ -7,8 +7,8 @@ metadata:
     app: olm-operator
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 spec:
   strategy:
     type: Recreate

--- a/microshift-manifests/0000_50_olm_08-catalog-operator.deployment.ibm-cloud-managed.yaml
+++ b/microshift-manifests/0000_50_olm_08-catalog-operator.deployment.ibm-cloud-managed.yaml
@@ -7,8 +7,8 @@ metadata:
     app: catalog-operator
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 spec:
   strategy:
     type: Recreate

--- a/microshift-manifests/0000_50_olm_09-aggregated.clusterrole.yaml
+++ b/microshift-manifests/0000_50_olm_09-aggregated.clusterrole.yaml
@@ -8,9 +8,9 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 rules:
   - apiGroups: ["operators.coreos.com"]
     resources: ["subscriptions"]
@@ -30,9 +30,9 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 rules:
   - apiGroups: ["operators.coreos.com"]
     resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions", "operatorgroups"]

--- a/microshift-manifests/0000_50_olm_11-olm-operators.configmap.removed.yaml
+++ b/microshift-manifests/0000_50_olm_11-olm-operators.configmap.removed.yaml
@@ -6,6 +6,6 @@ metadata:
   annotations:
     release.openshift.io/delete: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"

--- a/microshift-manifests/0000_50_olm_12-olm-operators.catalogsource.removed.yaml
+++ b/microshift-manifests/0000_50_olm_12-olm-operators.catalogsource.removed.yaml
@@ -6,6 +6,6 @@ metadata:
   annotations:
     release.openshift.io/delete: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"

--- a/microshift-manifests/0000_50_olm_13-operatorgroup-default.yaml
+++ b/microshift-manifests/0000_50_olm_13-operatorgroup-default.yaml
@@ -5,9 +5,9 @@ metadata:
   namespace: openshift-operators
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 ---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
@@ -16,9 +16,9 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 spec:
   targetNamespaces:
     - openshift-operator-lifecycle-manager

--- a/microshift-manifests/0000_50_olm_14-packageserver.subscription.removed.yaml
+++ b/microshift-manifests/0000_50_olm_14-packageserver.subscription.removed.yaml
@@ -6,6 +6,6 @@ metadata:
   annotations:
     release.openshift.io/delete: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"

--- a/microshift-manifests/0000_50_olm_15-csv-viewer.rbac.yaml
+++ b/microshift-manifests/0000_50_olm_15-csv-viewer.rbac.yaml
@@ -4,9 +4,9 @@ metadata:
   annotations:
     rbac.authorization.kubernetes.io/autoupdate: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
   name: copied-csv-viewer
   namespace: openshift-operator-lifecycle-manager
 rules:
@@ -25,9 +25,9 @@ metadata:
   annotations:
     rbac.authorization.kubernetes.io/autoupdate: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
   name: copied-csv-viewers
   namespace: openshift-operator-lifecycle-manager
 roleRef:

--- a/microshift-manifests/0000_50_olm_99-operatorstatus.yaml
+++ b/microshift-manifests/0000_50_olm_99-operatorstatus.yaml
@@ -4,9 +4,9 @@ metadata:
   name: operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 status:
   versions:
     - name: operator
@@ -23,9 +23,9 @@ metadata:
   name: operator-lifecycle-manager-catalog
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 status:
   versions:
     - name: operator
@@ -41,9 +41,9 @@ metadata:
   name: operator-lifecycle-manager-packageserver
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 status:
   versions:
     - name: operator

--- a/microshift-manifests/0000_90_olm_00-service-monitor.yaml
+++ b/microshift-manifests/0000_90_olm_00-service-monitor.yaml
@@ -5,9 +5,9 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 rules:
   - apiGroups:
       - ""
@@ -27,9 +27,9 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -48,9 +48,9 @@ metadata:
     app: olm-operator
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -82,9 +82,9 @@ metadata:
     app: catalog-operator
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/microshift-manifests/0000_90_olm_01-prometheus-rule.yaml
+++ b/microshift-manifests/0000_90_olm_01-prometheus-rule.yaml
@@ -8,9 +8,9 @@ metadata:
     role: alert-rules
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
 spec:
   groups:
     - name: olm.csv_abnormal.rules

--- a/scripts/generate_crds_manifests.sh
+++ b/scripts/generate_crds_manifests.sh
@@ -73,12 +73,10 @@ add_ibm_managed_cloud_annotations() {
    for f in "${manifests_dir}"/*.yaml; do
       if [[ ! "$(basename "${f}")" =~ .*\.deployment\..* ]]; then
          ${YQ} w -d'*' --inplace --style=double "$f" 'metadata.annotations['include.release.openshift.io/ibm-cloud-managed']' true
-         ${YQ} w -d'*' --inplace --style=double "$f" 'metadata.annotations['include.release.openshift.io/hypershift']' true
       else
          g="${f/%.yaml/.ibm-cloud-managed.yaml}"
          cp "${f}" "${g}"
          ${YQ} w -d'*' --inplace --style=double "$g" 'metadata.annotations['include.release.openshift.io/ibm-cloud-managed']' true
-         ${YQ} w -d'*' --inplace --style=double "$g" 'metadata.annotations['include.release.openshift.io/hypershift']' true
          ${YQ} w -d'*' --inplace --style=double "$g" 'metadata.annotations['capability.openshift.io/name']' OperatorLifecycleManager
          ${YQ} d -d'*' --inplace "$g" 'spec.template.spec.nodeSelector."node-role.kubernetes.io/master"'
       fi
@@ -496,6 +494,13 @@ subjects:
 EOF
 
 add_ibm_managed_cloud_annotations "${ROOT_DIR}/manifests"
+
+hypershift_manifests_dir="${ROOT_DIR}/manifests"
+for f in $(find "${hypershift_manifests_dir}" -type f -name "*.yaml"); do
+   if [[ ! "$f" =~ ".deployment.yaml" ]] && [[ ! "$(basename "${f}")" =~ "psm-operator" ]]; then
+      ${YQ} w -d'*' --inplace --style=double "$f" 'metadata.annotations['include.release.openshift.io/hypershift']' true
+   fi
+done
 
 find "${ROOT_DIR}/manifests" -type f -exec $SED -i "/^#/d" {} \;
 find "${ROOT_DIR}/manifests" -type f -exec $SED -i "1{/---/d}" {} \;


### PR DESCRIPTION
Remove cvo hypershift profile annotation from psm-operator manifests