### PR TITLE
Add bingo-update target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,8 +158,13 @@ vendor:
 	go mod vendor
 	go mod verify
 
+.PHONY: bingo-update
+bingo-update: ## Update bingo tools
+	#go install github.com/bwplotka/bingo@latest
+	bingo get
+
 .PHONY: manifests
-manifests: ## Generate manifests
+manifests: bingo-update ## Generate manifests
 	OLM_VERSION=$(OLM_VERSION) ./scripts/generate_crds_manifests.sh
 
 .PHONY: generate-manifests


### PR DESCRIPTION
This is required for generate-manifests that use a specific version of helm

Because this might be run in a container that doesn't already have bingo (i.e. operator-framework-tooling, a.k.a. bumper), install bingo as well.