### PR TITLE
[release-4.12] OCPBUGS-42161: adds paginating lister for evaluating CRs' upgrade fitness versus new CRDs

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator_test.go
@@ -1402,7 +1402,7 @@ func TestValidateExistingCRs(t *testing.T) {
 				Resource: "machinepools",
 			},
 			newCRD: unversionedCRDForV1beta1File("testdata/hivebug/crd.yaml"),
-			want:   fmt.Errorf("error validating custom resource against new schema for MachinePool /test: [[].spec.clusterDeploymentRef: Invalid value: \"null\": spec.clusterDeploymentRef in body must be of type object: \"null\", [].spec.name: Required value, [].spec.platform: Required value]"),
+			want:   fmt.Errorf("error validating hive.openshift.io/v1, Kind=MachinePool \"test\": updated validation is too restrictive: [[].spec.clusterDeploymentRef: Invalid value: \"null\": spec.clusterDeploymentRef in body must be of type object: \"null\", [].spec.name: Required value, [].spec.platform: Required value]"),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Manual backport of #871 to get CI rolling and hopefully merge it down quick(er)
