### PR TITLE
NO-ISSUE: Manually Synchronize From Upstream Repositories (Sept. 6)

### DIFF
--- a/staging/operator-lifecycle-manager/go.mod
+++ b/staging/operator-lifecycle-manager/go.mod
@@ -178,13 +178,6 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-// pin to v1.18.0 until k8s.io/component-base updates its prometheus dependency
-// issue: https://github.com/operator-framework/operator-lifecycle-manager/issues/3283
-//replace (
-//	github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.18.0
-//	github.com/prometheus/common => github.com/prometheus/common v0.47.0
-//)
-
 // v1.64.0 breaks our e2e tests as it affects the grpc connection state transition
 // issue: https://github.com/operator-framework/operator-lifecycle-manager/issues/3284
 replace google.golang.org/grpc => google.golang.org/grpc v1.63.2

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/client-go/metadata/metadatalister"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/pager"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
@@ -2230,15 +2231,15 @@ func validateExistingCRs(dynamicClient dynamic.Interface, gr schema.GroupResourc
 			return fmt.Errorf("error creating validator for schema version %s: %s", version, err)
 		}
 		gvr := schema.GroupVersionResource{Group: gr.Group, Version: version, Resource: gr.Resource}
-		crList, err := dynamicClient.Resource(gvr).List(context.TODO(), metav1.ListOptions{})
-		if err != nil {
-			return fmt.Errorf("error listing resources in GroupVersionResource %#v: %s", gvr, err)
-		}
-
-		// validate each CR against this version schema
-		for _, cr := range crList.Items {
-			err = validation.ValidateCustomResource(field.NewPath(""), cr.UnstructuredContent(), validator).ToAggregate()
+		pager := pager.New(pager.SimplePageFunc(func(opts metav1.ListOptions) (runtime.Object, error) {
+			return dynamicClient.Resource(gvr).List(context.TODO(), opts)
+		}))
+		validationFn := func(obj runtime.Object) error {
+			err = validation.ValidateCustomResource(field.NewPath(""), obj, validator).ToAggregate()
 			if err != nil {
+				// lister will only provide unstructured objects as runtime.Object, so this should never fail to convert
+				// if it does, it's a programming error
+				cr := obj.(*unstructured.Unstructured)
 				var namespacedName string
 				if cr.GetNamespace() == "" {
 					namespacedName = cr.GetName()
@@ -2247,6 +2248,11 @@ func validateExistingCRs(dynamicClient dynamic.Interface, gr schema.GroupResourc
 				}
 				return validationError{fmt.Errorf("error validating %s %q: updated validation is too restrictive: %v", cr.GroupVersionKind(), namespacedName, err)}
 			}
+			return nil
+		}
+		err = pager.EachListItem(context.Background(), metav1.ListOptions{}, validationFn)
+		if err != nil {
+			return err
 		}
 	}
 	return nil

--- a/staging/operator-lifecycle-manager/test/e2e/installplan_e2e_test.go
+++ b/staging/operator-lifecycle-manager/test/e2e/installplan_e2e_test.go
@@ -1435,7 +1435,7 @@ var _ = Describe("Install Plan", func() {
 		// excluded: new CRD, same version, same schema - won't trigger a CRD update
 
 		tableEntries := []TableEntry{
-			Entry("[FLAKE] upgrade CRD with deprecated version", schemaPayload{
+			Entry("upgrade CRD with deprecated version", schemaPayload{
 				name:          "upgrade CRD with deprecated version",
 				expectedPhase: operatorsv1alpha1.InstallPlanPhaseComplete,
 				oldCRD: func() *apiextensionsv1.CustomResourceDefinition {
@@ -1471,7 +1471,7 @@ var _ = Describe("Install Plan", func() {
 						},
 						{
 							Name:    "v1alpha1",
-							Served:  false,
+							Served:  true,
 							Storage: false,
 							Schema: &apiextensionsv1.CustomResourceValidation{
 								OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
@@ -1631,7 +1631,6 @@ var _ = Describe("Install Plan", func() {
 			fetchedInstallPlan, err = fetchInstallPlan(GinkgoT(), crc, installPlanName, generatedNamespace.GetName(), buildInstallPlanPhaseCheckFunc(operatorsv1alpha1.InstallPlanPhaseComplete, operatorsv1alpha1.InstallPlanPhaseFailed))
 			require.NoError(GinkgoT(), err)
 			GinkgoT().Logf("Install plan %s fetched with status %s", fetchedInstallPlan.GetName(), fetchedInstallPlan.Status.Phase)
-
 			require.Equal(GinkgoT(), tt.expectedPhase, fetchedInstallPlan.Status.Phase)
 
 			By(`Ensure correct in-cluster resource(s)`)
@@ -1688,7 +1687,6 @@ var _ = Describe("Install Plan", func() {
 			validateCRDVersions(GinkgoT(), c, tt.oldCRD.GetName(), expectedVersions)
 			GinkgoT().Logf("All expected resources resolved %s", fetchedCSV.Status.Phase)
 		}, tableEntries)
-
 	})
 
 	Describe("update catalog for subscription", func() {

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/client-go/metadata/metadatalister"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/pager"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
@@ -2230,15 +2231,15 @@ func validateExistingCRs(dynamicClient dynamic.Interface, gr schema.GroupResourc
 			return fmt.Errorf("error creating validator for schema version %s: %s", version, err)
 		}
 		gvr := schema.GroupVersionResource{Group: gr.Group, Version: version, Resource: gr.Resource}
-		crList, err := dynamicClient.Resource(gvr).List(context.TODO(), metav1.ListOptions{})
-		if err != nil {
-			return fmt.Errorf("error listing resources in GroupVersionResource %#v: %s", gvr, err)
-		}
-
-		// validate each CR against this version schema
-		for _, cr := range crList.Items {
-			err = validation.ValidateCustomResource(field.NewPath(""), cr.UnstructuredContent(), validator).ToAggregate()
+		pager := pager.New(pager.SimplePageFunc(func(opts metav1.ListOptions) (runtime.Object, error) {
+			return dynamicClient.Resource(gvr).List(context.TODO(), opts)
+		}))
+		validationFn := func(obj runtime.Object) error {
+			err = validation.ValidateCustomResource(field.NewPath(""), obj, validator).ToAggregate()
 			if err != nil {
+				// lister will only provide unstructured objects as runtime.Object, so this should never fail to convert
+				// if it does, it's a programming error
+				cr := obj.(*unstructured.Unstructured)
 				var namespacedName string
 				if cr.GetNamespace() == "" {
 					namespacedName = cr.GetName()
@@ -2247,6 +2248,11 @@ func validateExistingCRs(dynamicClient dynamic.Interface, gr schema.GroupResourc
 				}
 				return validationError{fmt.Errorf("error validating %s %q: updated validation is too restrictive: %v", cr.GroupVersionKind(), namespacedName, err)}
 			}
+			return nil
+		}
+		err = pager.EachListItem(context.Background(), metav1.ListOptions{}, validationFn)
+		if err != nil {
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
The staging/ and vendor/ directories have been synchronized from the upstream repositories, pulling in the following commits:

| Date | Commit | Author | Message |
| -    | -      | -      | -       |
|2024-06-04 14:28:32|[operator-framework/operator-lifecycle-manager@dc67d18](https://github.com/operator-framework/operator-lifecycle-manager/commit/dc67d18c42ce16249cc5c32cf31a6b01feae92b0)|dependabot[bot]|build(deps): bump github.com/onsi/ginkgo/v2 from 2.17.3 to 2.19.0 (#3305)|
|2024-06-04 14:29:09|[operator-framework/operator-lifecycle-manager@f340322](https://github.com/operator-framework/operator-lifecycle-manager/commit/f3403221344b4b2170d0d59535b8be70920c3131)|dependabot[bot]|build(deps): bump github.com/itchyny/gojq from 0.12.15 to 0.12.16 (#3306)|
|2024-06-04 16:27:11|[operator-framework/operator-lifecycle-manager@a9bf0da](https://github.com/operator-framework/operator-lifecycle-manager/commit/a9bf0da0b610772fca122b069e380d65a4746e9a)|Per Goncalves da Silva|build(deps): bump github.com/operator-framework/operator-registry from v1.41 to v1.43.1 (#3282)|
|2024-06-04 18:45:38|[operator-framework/operator-lifecycle-manager@889ae50](https://github.com/operator-framework/operator-lifecycle-manager/commit/889ae50a66fe36a46a3c756a0ad7b481b73672f1)|dependabot[bot]|build(deps): bump github.com/evanphx/json-patch (#3304)|
|2024-06-11 06:04:16|[operator-framework/operator-lifecycle-manager@09935f0](https://github.com/operator-framework/operator-lifecycle-manager/commit/09935f00859e2a15007c4f6a9fefbfbfb0a49e71)|dependabot[bot]|build(deps): bump golang.org/x/net from 0.25.0 to 0.26.0 (#3312)|
|2024-06-11 06:04:36|[operator-framework/operator-lifecycle-manager@7406613](https://github.com/operator-framework/operator-lifecycle-manager/commit/74066131d293ee7e25989ca816975a09dc1f6d3c)|dependabot[bot]|build(deps): bump sigs.k8s.io/controller-runtime from 0.18.3 to 0.18.4 (#3313)|
|2024-06-11 06:27:38|[operator-framework/operator-lifecycle-manager@0d07970](https://github.com/operator-framework/operator-lifecycle-manager/commit/0d079704e1fef98edb32c6dcb4dbf35c9f882328)|dependabot[bot]|build(deps): bump goreleaser/goreleaser-action from 5 to 6 (#3314)|
|2024-06-11 06:54:33|[operator-framework/operator-lifecycle-manager@4fc8920](https://github.com/operator-framework/operator-lifecycle-manager/commit/4fc8920527c1fe295611636a0a530b69ed40c90d)|dependabot[bot]|build(deps): bump github.com/go-logr/logr from 1.4.1 to 1.4.2 (#3311)|
|2024-06-13 18:09:24|[operator-framework/operator-lifecycle-manager@59606f2](https://github.com/operator-framework/operator-lifecycle-manager/commit/59606f2864ea94bfe8780e075392e0daa27fb9df)|Joe Lanford|bump of/api to v0.26.0 (#3317)|
|2024-06-18 07:26:01|[operator-framework/operator-lifecycle-manager@3e4b80f](https://github.com/operator-framework/operator-lifecycle-manager/commit/3e4b80f533f9fd9584229a2e9e1bfb58d4ae9f33)|dependabot[bot]|build(deps): bump github.com/spf13/cobra from 1.8.0 to 1.8.1 (#3318)|
|2024-06-18 09:40:11|[operator-framework/operator-lifecycle-manager@f767a04](https://github.com/operator-framework/operator-lifecycle-manager/commit/f767a04b90f70589cd98a45c6a08c065e566a252)|dependabot[bot]|build(deps): bump k8s.io/code-generator from 0.30.1 to 0.30.2 (#3319)|
|2024-06-18 11:17:35|[operator-framework/operator-lifecycle-manager@287faae](https://github.com/operator-framework/operator-lifecycle-manager/commit/287faae0090011253e09981263354deaa4c651ad)|dependabot[bot]|build(deps): bump k8s.io/api from 0.30.1 to 0.30.2 (#3321)|
|2024-06-18 11:17:59|[operator-framework/operator-lifecycle-manager@fa8824c](https://github.com/operator-framework/operator-lifecycle-manager/commit/fa8824c460445822e3ad5d3058dc68867081e0df)|dependabot[bot]|build(deps): bump k8s.io/component-base from 0.30.1 to 0.30.2 (#3320)|
|2024-06-20 14:00:07|[operator-framework/operator-lifecycle-manager@20a3cbc](https://github.com/operator-framework/operator-lifecycle-manager/commit/20a3cbcde1f46ed7f4d56042ccc8b5d962e4d1b8)|Ankita Thomas|[OCPBUGS-34173]: fix sorting unpack jobs (#3299)|
|2024-06-20 15:19:53|[operator-framework/operator-lifecycle-manager@908da0c](https://github.com/operator-framework/operator-lifecycle-manager/commit/908da0c05363da40ad09ab774d9904b22aca7869)|Ankita Thomas|[OCPBUGS-25341]: perform operator apiService certificate validity checks directly (#3217)|
|2024-06-26 14:24:40|[operator-framework/operator-lifecycle-manager@63a2293](https://github.com/operator-framework/operator-lifecycle-manager/commit/63a2293b9b1bb5c48d30f6362bc9c04bc2ed1d1e)|Per Goncalves da Silva|Bump kubeapis to 0.30.2 (#3329)|
|2024-06-26 16:44:00|[operator-framework/operator-lifecycle-manager@5d32045](https://github.com/operator-framework/operator-lifecycle-manager/commit/5d32045dbe4f65526264f6115bff748d340a7cab)|Per Goncalves da Silva|make flake attempts an optional parameter (#3330)|
|2024-06-26 17:48:08|[operator-framework/operator-lifecycle-manager@75c3f58](https://github.com/operator-framework/operator-lifecycle-manager/commit/75c3f583056548eae4c39c4e918789d6a9ced70b)|Per Goncalves da Silva|drop --show-node-events from e2e call (#3331)|
|2024-06-26 17:59:10|[operator-framework/operator-lifecycle-manager@b8fb628](https://github.com/operator-framework/operator-lifecycle-manager/commit/b8fb628f6eae82d8a036e90b57bf61bd4e88761a)|Per Goncalves da Silva|build(deps): bump k8s.io/component-base from 0.30.1 to 0.30.2 (#3320) (#3293)|
|2024-07-02 15:35:05|[operator-framework/operator-lifecycle-manager@8615a10](https://github.com/operator-framework/operator-lifecycle-manager/commit/8615a10dcce46dadaa627916c76fbbf6dc47ad37)|Per Goncalves da Silva|update ginkgo opts (#3337)|
|2024-07-02 13:35:21|[operator-framework/operator-lifecycle-manager@2a24a0f](https://github.com/operator-framework/operator-lifecycle-manager/commit/2a24a0fe2dc97231e664672912a5b93936d5fcdb)|Jordan Keister|bump operator-registry to v1.44.0 (#3335)|
|2024-07-02 16:24:57|[operator-framework/operator-lifecycle-manager@25aa039](https://github.com/operator-framework/operator-lifecycle-manager/commit/25aa03958865dc80693621b37e32405b7b3d4ce0)|Per Goncalves da Silva|mark flaky tests (#3333)|
|2024-07-05 14:12:33|[operator-framework/operator-lifecycle-manager@dec7501](https://github.com/operator-framework/operator-lifecycle-manager/commit/dec75019712bd7393c2277313a28dc075d92c1bd)|Jordan Keister|fix space-in-name paths common to macs for unit test (#3338)|
|2024-07-09 07:32:44|[operator-framework/operator-lifecycle-manager@3985db9](https://github.com/operator-framework/operator-lifecycle-manager/commit/3985db97caf2ae0e78b3f793202537dd12ddda19)|dependabot[bot]|build(deps): bump golang.org/x/net from 0.26.0 to 0.27.0 (#3341)|
|2024-07-10 17:33:14|[operator-framework/operator-lifecycle-manager@d8500d8](https://github.com/operator-framework/operator-lifecycle-manager/commit/d8500d88932b17aa9b1853f0f26086f6ee6b35f9)|Per Goncalves da Silva|mark flaky test as flaky (#3340)|
|2024-07-19 23:22:01|[operator-framework/operator-lifecycle-manager@8089266](https://github.com/operator-framework/operator-lifecycle-manager/commit/808926666c1fe5c8c3ed1aab4defa4bcecd2ac55)|Joe Lanford|bump operator-registry to v1.45.0 (#3343)|
|2024-07-24 20:18:12|[operator-framework/operator-lifecycle-manager@0212102](https://github.com/operator-framework/operator-lifecycle-manager/commit/0212102655b24829cbbdb84eb5c59b92665f5ef8)|dependabot[bot]|build(deps): bump k8s.io/kube-aggregator from 0.30.2 to 0.30.3 (#3347)|
|2024-07-30 11:58:48|[operator-framework/operator-lifecycle-manager@e491fbd](https://github.com/operator-framework/operator-lifecycle-manager/commit/e491fbdf2188569853b1fe24e63cd82774e8cb74)|dependabot[bot]|build(deps): bump github.com/onsi/ginkgo/v2 from 2.19.0 to 2.19.1 (#3352)|
|2024-07-30 14:58:46|[operator-framework/operator-lifecycle-manager@4fafdb0](https://github.com/operator-framework/operator-lifecycle-manager/commit/4fafdb046f0e5402c61741eda70384191aabb74d)|dependabot[bot]|build(deps): bump github.com/docker/docker (#3353)|
|2024-07-30 14:59:12|[operator-framework/operator-lifecycle-manager@901ff5e](https://github.com/operator-framework/operator-lifecycle-manager/commit/901ff5ecb46a9e208ee7dfe00981d88b11a0af79)|dependabot[bot]|build(deps): bump k8s.io/apiextensions-apiserver from 0.30.2 to 0.30.3 (#3350)|
|2024-07-30 20:50:56|[operator-framework/operator-lifecycle-manager@f1d9acd](https://github.com/operator-framework/operator-lifecycle-manager/commit/f1d9acdf455f41a9d6d2ebf8993444da62271210)|Per Goncalves da Silva|build(deps): bump github.com/onsi/gomega from 1.33.1 to 1.34.1 (#3354)|
|2024-08-07 00:17:00|[operator-framework/operator-lifecycle-manager@9eae867](https://github.com/operator-framework/operator-lifecycle-manager/commit/9eae867f9705eb4b0a257d5a9243a85aaeab9c6e)|dependabot[bot]|build(deps): bump golang.org/x/time from 0.5.0 to 0.6.0 (#3357)|
|2024-08-07 10:50:13|[operator-framework/operator-lifecycle-manager@af80a7b](https://github.com/operator-framework/operator-lifecycle-manager/commit/af80a7bf2c6388a407bd5d0fc648acad6a7606ea)|dependabot[bot]|build(deps): bump golang.org/x/sync from 0.7.0 to 0.8.0 (#3358)|
|2024-08-07 22:40:56|[operator-framework/operator-lifecycle-manager@ff9084a](https://github.com/operator-framework/operator-lifecycle-manager/commit/ff9084a24b19848c02c2cd4b7d827e057f7f8b11)|Anik|(fix) Resolver: list CatSrc using client, instead of referring to registry-server cache (#3349)|
|2024-08-08 17:54:33|[operator-framework/operator-lifecycle-manager@f9ee98e](https://github.com/operator-framework/operator-lifecycle-manager/commit/f9ee98e8a1347d7749348ef9781fc0296f3f09c6)|Anik|Update owners (#3361)|
|2024-08-13 13:18:15|[operator-framework/operator-lifecycle-manager@4aede69](https://github.com/operator-framework/operator-lifecycle-manager/commit/4aede69cccd715b33a7d82ffe759ff4ef25efef0)|dependabot[bot]|build(deps): bump golang.org/x/net from 0.27.0 to 0.28.0 (#3362)|
|2024-08-13 13:19:51|[operator-framework/operator-lifecycle-manager@3a8bc57](https://github.com/operator-framework/operator-lifecycle-manager/commit/3a8bc57f758dd62fc82d2d5b7185f3f819ce5e9a)|dependabot[bot]|build(deps): bump sigs.k8s.io/controller-runtime from 0.18.4 to 0.18.5 (#3364)|
|2024-08-13 14:53:49|[operator-framework/operator-lifecycle-manager@6c4aeb5](https://github.com/operator-framework/operator-lifecycle-manager/commit/6c4aeb51130abe4567138f594ecede362d018ae4)|dependabot[bot]|build(deps): bump github.com/docker/docker (#3365)|
|2024-08-13 16:00:27|[operator-framework/operator-lifecycle-manager@3e446bd](https://github.com/operator-framework/operator-lifecycle-manager/commit/3e446bde895c9598621b9fdb88203fed4f3f3ad7)|dependabot[bot]|build(deps): bump github.com/onsi/ginkgo/v2 from 2.19.1 to 2.20.0 (#3363)|
|2024-08-13 16:22:58|[operator-framework/operator-lifecycle-manager@27f347e](https://github.com/operator-framework/operator-lifecycle-manager/commit/27f347e32a0461c4a00723901f066ccac9784b7f)|Tomasz Janiszewski|Retract v.3.11.0 (#3355)|
|2024-08-27 18:03:42|[operator-framework/operator-lifecycle-manager@c730fbc](https://github.com/operator-framework/operator-lifecycle-manager/commit/c730fbc779a80c036830d906ae2bb3a1890fbf99)|Per Goncalves da Silva|:seedling: bump all the things (#3374)|
|2024-08-29 14:31:14|[operator-framework/operator-lifecycle-manager@cd1364f](https://github.com/operator-framework/operator-lifecycle-manager/commit/cd1364faf84449e9c8beb815af4ccedd89f03b43)|Per Goncalves da Silva|:seedling: Bump bingo tools (#3379)|
|2024-08-30 20:21:24|[operator-framework/operator-lifecycle-manager@f243189](https://github.com/operator-framework/operator-lifecycle-manager/commit/f2431893193e7112f78298ad7682ff3e1b179d8c)|Anik|(fix) registry pods do not come up again after node failure (#3366)|
|2024-09-02 13:00:04|[operator-framework/operator-lifecycle-manager@578ad82](https://github.com/operator-framework/operator-lifecycle-manager/commit/578ad8284aed63707dcb1c6f53d655811194a1d3)|Per Goncalves da Silva|Remove go.mod commented out base-components version pin (#3380)|
|2024-09-05 16:13:14|[operator-framework/operator-lifecycle-manager@a273449](https://github.com/operator-framework/operator-lifecycle-manager/commit/a273449ff8e562b2bae7e0640a4725c6e23561ce)|Per Goncalves da Silva|Fix up CRD with deprecated version e2e flake (#3386)|
|2024-09-05 16:18:42|[operator-framework/operator-lifecycle-manager@48a856a](https://github.com/operator-framework/operator-lifecycle-manager/commit/48a856ab0972be8d421b454b854db117975f5cca)|Jordan Keister|adds paginating lister for evaluating CRs' upgrade fitness versus new CRDs. (#3387)|
|2024-05-15 19:31:14|[operator-framework/operator-registry@7de2fc5](https://github.com/operator-framework/operator-registry/commit/7de2fc5e9bbb318bc87cc1d41262be01af3bf82d)|P. Radha Krishna|Bump k8s libraries to v0.30.0 (#1297)|
|2024-05-17 11:28:34|[operator-framework/operator-registry@93e2a5d](https://github.com/operator-framework/operator-registry/commit/93e2a5d7ee988c06d30fdf0653212ac59f728b5d)|dependabot[bot]|build(deps): bump google.golang.org/grpc from 1.63.2 to 1.64.0 (#1315)|
|2024-05-17 11:29:03|[operator-framework/operator-registry@1d72940](https://github.com/operator-framework/operator-registry/commit/1d729408041d61206b48afe8fadfb2686c88b1eb)|dependabot[bot]|build(deps): bump k8s.io/apimachinery from 0.30.0 to 0.30.1 (#1314)|
|2024-05-17 11:41:08|[operator-framework/operator-registry@ff2a117](https://github.com/operator-framework/operator-registry/commit/ff2a117be593e3bfe91f0c2321988153ee9bcc49)|dependabot[bot]|build(deps): bump sigs.k8s.io/kind from 0.22.0 to 0.23.0 (#1313)|
|2024-05-17 11:49:09|[operator-framework/operator-registry@e7ca8e3](https://github.com/operator-framework/operator-registry/commit/e7ca8e38e03b6fe863d6123a40f66ee19d5d5b8d)|dependabot[bot]|build(deps): bump k8s.io/apiextensions-apiserver from 0.30.0 to 0.30.1 (#1312)|
|2024-05-17 12:55:09|[operator-framework/operator-registry@3a4d9e1](https://github.com/operator-framework/operator-registry/commit/3a4d9e1fe2d91517d8b4c9a420ebdbd2823c133a)|Joe Lanford|cache: fixup pogreb db permissions (#1317)|
|2024-05-21 08:04:21|[operator-framework/operator-registry@35df28c](https://github.com/operator-framework/operator-registry/commit/35df28cbcfe2e62a6530e414fc1fed29bcb171c6)|dependabot[bot]|build(deps): bump github.com/containers/common from 0.58.2 to 0.58.3 (#1318)|
|2024-05-21 08:05:01|[operator-framework/operator-registry@f33f389](https://github.com/operator-framework/operator-registry/commit/f33f3897c26d16434328caf90c062f618b833241)|dependabot[bot]|build(deps): bump github.com/docker/cli (#1319)|
|2024-05-21 08:25:20|[operator-framework/operator-registry@4e17217](https://github.com/operator-framework/operator-registry/commit/4e172177434f563e6137c7695d49f275da77d299)|dependabot[bot]|build(deps): bump github.com/containerd/containerd from 1.7.16 to 1.7.17 (#1320)|
|2024-05-22 07:40:50|[operator-framework/operator-registry@0f25229](https://github.com/operator-framework/operator-registry/commit/0f2522936a776dabfeb18653fa0038c41cc91848)|dependabot[bot]|--- (#1322)|
|2024-05-22 10:21:48|[operator-framework/operator-registry@da0b7d0](https://github.com/operator-framework/operator-registry/commit/da0b7d0e7a83cbe15115388d3d1725b2f8cbf6ae)|dependabot[bot]|--- (#1321)|
|2024-05-23 09:49:06|[operator-framework/operator-registry@bcefe26](https://github.com/operator-framework/operator-registry/commit/bcefe26a389b5d911ca6882938d6e7b7158a3c6b)|Per Goncalves da Silva|build(deps): bump github.com/operator-framework/api from v0.24.0 to v0.25.0 (#1323)|
|2024-05-24 09:48:59|[operator-framework/operator-registry@58f1d01](https://github.com/operator-framework/operator-registry/commit/58f1d01329371b79b56ddfc9f12974e447e3a70c)|dependabot[bot]|Bump github.com/containers/common from 0.58.3 to 0.59.0 (#1324)|
|2024-05-27 08:05:29|[operator-framework/operator-registry@c4170c0](https://github.com/operator-framework/operator-registry/commit/c4170c0d2eb458121d386f9ba6de77ee0e96560b)|dependabot[bot]|Bump sigs.k8s.io/controller-runtime from 0.18.2 to 0.18.3 (#1326)|
|2024-05-28 06:54:26|[operator-framework/operator-registry@da4828d](https://github.com/operator-framework/operator-registry/commit/da4828d472d560b529d8dc243436a9e0cb2e84d4)|dependabot[bot]|Bump github.com/onsi/ginkgo/v2 from 2.18.0 to 2.19.0 (#1327)|
|2024-05-29 15:44:30|[operator-framework/operator-registry@0486312](https://github.com/operator-framework/operator-registry/commit/04863125a01e22235fcb7c2b4c4b856d6ba69e88)|Joe Lanford|Makefile: avoid ?= shell executions (#1328)|
|2024-06-04 14:46:23|[operator-framework/operator-registry@eb32d18](https://github.com/operator-framework/operator-registry/commit/eb32d18f0785d99b5bb29e2f528d6a90754b004f)|dependabot[bot]|Bump google.golang.org/grpc/cmd/protoc-gen-go-grpc from 1.3.0 to 1.4.0 (#1340)|
|2024-06-05 07:00:45|[operator-framework/operator-registry@00d8865](https://github.com/operator-framework/operator-registry/commit/00d8865b01887e6abf906b2189dbc8bdc6a64eaa)|dependabot[bot]|Bump golang.org/x/sys from 0.20.0 to 0.21.0 (#1345)|
|2024-06-05 07:01:42|[operator-framework/operator-registry@52b8fad](https://github.com/operator-framework/operator-registry/commit/52b8fad7ff4c5aaefaa1ecf65a9bbd2babf5883f)|dependabot[bot]|Bump github.com/containerd/containerd from 1.7.17 to 1.7.18 (#1343)|
|2024-06-06 05:49:38|[operator-framework/operator-registry@f709da3](https://github.com/operator-framework/operator-registry/commit/f709da36c94fdd7511d30d7b98a7ec60f06dad07)|dependabot[bot]|Bump golang.org/x/text from 0.15.0 to 0.16.0 (#1341)|
|2024-06-06 05:49:58|[operator-framework/operator-registry@2a6b03e](https://github.com/operator-framework/operator-registry/commit/2a6b03e087aeef495b8b1e4aa10a6dce378bf2a5)|dependabot[bot]|Bump github.com/containers/common from 0.59.0 to 0.59.1 (#1342)|
|2024-06-06 05:50:19|[operator-framework/operator-registry@7735d22](https://github.com/operator-framework/operator-registry/commit/7735d2222f03575f0d9599b081b7af6d69a27311)|dependabot[bot]|Bump golang.org/x/net from 0.25.0 to 0.26.0 (#1344)|
|2024-06-06 05:50:41|[operator-framework/operator-registry@633c1d0](https://github.com/operator-framework/operator-registry/commit/633c1d036917ee4bf13b4b42fc26235c47f3b8f8)|dependabot[bot]|Bump sigs.k8s.io/controller-runtime from 0.18.3 to 0.18.4 (#1346)|
|2024-06-07 06:01:31|[operator-framework/operator-registry@a2a48db](https://github.com/operator-framework/operator-registry/commit/a2a48db694592f9de2c5f077d686fdfab66387a4)|dependabot[bot]|Bump github.com/docker/cli (#1348)|
|2024-06-07 06:02:01|[operator-framework/operator-registry@b8dfb7b](https://github.com/operator-framework/operator-registry/commit/b8dfb7b5e124d0f780ba6d6c3210d6a4a24013ce)|dependabot[bot]|Bump golang.org/x/mod from 0.17.0 to 0.18.0 (#1347)|
|2024-06-11 13:46:09|[operator-framework/operator-registry@44bb1f4](https://github.com/operator-framework/operator-registry/commit/44bb1f4d188066cbf3a7b4e953c84a0e0a96e0e3)|Jordan Keister|deprecate composite template (#1339)|
|2024-06-12 08:17:24|[operator-framework/operator-registry@cf44ac5](https://github.com/operator-framework/operator-registry/commit/cf44ac55e0645c012a63696dcba7fdb6f7189ad0)|dependabot[bot]|Bump google.golang.org/protobuf from 1.34.1 to 1.34.2 (#1353)|
|2024-06-12 08:17:53|[operator-framework/operator-registry@7393a82](https://github.com/operator-framework/operator-registry/commit/7393a820c33fb7c976277f3f36f6c891c3d4c765)|dependabot[bot]|Bump github.com/grpc-ecosystem/grpc-health-probe from 0.4.26 to 0.4.29 (#1352)|
|2024-06-14 08:28:06|[operator-framework/operator-registry@a19e95d](https://github.com/operator-framework/operator-registry/commit/a19e95d6eba0e8f437f2d7bc1a08a55d67428921)|dependabot[bot]|Bump k8s.io/apiextensions-apiserver from 0.30.1 to 0.30.2 (#1355)|
|2024-06-14 08:31:28|[operator-framework/operator-registry@997fec6](https://github.com/operator-framework/operator-registry/commit/997fec6c2bc79baf4e67f49fca3b49de8e555071)|dependabot[bot]|Bump github.com/operator-framework/api from 0.25.0 to 0.26.0 (#1358)|
|2024-06-17 06:53:19|[operator-framework/operator-registry@69e2e46](https://github.com/operator-framework/operator-registry/commit/69e2e462df3523750eba6509d01d62a02225711e)|dependabot[bot]|Bump github.com/spf13/cobra from 1.8.0 to 1.8.1 (#1359)|
|2024-06-20 12:04:59|[operator-framework/operator-registry@6bddca8](https://github.com/operator-framework/operator-registry/commit/6bddca80b927fd1c3bb393932c74c7690099ba03)|Mikalai Radchuk|Fix codecov-action params (#1361)|
|2024-06-24 07:00:13|[operator-framework/operator-registry@ea4e736](https://github.com/operator-framework/operator-registry/commit/ea4e736decd951d0778867785cb495d882d94526)|dependabot[bot]|Bump github.com/containers/image/v5 from 5.31.0 to 5.31.1 (#1363)|
|2024-06-24 19:26:09|[operator-framework/operator-registry@4c106e2](https://github.com/operator-framework/operator-registry/commit/4c106e2a5b563cf314d23dc63352592a8de53c89)|Jordan Keister|generate binary-less dockerfiles (#1338)|
|2024-06-26 12:24:14|[operator-framework/operator-registry@e046dde](https://github.com/operator-framework/operator-registry/commit/e046dde2b9a82371494e054fc68758834f1482dd)|dependabot[bot]|Bump github.com/docker/cli (#1365)|
|2024-06-27 06:09:30|[operator-framework/operator-registry@965f085](https://github.com/operator-framework/operator-registry/commit/965f08582e15bdcb2968f71673d61128d84ecb44)|dependabot[bot]|Bump github.com/docker/cli (#1366)|
|2024-06-27 18:47:55|[operator-framework/operator-registry@dff7915](https://github.com/operator-framework/operator-registry/commit/dff7915e80b476bf817e25e8101455716e6352be)|Jordan Keister|provide required schema for basic template and fbc conversion (#1335)|
|2024-07-02 08:23:13|[operator-framework/operator-registry@9fb0b73](https://github.com/operator-framework/operator-registry/commit/9fb0b73c7cd40c7cc3433196af809bdb4803a04b)|dependabot[bot]|Bump github.com/docker/cli (#1367)|
|2024-07-05 14:14:46|[operator-framework/operator-registry@f83058c](https://github.com/operator-framework/operator-registry/commit/f83058cfcec1f4fbcd59e3dd7312dcdbfb3a4629)|dependabot[bot]|Bump google.golang.org/grpc from 1.64.0 to 1.65.0 (#1369)|
|2024-07-05 14:15:06|[operator-framework/operator-registry@9640ca0](https://github.com/operator-framework/operator-registry/commit/9640ca01726318a5d18e4baf4bd298c052955e36)|dependabot[bot]|Bump golang.org/x/sys from 0.21.0 to 0.22.0 (#1371)|
|2024-07-07 10:08:01|[operator-framework/operator-registry@d6ff84c](https://github.com/operator-framework/operator-registry/commit/d6ff84c5f7e89578e92f84c089736dd72a37af6a)|dependabot[bot]|Bump github.com/containerd/containerd from 1.7.18 to 1.7.19 (#1368)|
|2024-07-08 05:35:28|[operator-framework/operator-registry@ea2ff27](https://github.com/operator-framework/operator-registry/commit/ea2ff27a57870cb35cc024d41011b85e6d7c8d3f)|dependabot[bot]|Bump golang.org/x/net from 0.26.0 to 0.27.0 (#1372)|
|2024-07-08 12:42:45|[operator-framework/operator-registry@cd680c4](https://github.com/operator-framework/operator-registry/commit/cd680c45814208e8baeb5e952c698cf7dd707a51)|dependabot[bot]|Bump golang.org/x/mod from 0.18.0 to 0.19.0 (#1370)|
|2024-07-10 17:19:08|[operator-framework/operator-registry@2356c9c](https://github.com/operator-framework/operator-registry/commit/2356c9ccb664cfa8939be6143220a77ada3bb882)|Joe Lanford|serve: add logging of grpc requests (#1373)|
|2024-07-11 09:04:54|[operator-framework/operator-registry@3be1d97](https://github.com/operator-framework/operator-registry/commit/3be1d97c5d8dfe672ba66e7b8fd4aaaa21fe7d2b)|dependabot[bot]|Bump github.com/containers/common from 0.59.1 to 0.59.2 (#1375)|
|2024-07-18 13:21:48|[operator-framework/operator-registry@6f0bd3c](https://github.com/operator-framework/operator-registry/commit/6f0bd3c161ac0bacfaf8f51dad80ed09b4e7d34a)|dependabot[bot]|Bump k8s.io/client-go from 0.30.2 to 0.30.3 (#1377)|
|2024-07-19 08:51:49|[operator-framework/operator-registry@cac5f2d](https://github.com/operator-framework/operator-registry/commit/cac5f2d6638bddc5c35c68a5304f716445bfdc0a)|Jordan Keister|bump distribution to v3.0-beta-1 (#1380)|
|2024-07-23 20:32:13|[operator-framework/operator-registry@e269771](https://github.com/operator-framework/operator-registry/commit/e2697710045c7fd0c8e29ce80c8f087d55f21731)|dependabot[bot]|Bump k8s.io/apiextensions-apiserver from 0.30.2 to 0.30.3 (#1379)|
|2024-07-23 20:34:48|[operator-framework/operator-registry@3dd8c60](https://github.com/operator-framework/operator-registry/commit/3dd8c604c383e79a7fb05ce97957ac0f64051060)|dependabot[bot]|Bump github.com/containerd/containerd from 1.7.19 to 1.7.20 (#1382)|
|2024-07-23 20:37:51|[operator-framework/operator-registry@717584e](https://github.com/operator-framework/operator-registry/commit/717584e4fb1f0d82d99ad16216ee825ca100b8a3)|dependabot[bot]|Bump github.com/docker/cli (#1383)|
|2024-07-24 20:21:23|[operator-framework/operator-registry@0c0ecb3](https://github.com/operator-framework/operator-registry/commit/0c0ecb35eb3861557ddba91f339574b425ad3151)|dependabot[bot]|Bump github.com/docker/cli (#1385)|
|2024-07-24 20:24:08|[operator-framework/operator-registry@c7d9d3c](https://github.com/operator-framework/operator-registry/commit/c7d9d3c1f4fa3c13560ae88f692b665cd87a71e3)|dependabot[bot]|Bump github.com/grpc-ecosystem/grpc-health-probe from 0.4.29 to 0.4.30 (#1374)|
|2024-07-29 13:02:30|[operator-framework/operator-registry@d0240d2](https://github.com/operator-framework/operator-registry/commit/d0240d2ab1de7f04fca5a644c7009c3d406ee0f3)|dependabot[bot]|Bump github.com/onsi/ginkgo/v2 from 2.19.0 to 2.19.1 (#1388)|
|2024-07-29 13:05:43|[operator-framework/operator-registry@036918e](https://github.com/operator-framework/operator-registry/commit/036918e6ea1c025bd6422883ce059e362be3e017)|dependabot[bot]|Bump github.com/containers/common from 0.59.2 to 0.60.0 (#1389)|
|2024-07-30 12:02:20|[operator-framework/operator-registry@550ce18](https://github.com/operator-framework/operator-registry/commit/550ce18df8831308ccfe1a8e12e030295a92e346)|dependabot[bot]|Bump github.com/onsi/gomega from 1.34.0 to 1.34.1 (#1391)|
|2024-07-30 12:02:46|[operator-framework/operator-registry@9d60039](https://github.com/operator-framework/operator-registry/commit/9d6003971be7d06aec4c8536ab1d6afb0cd2c2e0)|dependabot[bot]|Bump google.golang.org/grpc/cmd/protoc-gen-go-grpc from 1.4.0 to 1.5.1 (#1390)|
|2024-07-30 12:29:43|[operator-framework/operator-registry@49158cb](https://github.com/operator-framework/operator-registry/commit/49158cbb392a19f47980a2eba1775cb999285e2b)|Joe Lanford|add bingo for managing tool deps (#1329)|
|2024-07-30 13:49:17|[operator-framework/operator-registry@4c943fa](https://github.com/operator-framework/operator-registry/commit/4c943faa1281c4b24651f73fd7a7d6f7babb4c41)|Per Goncalves da Silva|Revert "add bingo for managing tool deps (#1329)" (#1393)|
|2024-08-07 00:18:40|[operator-framework/operator-registry@040c3e3](https://github.com/operator-framework/operator-registry/commit/040c3e32855cfe314c35b5659331b8c0a5ea6df9)|dependabot[bot]|Bump golang.org/x/mod from 0.19.0 to 0.20.0 (#1397)|
|2024-08-07 00:19:00|[operator-framework/operator-registry@f49f9b8](https://github.com/operator-framework/operator-registry/commit/f49f9b8ebb48ddfbcfe3eea380fa927ce5917320)|dependabot[bot]|Bump golang.org/x/sys from 0.22.0 to 0.23.0 (#1396)|
|2024-08-07 10:40:56|[operator-framework/operator-registry@b53ed88](https://github.com/operator-framework/operator-registry/commit/b53ed8820ea3508bc0d5d06525729b83f053fca6)|dependabot[bot]|Bump golang.org/x/net from 0.27.0 to 0.28.0 (#1398)|
|2024-08-07 13:54:20|[operator-framework/operator-registry@5d090ba](https://github.com/operator-framework/operator-registry/commit/5d090bab31460896add0563971f26a3f71cd0c19)|Per Goncalves da Silva|add bingo for managing tool deps (#1394)|
|2024-08-08 18:02:23|[operator-framework/operator-registry@0db27a6](https://github.com/operator-framework/operator-registry/commit/0db27a615955dda3e614155ece9f379d38da9116)|dependabot[bot]|Bump github.com/onsi/ginkgo/v2 from 2.19.1 to 2.20.0 (#1400)|
|2024-08-09 14:36:31|[operator-framework/operator-registry@39a3278](https://github.com/operator-framework/operator-registry/commit/39a32787c3a8980ed07c70fcec3d3ccc3a96530e)|dependabot[bot]|Bump golang.org/x/sys from 0.23.0 to 0.24.0 (#1401)|
|2024-08-12 13:21:53|[operator-framework/operator-registry@53dc8e6](https://github.com/operator-framework/operator-registry/commit/53dc8e6fbf536873b00fde09b3f3b107e2d60400)|dependabot[bot]|Bump github.com/containers/image/v5 from 5.32.0 to 5.32.1 (#1402)|
|2024-08-13 13:29:57|[operator-framework/operator-registry@7892e84](https://github.com/operator-framework/operator-registry/commit/7892e84372dd31e1b7c0176c38dc851b991ffbbf)|dependabot[bot]|Bump github.com/containers/common from 0.60.0 to 0.60.1 (#1403)|
|2024-08-13 13:32:41|[operator-framework/operator-registry@f17737d](https://github.com/operator-framework/operator-registry/commit/f17737d5518b77ed437a5080293fca78af95b43b)|dependabot[bot]|Bump sigs.k8s.io/controller-runtime from 0.18.4 to 0.18.5 (#1404)|
|2024-08-14 14:51:18|[operator-framework/operator-registry@86ed094](https://github.com/operator-framework/operator-registry/commit/86ed094b6ba74e9000fcf789efd414831c6dff69)|dependabot[bot]|Bump github.com/docker/cli (#1407)|
|2024-08-14 14:52:09|[operator-framework/operator-registry@5fb8c1c](https://github.com/operator-framework/operator-registry/commit/5fb8c1c50709bb419476e0ef56195fa2ece944fe)|dependabot[bot]|Bump k8s.io/client-go from 0.30.3 to 0.31.0 (#1406)|
|2024-08-15 21:19:40|[operator-framework/operator-registry@a758bd9](https://github.com/operator-framework/operator-registry/commit/a758bd9c5388b6eaee57dd0139fc5dfc59357928)|Joe Lanford|server_test.go: wait to run tests until listeners have started (#1411)|
|2024-08-15 21:19:57|[operator-framework/operator-registry@c80e875](https://github.com/operator-framework/operator-registry/commit/c80e8751e716c069017b55279a0f29d0254d426a)|Jordan Keister|add optional schema migrations; default to olm.bundle.object instead of olm.csv.metadata (#1384)|
|2024-08-15 21:33:26|[operator-framework/operator-registry@b12dea8](https://github.com/operator-framework/operator-registry/commit/b12dea86e3642f7644be766bfdd0ca3b79ffdc30)|Joe Lanford|remove 'automatically generated' strings from repo (#1412)|
|2024-08-16 11:55:26|[operator-framework/operator-registry@e787595](https://github.com/operator-framework/operator-registry/commit/e78759538e6979ee260c030a620f35cc17e343e4)|dependabot[bot]|Bump github.com/grpc-ecosystem/grpc-health-probe from 0.4.30 to 0.4.31 (#1414)|
|2024-08-16 12:40:23|[operator-framework/operator-registry@ced4d17](https://github.com/operator-framework/operator-registry/commit/ced4d17d8ec7caca1c0f00cac0529d270ff07cd3)|dependabot[bot]|Bump sigs.k8s.io/kind from 0.23.0 to 0.24.0 (#1413)|
|2024-04-25 12:56:45|[operator-framework/api@07779ac](https://github.com/operator-framework/api/commit/07779ac1eea89f2b591a87f900278093e90c0900)|dependabot[bot]|build(deps): bump golang.org/x/net from 0.21.0 to 0.23.0|
|2024-04-29 16:50:53|[operator-framework/api@d842da5](https://github.com/operator-framework/api/commit/d842da5fb9ac8a7e88220717a904a98d6b87afd4)|Neo2308|K8s 1.30 version update and go 1.22|
|2024-04-29 16:50:53|[operator-framework/api@dea7d94](https://github.com/operator-framework/api/commit/dea7d94fa00dbae9c95b1f4e3a2a630a930235c2)|Neo2308|K8s 1.30 version update and go 1.22|
|2024-04-29 16:50:53|[operator-framework/api@7d638a0](https://github.com/operator-framework/api/commit/7d638a091922d82df53d17c082268a45946da626)|Neo2308|Fix build failures|
|2024-05-22 11:42:14|[operator-framework/api@a0f4415](https://github.com/operator-framework/api/commit/a0f4415cbd873c230f3969def11a61aa15e61c35)|Per Goncalves da Silva|adds dependabot.yml configuration|
|2024-05-22 11:44:56|[operator-framework/api@5ff09d8](https://github.com/operator-framework/api/commit/5ff09d809f2c5a2f1f649d1492cee1690d56a151)|Per Goncalves da Silva|fixup crds/zz_defs.go|
|2024-05-22 11:44:56|[operator-framework/api@104f4b7](https://github.com/operator-framework/api/commit/104f4b78e1e20a452ab176e871ad04fa55d32864)|Per Goncalves da Silva|Fixes CSV CRD validation issues by adding missing default values|
|2024-05-22 12:05:41|[operator-framework/api@a1a115a](https://github.com/operator-framework/api/commit/a1a115a36cbc4eb808055df6569c3adbac179883)|Per Goncalves da Silva|adds CRD create test against kind running on the same kube version as client-go|
|2024-05-22 12:13:46|[operator-framework/api@0473142](https://github.com/operator-framework/api/commit/0473142ef7a38058f1995f6d79ada3663cccce62)|dependabot[bot]|--- updated-dependencies: - dependency-name: actions/checkout   dependency-type: direct:production   update-type: version-update:semver-major ...|
|2024-05-22 12:14:09|[operator-framework/api@b12655b](https://github.com/operator-framework/api/commit/b12655b3a48b758b67ccc4ff662ee16ce3e01aed)|dependabot[bot]|--- updated-dependencies: - dependency-name: actions/cache   dependency-type: direct:production   update-type: version-update:semver-major ...|
|2024-05-22 12:15:06|[operator-framework/api@64036e9](https://github.com/operator-framework/api/commit/64036e9e3a7aef3c25599fadc9bf7421ea4a0cb3)|dependabot[bot]|--- updated-dependencies: - dependency-name: sigs.k8s.io/controller-runtime   dependency-type: direct:production   update-type: version-update:semver-patch ...|
|2024-05-22 12:15:28|[operator-framework/api@e34631d](https://github.com/operator-framework/api/commit/e34631d6bf7bafc4a6ba42ec32515c5d1247d7f6)|dependabot[bot]|--- updated-dependencies: - dependency-name: github.com/stretchr/testify   dependency-type: direct:production   update-type: version-update:semver-minor ...|
|2024-05-22 12:17:15|[operator-framework/api@f3cb22c](https://github.com/operator-framework/api/commit/f3cb22c6e384911eaccc40deedbc851000bcac65)|dependabot[bot]|--- updated-dependencies: - dependency-name: actions/setup-go   dependency-type: direct:production   update-type: version-update:semver-major ...|
|2024-05-22 12:18:01|[operator-framework/api@b33b58d](https://github.com/operator-framework/api/commit/b33b58d43caf4c39ca479d0f8e2e7c8f70099da5)|dependabot[bot]|--- updated-dependencies: - dependency-name: k8s.io/apimachinery   dependency-type: direct:production   update-type: version-update:semver-patch ...|
|2024-05-22 15:12:58|[operator-framework/api@4c60841](https://github.com/operator-framework/api/commit/4c60841f3c610b95daf3103cfae4fdf2bc7db025)|Per Goncalves da Silva|update kube libraries to v0.30.1|
|2024-05-28 09:31:47|[operator-framework/api@9698d12](https://github.com/operator-framework/api/commit/9698d12a5f3e27980773fe3e5c0cc3e8e596a6d7)|dependabot[bot]|Bump github.com/sirupsen/logrus from 1.9.2 to 1.9.3|
|2024-05-28 09:32:07|[operator-framework/api@d6920a4](https://github.com/operator-framework/api/commit/d6920a4c8df5b2a6f9f96792c50cdb2c3e43674d)|dependabot[bot]|Bump sigs.k8s.io/controller-runtime from 0.18.2 to 0.18.3|
|2024-06-11 08:06:09|[operator-framework/api@e684a59](https://github.com/operator-framework/api/commit/e684a5915a470e217294aede72cad2c5daa830e7)|dependabot[bot]|Bump sigs.k8s.io/controller-runtime from 0.18.3 to 0.18.4|
|2024-06-13 14:13:18|[operator-framework/api@5d2d3fb](https://github.com/operator-framework/api/commit/5d2d3fbe061b7b4a942747877efa58958fa9889e)|Joe Lanford|remove default value of catsrc.spec.grpcPodConfig.securityContextConfig (#342)|

This pull request is expected to merge without any human intervention. If tests are failing here, changes must land upstream to fix any issues so that future downstreaming efforts succeed.

/cc @openshift/openshift-team-operator-runtime
/cc @openshift/openshift-team-operator-ecosystemopenshift-bot:synchronize-upstreammastersynchronize-upstreamtrue &{0xc0003fc3f0  0xc0009ae480 false {0 0} 0xc0009ae420} [] true 