### PR TITLE
NO-ISSUE: Update junit report file name to show spec results on Test Grid

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ e2e/olm: ## Run e2e olm tests
 	E2E_TEST_NS=openshift-operators \
 	E2E_TIMEOUT=135m \
 	KUBECTL=oc \
-	E2E_GINKGO_OPTS="$(if $(ARTIFACT_DIR),--output-dir='$(ARTIFACT_DIR)') --junit-report olm-e2e-junit.xml" \
+	E2E_GINKGO_OPTS="$(if $(ARTIFACT_DIR),--output-dir='$(ARTIFACT_DIR)') --junit-report junit_e2e.xml" \
 	$(MAKE) e2e
 
 .PHONY: vendor


### PR DESCRIPTION
I've noticed that the 4.14 test grid shows the individual spec results for the e2e tests. Looking at the diff between what we do in 4.17 and what we do in 4.14, it seems that the only difference is the filename. Updating the junit report filename back to 
`junit_e2e.xml`.

### 4.14

![Screenshot 2024-08-07 at 08 27 13](https://github.com/user-attachments/assets/007212cd-a202-46b7-a092-6046e4ba68b5)


### master (4.17)

![Screenshot 2024-08-07 at 08 27 06](https://github.com/user-attachments/assets/764350c3-c426-4094-aa64-92d50ada9143)
