### PR TITLE
OCPBUGS-42114: add optional schema migrations; default to olm.bundle.object instead of olm.csv.metadata

### DIFF
--- a/staging/operator-registry/alpha/action/migrate.go
+++ b/staging/operator-registry/alpha/action/migrate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/operator-framework/operator-registry/alpha/action/migrations"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/pkg/image"
 )
@@ -12,6 +13,7 @@ import (
 type Migrate struct {
 	CatalogRef string
 	OutputDir  string
+	Migrations *migrations.Migrations
 
 	WriteFunc declcfg.WriteFunc
 	FileExt   string
@@ -28,8 +30,8 @@ func (m Migrate) Run(ctx context.Context) error {
 	}
 
 	r := Render{
-		Refs:    []string{m.CatalogRef},
-		Migrate: true,
+		Refs:       []string{m.CatalogRef},
+		Migrations: m.Migrations,
 
 		// Only allow catalogs to be migrated.
 		AllowedRefMask: RefSqliteImage | RefSqliteFile | RefDCImage | RefDCDir,

--- a/staging/operator-registry/alpha/action/migrations/000_bundle_object_to_csv_metadata.go
+++ b/staging/operator-registry/alpha/action/migrations/000_bundle_object_to_csv_metadata.go
@@ -1,0 +1,47 @@
+package migrations
+
+import (
+	"encoding/json"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
+	"github.com/operator-framework/operator-registry/alpha/property"
+)
+
+func bundleObjectToCSVMetadata(cfg *declcfg.DeclarativeConfig) error {
+	convertBundleObjectToCSVMetadata := func(b *declcfg.Bundle) error {
+		if b.Image == "" || b.CsvJSON == "" {
+			return nil
+		}
+
+		var csv v1alpha1.ClusterServiceVersion
+		if err := json.Unmarshal([]byte(b.CsvJSON), &csv); err != nil {
+			return err
+		}
+
+		props := b.Properties[:0]
+		for _, p := range b.Properties {
+			switch p.Type {
+			case property.TypeBundleObject:
+				// Get rid of the bundle objects
+			case property.TypeCSVMetadata:
+				// If this bundle already has a CSV metadata
+				// property, we won't mutate the bundle at all.
+				return nil
+			default:
+				// Keep all of the other properties
+				props = append(props, p)
+			}
+		}
+		b.Properties = append(props, property.MustBuildCSVMetadata(csv))
+		return nil
+	}
+
+	for bi := range cfg.Bundles {
+		if err := convertBundleObjectToCSVMetadata(&cfg.Bundles[bi]); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/staging/operator-registry/alpha/action/migrations/migrations.go
+++ b/staging/operator-registry/alpha/action/migrations/migrations.go
@@ -1,0 +1,109 @@
+package migrations
+
+import (
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
+)
+
+type MigrationToken string
+
+const (
+	invalidMigration string = ""
+	NoMigrations     string = "none"
+	AllMigrations    string = "all"
+)
+
+type Migration interface {
+	Token() MigrationToken
+	Help() string
+	Migrate(*declcfg.DeclarativeConfig) error
+}
+
+func newMigration(token string, help string, fn func(config *declcfg.DeclarativeConfig) error) Migration {
+	return &simpleMigration{token: MigrationToken(token), help: help, fn: fn}
+}
+
+type simpleMigration struct {
+	token MigrationToken
+	help  string
+	fn    func(*declcfg.DeclarativeConfig) error
+}
+
+func (s simpleMigration) Token() MigrationToken {
+	return s.token
+}
+
+func (s simpleMigration) Migrate(config *declcfg.DeclarativeConfig) error {
+	return s.fn(config)
+}
+
+func (s simpleMigration) Help() string {
+	return s.help
+}
+
+type Migrations struct {
+	Migrations []Migration
+}
+
+// CloneAllMigrations returns a shallow copy of allMigrations
+// since slices.Clone is not available in the current golang version
+func CloneAllMigrations() []Migration {
+	return append(allMigrations[:0:0], allMigrations...)
+}
+
+// allMigrations represents the migration catalog
+// the order of these migrations is important
+var allMigrations = []Migration{
+	newMigration(NoMigrations, "do nothing", func(_ *declcfg.DeclarativeConfig) error { return nil }),
+	newMigration("bundle-object-to-csv-metadata", `migrates bundles' "olm.bundle.object" to "olm.csv.metadata"`, bundleObjectToCSVMetadata),
+}
+
+func NewMigrations(name string) (*Migrations, error) {
+	if name == AllMigrations {
+		return &Migrations{Migrations: CloneAllMigrations()}, nil
+	}
+
+	migrations := CloneAllMigrations()
+
+	found := false
+	keep := migrations[:0]
+	for _, migration := range migrations {
+		keep = append(keep, migration)
+		if migration.Token() == MigrationToken(name) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil, fmt.Errorf("unknown migration level %q", name)
+	}
+	return &Migrations{Migrations: keep}, nil
+}
+
+func HelpText() string {
+	var help strings.Builder
+	help.WriteString("\nThe migrator will run all migrations up to and including the selected level.\n\n")
+	help.WriteString("Available migrators:\n")
+	if len(allMigrations) == 0 {
+		help.WriteString("   (no migrations available in this version)\n")
+	}
+
+	tabber := tabwriter.NewWriter(&help, 0, 0, 1, ' ', 0)
+	for _, migration := range allMigrations {
+		fmt.Fprintf(tabber, "  - %s\t: %s\n", migration.Token(), migration.Help())
+	}
+	tabber.Flush()
+	return help.String()
+}
+
+func (m *Migrations) Migrate(config *declcfg.DeclarativeConfig) error {
+	for _, migration := range m.Migrations {
+		if err := migration.Migrate(config); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/staging/operator-registry/alpha/action/migrations/migrations_test.go
+++ b/staging/operator-registry/alpha/action/migrations/migrations_test.go
@@ -1,0 +1,139 @@
+package migrations
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
+	"github.com/operator-framework/operator-registry/alpha/property"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrations(t *testing.T) {
+	noneMigration, err := NewMigrations(NoMigrations)
+	require.NoError(t, err)
+	csvMigration, err := NewMigrations("bundle-object-to-csv-metadata")
+	require.NoError(t, err)
+	allMigrations, err := NewMigrations(AllMigrations)
+	require.NoError(t, err)
+
+	migrationPhaseEvaluators := map[MigrationToken]func(*declcfg.DeclarativeConfig) error{
+		MigrationToken(NoMigrations): func(d *declcfg.DeclarativeConfig) error {
+			if diff := cmp.Diff(*d, unmigratedCatalogFBC()); diff != "" {
+				return fmt.Errorf("'none' migrator is not expected to change the config\n%s", diff)
+			}
+			return nil
+		},
+		MigrationToken("bundle-object-to-csv-metadata"): func(d *declcfg.DeclarativeConfig) error {
+			if diff := cmp.Diff(*d, csvMetadataCatalogFBC()); diff != "" {
+				return fmt.Errorf("unexpected result of migration\n%s", diff)
+			}
+			return nil
+		},
+	}
+
+	tests := []struct {
+		name      string
+		migrators *Migrations
+	}{
+		{
+			name:      "NoMigrations",
+			migrators: noneMigration,
+		},
+		{
+			name:      "BundleObjectToCSVMetadata",
+			migrators: csvMigration,
+		},
+		{
+			name:      "MigrationSequence",
+			migrators: allMigrations,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var config declcfg.DeclarativeConfig = unmigratedCatalogFBC()
+
+			for _, m := range test.migrators.Migrations {
+				err := m.Migrate(&config)
+				require.NoError(t, err)
+				err = migrationPhaseEvaluators[m.Token()](&config)
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func mustBuildCSVMetadata(r io.Reader) property.Property {
+	var csv v1alpha1.ClusterServiceVersion
+	if err := json.NewDecoder(r).Decode(&csv); err != nil {
+		panic(err)
+	}
+	return property.MustBuildCSVMetadata(csv)
+}
+
+var fooRawCsv = []byte(`{"apiVersion": "operators.coreos.com/v1alpha1", "kind": "ClusterServiceVersion", "metadata": {"name": "foo.v0.1.0"}, "spec": {"displayName": "Foo Operator", "customresourcedefinitions": {"owned": [{"group": "test.foo", "version": "v1", "kind": "Foo", "name": "foos.test.foo"}]}, "version": "0.1.0", "relatedImages": [{"name": "operator", "image": "test.registry/foo-operator/foo:v0.1.0"}]}}`)
+
+var fooRawCrd = []byte(`---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: foos.test.foo
+spec:
+  group: test.foo
+  names:
+    kind: Foo
+    plural: foos
+  versions:
+    - name: v1`,
+)
+
+func unmigratedCatalogFBC() declcfg.DeclarativeConfig {
+	return declcfg.DeclarativeConfig{
+		Bundles: []declcfg.Bundle{
+			{
+				Schema:  "olm.bundle",
+				Name:    "foo.v0.1.0",
+				Package: "foo",
+				Image:   "quay.io/openshift-community-operators/foo:v0.1.0",
+				Properties: []property.Property{
+					property.MustBuildGVK("test.foo", "v1", "Foo"),
+					property.MustBuildGVKRequired("test.bar", "v1alpha1", "Bar"),
+					property.MustBuildPackage("foo", "0.1.0"),
+					property.MustBuildPackageRequired("bar", "<0.1.0"),
+					property.MustBuildBundleObject(fooRawCrd),
+					property.MustBuildBundleObject(fooRawCsv),
+				},
+				Objects: []string{string(fooRawCsv), string(fooRawCrd)},
+				CsvJSON: string(fooRawCsv),
+			},
+		},
+	}
+}
+
+func csvMetadataCatalogFBC() declcfg.DeclarativeConfig {
+	return declcfg.DeclarativeConfig{
+		Bundles: []declcfg.Bundle{
+			{
+				Schema:  "olm.bundle",
+				Name:    "foo.v0.1.0",
+				Package: "foo",
+				Image:   "quay.io/openshift-community-operators/foo:v0.1.0",
+				Properties: []property.Property{
+					property.MustBuildGVK("test.foo", "v1", "Foo"),
+					property.MustBuildGVKRequired("test.bar", "v1alpha1", "Bar"),
+					property.MustBuildPackage("foo", "0.1.0"),
+					property.MustBuildPackageRequired("bar", "<0.1.0"),
+					mustBuildCSVMetadata(bytes.NewReader(fooRawCsv)),
+				},
+				Objects: []string{string(fooRawCsv), string(fooRawCrd)},
+				CsvJSON: string(fooRawCsv),
+			},
+		},
+	}
+}

--- a/staging/operator-registry/alpha/action/render.go
+++ b/staging/operator-registry/alpha/action/render.go
@@ -15,10 +15,10 @@ import (
 
 	"github.com/h2non/filetype"
 	"github.com/h2non/filetype/matchers"
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/operator-framework/operator-registry/alpha/action/migrations"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/alpha/property"
 	"github.com/operator-framework/operator-registry/pkg/containertools"
@@ -50,10 +50,10 @@ func (r RefType) Allowed(refType RefType) bool {
 var ErrNotAllowed = errors.New("not allowed")
 
 type Render struct {
-	Refs           []string
-	Registry       image.Registry
-	AllowedRefMask RefType
-	Migrate        bool
+	Refs             []string
+	Registry         image.Registry
+	AllowedRefMask   RefType
+	Migrations       *migrations.Migrations
 
 	skipSqliteDeprecationLog bool
 }
@@ -92,10 +92,8 @@ func (r Render) Run(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
 			})
 		}
 
-		if r.Migrate {
-			if err := migrate(cfg); err != nil {
-				return nil, fmt.Errorf("migrate: %v", err)
-			}
+		if err := r.migrate(cfg); err != nil {
+			return nil, fmt.Errorf("migrate: %v", err)
 		}
 
 		cfgs = append(cfgs, *cfg)
@@ -403,48 +401,12 @@ func moveBundleObjectsToEndOfPropertySlices(cfg *declcfg.DeclarativeConfig) {
 	}
 }
 
-func migrate(cfg *declcfg.DeclarativeConfig) error {
-	migrations := []func(*declcfg.DeclarativeConfig) error{
-		convertObjectsToCSVMetadata,
+func (r Render) migrate(cfg *declcfg.DeclarativeConfig) error {
+	// If there are no migrations, do nothing.
+	if r.Migrations == nil {
+		return nil
 	}
-
-	for _, m := range migrations {
-		if err := m(cfg); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func convertObjectsToCSVMetadata(cfg *declcfg.DeclarativeConfig) error {
-BundleLoop:
-	for bi, b := range cfg.Bundles {
-		if b.Image == "" || b.CsvJSON == "" {
-			continue
-		}
-
-		var csv v1alpha1.ClusterServiceVersion
-		if err := json.Unmarshal([]byte(b.CsvJSON), &csv); err != nil {
-			return err
-		}
-
-		props := b.Properties[:0]
-		for _, p := range b.Properties {
-			switch p.Type {
-			case property.TypeBundleObject:
-				// Get rid of the bundle objects
-			case property.TypeCSVMetadata:
-				// If this bundle already has a CSV metadata
-				// property, we won't mutate the bundle at all.
-				continue BundleLoop
-			default:
-				// Keep all of the other properties
-				props = append(props, p)
-			}
-		}
-		cfg.Bundles[bi].Properties = append(props, property.MustBuildCSVMetadata(csv))
-	}
-	return nil
+	return r.Migrations.Migrate(cfg)
 }
 
 func combineConfigs(cfgs []declcfg.DeclarativeConfig) *declcfg.DeclarativeConfig {

--- a/staging/operator-registry/alpha/action/render_test.go
+++ b/staging/operator-registry/alpha/action/render_test.go
@@ -1,24 +1,23 @@
 package action_test
 
 import (
-	"bytes"
 	"context"
 	"embed"
 	"encoding/json"
 	"errors"
-	"io"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
 	"testing/fstest"
 
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/operator-framework/operator-registry/alpha/action"
+	"github.com/operator-framework/operator-registry/alpha/action/migrations"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/alpha/property"
 	"github.com/operator-framework/operator-registry/pkg/containertools"
@@ -27,6 +26,22 @@ import (
 	"github.com/operator-framework/operator-registry/pkg/registry"
 	"github.com/operator-framework/operator-registry/pkg/sqlite"
 )
+
+type fauxMigration struct {
+	token   string
+	help    string
+	migrate func(*declcfg.DeclarativeConfig) error
+}
+
+func (m fauxMigration) Token() migrations.MigrationToken {
+	return migrations.MigrationToken(m.token)
+}
+func (m fauxMigration) Help() string {
+	return m.help
+}
+func (m fauxMigration) Migrate(config *declcfg.DeclarativeConfig) error {
+	return m.migrate(config)
+}
 
 func TestRender(t *testing.T) {
 	type spec struct {
@@ -71,6 +86,16 @@ func TestRender(t *testing.T) {
 		image.SimpleReference("test.registry/foo-operator/foo-bundle:v0.2.0"): "testdata/foo-bundle-v0.2.0",
 	}
 	assert.NoError(t, generateSqliteFile(dbFile, imageMap))
+	testMigrations := migrations.Migrations{
+		Migrations: []migrations.Migration{
+			fauxMigration{"faux-migration", "my help text", func(d *declcfg.DeclarativeConfig) error {
+				for i, _ := range d.Bundles {
+					d.Bundles[i].Name = fmt.Sprintf("%s-MIGRATED", d.Bundles[i].Name)
+				}
+				return nil
+			}},
+		},
+	}
 
 	specs := []spec{
 		{
@@ -108,7 +133,8 @@ func TestRender(t *testing.T) {
 							property.MustBuildGVKRequired("test.bar", "v1alpha1", "Bar"),
 							property.MustBuildPackage("foo", "0.1.0"),
 							property.MustBuildPackageRequired("bar", "<0.1.0"),
-							mustBuildCSVMetadata(bytes.NewReader(foov1csv)),
+							property.MustBuildBundleObject(foov1crd),
+							property.MustBuildBundleObject(foov1csv),
 						},
 						RelatedImages: []declcfg.RelatedImage{
 							{
@@ -132,7 +158,101 @@ func TestRender(t *testing.T) {
 							property.MustBuildGVKRequired("test.bar", "v1alpha1", "Bar"),
 							property.MustBuildPackage("foo", "0.2.0"),
 							property.MustBuildPackageRequired("bar", "<0.1.0"),
-							mustBuildCSVMetadata(bytes.NewReader(foov2csv)),
+							property.MustBuildBundleObject(foov2crd),
+							property.MustBuildBundleObject(foov2csv),
+						},
+						RelatedImages: []declcfg.RelatedImage{
+							{
+								Image: "test.registry/foo-operator/foo-2:v0.2.0",
+							},
+							{
+								Image: "test.registry/foo-operator/foo-bundle:v0.2.0",
+							},
+							{
+								Image: "test.registry/foo-operator/foo-init-2:v0.2.0",
+							},
+							{
+								Image: "test.registry/foo-operator/foo-init:v0.2.0",
+							},
+							{
+								Name:  "other",
+								Image: "test.registry/foo-operator/foo-other:v0.2.0",
+							},
+							{
+								Name:  "operator",
+								Image: "test.registry/foo-operator/foo:v0.2.0",
+							},
+						},
+						CsvJSON: string(foov2csv),
+						Objects: []string{string(foov2csv), string(foov2crd)},
+					},
+				},
+			},
+			assertion: require.NoError,
+		},
+		{
+			name: "Success/SqliteIndexImageWithMigration",
+			render: action.Render{
+				Refs:       []string{"test.registry/foo-operator/foo-index-sqlite:v0.2.0"},
+				Registry:   reg,
+				Migrations: &testMigrations,
+			},
+			expectCfg: &declcfg.DeclarativeConfig{
+				Packages: []declcfg.Package{
+					{
+						Schema:         "olm.package",
+						Name:           "foo",
+						DefaultChannel: "beta",
+					},
+				},
+				Channels: []declcfg.Channel{
+					{Schema: "olm.channel", Package: "foo", Name: "beta", Entries: []declcfg.ChannelEntry{
+						{Name: "foo.v0.1.0", SkipRange: "<0.1.0"},
+						{Name: "foo.v0.2.0", Replaces: "foo.v0.1.0", SkipRange: "<0.2.0", Skips: []string{"foo.v0.1.1", "foo.v0.1.2"}},
+					}},
+					{Schema: "olm.channel", Package: "foo", Name: "stable", Entries: []declcfg.ChannelEntry{
+						{Name: "foo.v0.1.0", SkipRange: "<0.1.0"},
+						{Name: "foo.v0.2.0", Replaces: "foo.v0.1.0", SkipRange: "<0.2.0", Skips: []string{"foo.v0.1.1", "foo.v0.1.2"}},
+					}},
+				},
+				Bundles: []declcfg.Bundle{
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.1.0-MIGRATED",
+						Package: "foo",
+						Image:   "test.registry/foo-operator/foo-bundle:v0.1.0",
+						Properties: []property.Property{
+							property.MustBuildGVK("test.foo", "v1", "Foo"),
+							property.MustBuildGVKRequired("test.bar", "v1alpha1", "Bar"),
+							property.MustBuildPackage("foo", "0.1.0"),
+							property.MustBuildPackageRequired("bar", "<0.1.0"),
+							property.MustBuildBundleObject(foov1crd),
+							property.MustBuildBundleObject(foov1csv),
+						},
+						RelatedImages: []declcfg.RelatedImage{
+							{
+								Image: "test.registry/foo-operator/foo-bundle:v0.1.0",
+							},
+							{
+								Name:  "operator",
+								Image: "test.registry/foo-operator/foo:v0.1.0",
+							},
+						},
+						CsvJSON: string(foov1csv),
+						Objects: []string{string(foov1csv), string(foov1crd)},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.2.0-MIGRATED",
+						Package: "foo",
+						Image:   "test.registry/foo-operator/foo-bundle:v0.2.0",
+						Properties: []property.Property{
+							property.MustBuildGVK("test.foo", "v1", "Foo"),
+							property.MustBuildGVKRequired("test.bar", "v1alpha1", "Bar"),
+							property.MustBuildPackage("foo", "0.2.0"),
+							property.MustBuildPackageRequired("bar", "<0.1.0"),
+							property.MustBuildBundleObject(foov2crd),
+							property.MustBuildBundleObject(foov2csv),
 						},
 						RelatedImages: []declcfg.RelatedImage{
 							{
@@ -198,7 +318,8 @@ func TestRender(t *testing.T) {
 							property.MustBuildGVKRequired("test.bar", "v1alpha1", "Bar"),
 							property.MustBuildPackage("foo", "0.1.0"),
 							property.MustBuildPackageRequired("bar", "<0.1.0"),
-							mustBuildCSVMetadata(bytes.NewReader(foov1csv)),
+							property.MustBuildBundleObject(foov1crd),
+							property.MustBuildBundleObject(foov1csv),
 						},
 						RelatedImages: []declcfg.RelatedImage{
 							{
@@ -222,7 +343,101 @@ func TestRender(t *testing.T) {
 							property.MustBuildGVKRequired("test.bar", "v1alpha1", "Bar"),
 							property.MustBuildPackage("foo", "0.2.0"),
 							property.MustBuildPackageRequired("bar", "<0.1.0"),
-							mustBuildCSVMetadata(bytes.NewReader(foov2csv)),
+							property.MustBuildBundleObject(foov2crd),
+							property.MustBuildBundleObject(foov2csv),
+						},
+						RelatedImages: []declcfg.RelatedImage{
+							{
+								Image: "test.registry/foo-operator/foo-2:v0.2.0",
+							},
+							{
+								Image: "test.registry/foo-operator/foo-bundle:v0.2.0",
+							},
+							{
+								Image: "test.registry/foo-operator/foo-init-2:v0.2.0",
+							},
+							{
+								Image: "test.registry/foo-operator/foo-init:v0.2.0",
+							},
+							{
+								Name:  "other",
+								Image: "test.registry/foo-operator/foo-other:v0.2.0",
+							},
+							{
+								Name:  "operator",
+								Image: "test.registry/foo-operator/foo:v0.2.0",
+							},
+						},
+						CsvJSON: string(foov2csv),
+						Objects: []string{string(foov2csv), string(foov2crd)},
+					},
+				},
+			},
+			assertion: require.NoError,
+		},
+		{
+			name: "Success/SqliteFileMigration",
+			render: action.Render{
+				Refs:       []string{dbFile},
+				Registry:   reg,
+				Migrations: &testMigrations,
+			},
+			expectCfg: &declcfg.DeclarativeConfig{
+				Packages: []declcfg.Package{
+					{
+						Schema:         "olm.package",
+						Name:           "foo",
+						DefaultChannel: "beta",
+					},
+				},
+				Channels: []declcfg.Channel{
+					{Schema: "olm.channel", Package: "foo", Name: "beta", Entries: []declcfg.ChannelEntry{
+						{Name: "foo.v0.1.0", SkipRange: "<0.1.0"},
+						{Name: "foo.v0.2.0", Replaces: "foo.v0.1.0", SkipRange: "<0.2.0", Skips: []string{"foo.v0.1.1", "foo.v0.1.2"}},
+					}},
+					{Schema: "olm.channel", Package: "foo", Name: "stable", Entries: []declcfg.ChannelEntry{
+						{Name: "foo.v0.1.0", SkipRange: "<0.1.0"},
+						{Name: "foo.v0.2.0", Replaces: "foo.v0.1.0", SkipRange: "<0.2.0", Skips: []string{"foo.v0.1.1", "foo.v0.1.2"}},
+					}},
+				},
+				Bundles: []declcfg.Bundle{
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.1.0-MIGRATED",
+						Package: "foo",
+						Image:   "test.registry/foo-operator/foo-bundle:v0.1.0",
+						Properties: []property.Property{
+							property.MustBuildGVK("test.foo", "v1", "Foo"),
+							property.MustBuildGVKRequired("test.bar", "v1alpha1", "Bar"),
+							property.MustBuildPackage("foo", "0.1.0"),
+							property.MustBuildPackageRequired("bar", "<0.1.0"),
+							property.MustBuildBundleObject(foov1crd),
+							property.MustBuildBundleObject(foov1csv),
+						},
+						RelatedImages: []declcfg.RelatedImage{
+							{
+								Image: "test.registry/foo-operator/foo-bundle:v0.1.0",
+							},
+							{
+								Name:  "operator",
+								Image: "test.registry/foo-operator/foo:v0.1.0",
+							},
+						},
+						CsvJSON: string(foov1csv),
+						Objects: []string{string(foov1csv), string(foov1crd)},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.2.0-MIGRATED",
+						Package: "foo",
+						Image:   "test.registry/foo-operator/foo-bundle:v0.2.0",
+						Properties: []property.Property{
+							property.MustBuildGVK("test.foo", "v1", "Foo"),
+							property.MustBuildGVKRequired("test.bar", "v1alpha1", "Bar"),
+							property.MustBuildPackage("foo", "0.2.0"),
+							property.MustBuildPackageRequired("bar", "<0.1.0"),
+							property.MustBuildBundleObject(foov2crd),
+							property.MustBuildBundleObject(foov2csv),
 						},
 						RelatedImages: []declcfg.RelatedImage{
 							{
@@ -452,9 +667,9 @@ func TestRender(t *testing.T) {
 		{
 			name: "Success/DeclcfgImageMigrate",
 			render: action.Render{
-				Refs:     []string{"test.registry/foo-operator/foo-index-declcfg:v0.2.0"},
-				Migrate:  true,
-				Registry: reg,
+				Refs:       []string{"test.registry/foo-operator/foo-index-declcfg:v0.2.0"},
+				Registry:   reg,
+				Migrations: &testMigrations,
 			},
 			expectCfg: &declcfg.DeclarativeConfig{
 				Packages: []declcfg.Package{
@@ -483,7 +698,7 @@ func TestRender(t *testing.T) {
 				Bundles: []declcfg.Bundle{
 					{
 						Schema:  "olm.bundle",
-						Name:    "foo.v0.1.0",
+						Name:    "foo.v0.1.0-MIGRATED",
 						Package: "foo",
 						Image:   "test.registry/foo-operator/foo-bundle:v0.1.0",
 						Properties: []property.Property{
@@ -491,7 +706,8 @@ func TestRender(t *testing.T) {
 							property.MustBuildGVKRequired("test.bar", "v1alpha1", "Bar"),
 							property.MustBuildPackage("foo", "0.1.0"),
 							property.MustBuildPackageRequired("bar", "<0.1.0"),
-							mustBuildCSVMetadata(bytes.NewReader(foov1csv)),
+							property.MustBuildBundleObject(foov1csv),
+							property.MustBuildBundleObject(foov1crd),
 						},
 						RelatedImages: []declcfg.RelatedImage{
 							{
@@ -507,7 +723,7 @@ func TestRender(t *testing.T) {
 					},
 					{
 						Schema:  "olm.bundle",
-						Name:    "foo.v0.2.0",
+						Name:    "foo.v0.2.0-MIGRATED",
 						Package: "foo",
 						Image:   "test.registry/foo-operator/foo-bundle:v0.2.0",
 						Properties: []property.Property{
@@ -515,7 +731,8 @@ func TestRender(t *testing.T) {
 							property.MustBuildGVKRequired("test.bar", "v1alpha1", "Bar"),
 							property.MustBuildPackage("foo", "0.2.0"),
 							property.MustBuildPackageRequired("bar", "<0.1.0"),
-							mustBuildCSVMetadata(bytes.NewReader(foov2csv)),
+							property.MustBuildBundleObject(foov2csv),
+							property.MustBuildBundleObject(foov2crd),
 						},
 						RelatedImages: []declcfg.RelatedImage{
 							{
@@ -549,9 +766,9 @@ func TestRender(t *testing.T) {
 		{
 			name: "Success/DeclcfgDirectoryMigrate",
 			render: action.Render{
-				Refs:     []string{"testdata/foo-index-v0.2.0-declcfg"},
-				Migrate:  true,
-				Registry: reg,
+				Refs:       []string{"testdata/foo-index-v0.2.0-declcfg"},
+				Registry:   reg,
+				Migrations: &testMigrations,
 			},
 			expectCfg: &declcfg.DeclarativeConfig{
 				Packages: []declcfg.Package{
@@ -580,7 +797,7 @@ func TestRender(t *testing.T) {
 				Bundles: []declcfg.Bundle{
 					{
 						Schema:  "olm.bundle",
-						Name:    "foo.v0.1.0",
+						Name:    "foo.v0.1.0-MIGRATED",
 						Package: "foo",
 						Image:   "test.registry/foo-operator/foo-bundle:v0.1.0",
 						Properties: []property.Property{
@@ -588,7 +805,8 @@ func TestRender(t *testing.T) {
 							property.MustBuildGVKRequired("test.bar", "v1alpha1", "Bar"),
 							property.MustBuildPackage("foo", "0.1.0"),
 							property.MustBuildPackageRequired("bar", "<0.1.0"),
-							mustBuildCSVMetadata(bytes.NewReader(foov1csv)),
+							property.MustBuildBundleObject(foov1csv),
+							property.MustBuildBundleObject(foov1crd),
 						},
 						RelatedImages: []declcfg.RelatedImage{
 							{
@@ -604,7 +822,7 @@ func TestRender(t *testing.T) {
 					},
 					{
 						Schema:  "olm.bundle",
-						Name:    "foo.v0.2.0",
+						Name:    "foo.v0.2.0-MIGRATED",
 						Package: "foo",
 						Image:   "test.registry/foo-operator/foo-bundle:v0.2.0",
 						Properties: []property.Property{
@@ -612,7 +830,8 @@ func TestRender(t *testing.T) {
 							property.MustBuildGVKRequired("test.bar", "v1alpha1", "Bar"),
 							property.MustBuildPackage("foo", "0.2.0"),
 							property.MustBuildPackageRequired("bar", "<0.1.0"),
-							mustBuildCSVMetadata(bytes.NewReader(foov2csv)),
+							property.MustBuildBundleObject(foov2csv),
+							property.MustBuildBundleObject(foov2crd),
 						},
 						RelatedImages: []declcfg.RelatedImage{
 							{
@@ -661,7 +880,59 @@ func TestRender(t *testing.T) {
 							property.MustBuildGVKRequired("test.bar", "v1alpha1", "Bar"),
 							property.MustBuildPackage("foo", "0.2.0"),
 							property.MustBuildPackageRequired("bar", "<0.1.0"),
-							mustBuildCSVMetadata(bytes.NewReader(foov2csv)),
+							property.MustBuildBundleObject(foov2crd),
+							property.MustBuildBundleObject(foov2csv),
+						},
+						Objects: []string{string(foov2csv), string(foov2crd)},
+						CsvJSON: string(foov2csv),
+						RelatedImages: []declcfg.RelatedImage{
+							{
+								Image: "test.registry/foo-operator/foo-2:v0.2.0",
+							},
+							{
+								Image: "test.registry/foo-operator/foo-bundle:v0.2.0",
+							},
+							{
+								Image: "test.registry/foo-operator/foo-init-2:v0.2.0",
+							},
+							{
+								Image: "test.registry/foo-operator/foo-init:v0.2.0",
+							},
+							{
+								Name:  "other",
+								Image: "test.registry/foo-operator/foo-other:v0.2.0",
+							},
+							{
+								Name:  "operator",
+								Image: "test.registry/foo-operator/foo:v0.2.0",
+							},
+						},
+					},
+				},
+			},
+			assertion: require.NoError,
+		},
+		{
+			name: "Success/BundleImageMigration",
+			render: action.Render{
+				Refs:       []string{"test.registry/foo-operator/foo-bundle:v0.2.0"},
+				Registry:   reg,
+				Migrations: &testMigrations,
+			},
+			expectCfg: &declcfg.DeclarativeConfig{
+				Bundles: []declcfg.Bundle{
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.2.0-MIGRATED",
+						Package: "foo",
+						Image:   "test.registry/foo-operator/foo-bundle:v0.2.0",
+						Properties: []property.Property{
+							property.MustBuildGVK("test.foo", "v1", "Foo"),
+							property.MustBuildGVKRequired("test.bar", "v1alpha1", "Bar"),
+							property.MustBuildPackage("foo", "0.2.0"),
+							property.MustBuildPackageRequired("bar", "<0.1.0"),
+							property.MustBuildBundleObject(foov2crd),
+							property.MustBuildBundleObject(foov2csv),
 						},
 						Objects: []string{string(foov2csv), string(foov2crd)},
 						CsvJSON: string(foov2csv),
@@ -710,7 +981,54 @@ func TestRender(t *testing.T) {
 							property.MustBuildGVKRequired("test.bar", "v1alpha1", "Bar"),
 							property.MustBuildPackage("foo", "0.2.0"),
 							property.MustBuildPackageRequired("bar", "<0.1.0"),
-							mustBuildCSVMetadata(bytes.NewReader(foov2csvNoRelatedImages)),
+							property.MustBuildBundleObject(foov2crdNoRelatedImages),
+							property.MustBuildBundleObject(foov2csvNoRelatedImages),
+						},
+						Objects: []string{string(foov2csvNoRelatedImages), string(foov2crdNoRelatedImages)},
+						CsvJSON: string(foov2csvNoRelatedImages),
+						RelatedImages: []declcfg.RelatedImage{
+							{
+								Image: "test.registry/foo-operator/foo-2:v0.2.0",
+							},
+							{
+								Image: "test.registry/foo-operator/foo-bundle-no-csv-related-images:v0.2.0",
+							},
+							{
+								Image: "test.registry/foo-operator/foo-init-2:v0.2.0",
+							},
+							{
+								Image: "test.registry/foo-operator/foo-init:v0.2.0",
+							},
+							{
+								Image: "test.registry/foo-operator/foo:v0.2.0",
+							},
+						},
+					},
+				},
+			},
+			assertion: require.NoError,
+		},
+		{
+			name: "Success/BundleImageWithNoCSVRelatedImagesMigration",
+			render: action.Render{
+				Refs:       []string{"test.registry/foo-operator/foo-bundle-no-csv-related-images:v0.2.0"},
+				Registry:   reg,
+				Migrations: &testMigrations,
+			},
+			expectCfg: &declcfg.DeclarativeConfig{
+				Bundles: []declcfg.Bundle{
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.2.0-MIGRATED",
+						Package: "foo",
+						Image:   "test.registry/foo-operator/foo-bundle-no-csv-related-images:v0.2.0",
+						Properties: []property.Property{
+							property.MustBuildGVK("test.foo", "v1", "Foo"),
+							property.MustBuildGVKRequired("test.bar", "v1alpha1", "Bar"),
+							property.MustBuildPackage("foo", "0.2.0"),
+							property.MustBuildPackageRequired("bar", "<0.1.0"),
+							property.MustBuildBundleObject(foov2crd),
+							property.MustBuildBundleObject(foov2csvNoRelatedImages),
 						},
 						Objects: []string{string(foov2csvNoRelatedImages), string(foov2crdNoRelatedImages)},
 						CsvJSON: string(foov2csvNoRelatedImages),
@@ -1080,12 +1398,4 @@ func generateSqliteFile(path string, imageMap map[image.Reference]string) error 
 		return err
 	}
 	return nil
-}
-
-func mustBuildCSVMetadata(r io.Reader) property.Property {
-	var csv v1alpha1.ClusterServiceVersion
-	if err := json.NewDecoder(r).Decode(&csv); err != nil {
-		panic(err)
-	}
-	return property.MustBuildCSVMetadata(csv)
 }

--- a/staging/operator-registry/alpha/template/basic/basic.go
+++ b/staging/operator-registry/alpha/template/basic/basic.go
@@ -6,12 +6,14 @@ import (
 	"io"
 
 	"github.com/operator-framework/operator-registry/alpha/action"
+	"github.com/operator-framework/operator-registry/alpha/action/migrations"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/pkg/image"
 )
 
 type Template struct {
-	Registry image.Registry
+	Registry   image.Registry
+	Migrations *migrations.Migrations
 }
 
 func (t Template) Render(ctx context.Context, reader io.Reader) (*declcfg.DeclarativeConfig, error) {
@@ -25,6 +27,7 @@ func (t Template) Render(ctx context.Context, reader io.Reader) (*declcfg.Declar
 	r := action.Render{
 		Registry:       t.Registry,
 		AllowedRefMask: action.RefBundleImage,
+		Migrations:     t.Migrations,
 	}
 
 	for _, b := range cfg.Bundles {

--- a/staging/operator-registry/alpha/template/composite/builder.go
+++ b/staging/operator-registry/alpha/template/composite/builder.go
@@ -13,6 +13,7 @@ import (
 
 	"sigs.k8s.io/yaml"
 
+	"github.com/operator-framework/operator-registry/alpha/action/migrations"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	basictemplate "github.com/operator-framework/operator-registry/alpha/template/basic"
 	semvertemplate "github.com/operator-framework/operator-registry/alpha/template/semver"
@@ -78,6 +79,12 @@ func (bb *BasicBuilder) Build(ctx context.Context, reg image.Registry, dir strin
 	}
 
 	b := basictemplate.Template{Registry: reg}
+	migrations, err := migrations.NewMigrations(migrations.AllMigrations)
+	if err != nil {
+		return fmt.Errorf("error creating migrations: %v", err)
+	}
+	b.Migrations = migrations
+
 	reader, err := os.Open(basicConfig.Input)
 	if err != nil {
 		return fmt.Errorf("error reading basic template: %v", err)
@@ -145,6 +152,11 @@ func (sb *SemverBuilder) Build(ctx context.Context, reg image.Registry, dir stri
 	defer reader.Close()
 
 	s := semvertemplate.Template{Registry: reg, Data: reader}
+	migrations, err := migrations.NewMigrations(migrations.AllMigrations)
+	if err != nil {
+		return fmt.Errorf("error creating migrations: %v", err)
+	}
+	s.Migrations = migrations
 
 	dcfg, err := s.Render(ctx)
 	if err != nil {

--- a/staging/operator-registry/alpha/template/semver/semver.go
+++ b/staging/operator-registry/alpha/template/semver/semver.go
@@ -7,12 +7,13 @@ import (
 	"sort"
 
 	"github.com/blang/semver/v4"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/yaml"
+
 	"github.com/operator-framework/operator-registry/alpha/action"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/alpha/property"
-	"k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 func (t Template) Render(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
@@ -35,6 +36,7 @@ func (t Template) Render(ctx context.Context) (*declcfg.DeclarativeConfig, error
 			AllowedRefMask: action.RefBundleImage,
 			Refs:           []string{b},
 			Registry:       t.Registry,
+			Migrations:     t.Migrations,
 		}
 		c, err := r.Run(ctx)
 		if err != nil {

--- a/staging/operator-registry/alpha/template/semver/types.go
+++ b/staging/operator-registry/alpha/template/semver/types.go
@@ -5,13 +5,16 @@ import (
 	"io"
 
 	"github.com/blang/semver/v4"
+
+	"github.com/operator-framework/operator-registry/alpha/action/migrations"
 	"github.com/operator-framework/operator-registry/pkg/image"
 )
 
 // data passed into this module externally
 type Template struct {
-	Data     io.Reader
-	Registry image.Registry
+	Data       io.Reader
+	Registry   image.Registry
+	Migrations *migrations.Migrations
 }
 
 // IO structs -- BEGIN

--- a/staging/operator-registry/cmd/opm/alpha/render-graph/cmd.go
+++ b/staging/operator-registry/cmd/opm/alpha/render-graph/cmd.go
@@ -5,11 +5,12 @@ import (
 	"log"
 	"os"
 
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/operator-framework/operator-registry/alpha/action"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/cmd/opm/internal/util"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 func NewCmd() *cobra.Command {

--- a/staging/operator-registry/cmd/opm/alpha/template/basic.go
+++ b/staging/operator-registry/cmd/opm/alpha/template/basic.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/operator-framework/operator-registry/alpha/action/migrations"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/alpha/template/basic"
 	"github.com/operator-framework/operator-registry/cmd/opm/internal/util"
@@ -15,8 +16,9 @@ import (
 
 func newBasicTemplateCmd() *cobra.Command {
 	var (
-		template basic.Template
-		output   string
+		template     basic.Template
+		output       string
+		migrateLevel string
 	)
 	cmd := &cobra.Command{
 		Use: "basic basic-template-file",
@@ -59,6 +61,14 @@ When FILE is '-' or not provided, the template is read from standard input`,
 
 			template.Registry = reg
 
+			if migrateLevel != "" {
+				m, err := migrations.NewMigrations(migrateLevel)
+				if err != nil {
+					log.Fatal(err)
+				}
+				template.Migrations = m
+			}
+
 			// only taking first file argument
 			cfg, err := template.Render(cmd.Context(), data)
 			if err != nil {
@@ -71,5 +81,7 @@ When FILE is '-' or not provided, the template is read from standard input`,
 		},
 	}
 	cmd.Flags().StringVarP(&output, "output", "o", "json", "Output format (json|yaml)")
+	cmd.Flags().StringVar(&migrateLevel, "migrate-level", "", "Name of the last migration to run (default: none)\n"+migrations.HelpText())
+
 	return cmd
 }

--- a/staging/operator-registry/cmd/opm/alpha/template/semver.go
+++ b/staging/operator-registry/cmd/opm/alpha/template/semver.go
@@ -7,15 +7,20 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 
+	"github.com/operator-framework/operator-registry/alpha/action/migrations"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/alpha/template/semver"
 	"github.com/operator-framework/operator-registry/cmd/opm/internal/util"
-	"github.com/spf13/cobra"
 )
 
 func newSemverTemplateCmd() *cobra.Command {
-	output := ""
+	var (
+		output       string
+		migrateLevel string
+	)
+
 	cmd := &cobra.Command{
 		Use: "semver [FILE]",
 		Short: `Generate a file-based catalog from a single 'semver template' file
@@ -64,6 +69,13 @@ When FILE is '-' or not provided, the template is read from standard input`,
 				Data:     data,
 				Registry: reg,
 			}
+			if migrateLevel != "" {
+				m, err := migrations.NewMigrations(migrateLevel)
+				if err != nil {
+					log.Fatal(err)
+				}
+				template.Migrations = m
+			}
 			out, err := template.Render(cmd.Context())
 			if err != nil {
 				log.Fatalf("semver %q: %v", source, err)
@@ -79,6 +91,8 @@ When FILE is '-' or not provided, the template is read from standard input`,
 		},
 	}
 
+	cmd.Flags().StringVar(&migrateLevel, "migrate-level", "", "Name of the last migration to run (default: none)\n"+migrations.HelpText())
 	cmd.Flags().StringVarP(&output, "output", "o", "json", "Output format (json|yaml|mermaid)")
+
 	return cmd
 }

--- a/staging/operator-registry/cmd/opm/render/cmd.go
+++ b/staging/operator-registry/cmd/opm/render/cmd.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/operator-framework/operator-registry/alpha/action"
+	"github.com/operator-framework/operator-registry/alpha/action/migrations"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/cmd/opm/internal/util"
 	"github.com/operator-framework/operator-registry/pkg/sqlite"
@@ -16,8 +17,11 @@ import (
 
 func NewCmd() *cobra.Command {
 	var (
-		render action.Render
-		output string
+		render           action.Render
+		output           string
+
+		oldMigrateAllFlag bool
+		migrateLevel      string
 	)
 	cmd := &cobra.Command{
 		Use:   "render [index-image | bundle-image | sqlite-file]...",
@@ -54,6 +58,18 @@ database files.
 
 			render.Registry = reg
 
+			// if the deprecated flag was used, set the level explicitly to the last migration to perform all migrations
+			var m *migrations.Migrations
+			if oldMigrateAllFlag {
+				m, err = migrations.NewMigrations(migrations.AllMigrations)
+			} else if migrateLevel != "" {
+				m, err = migrations.NewMigrations(migrateLevel)
+			}
+			if err != nil {
+				log.Fatal(err)
+			}
+			render.Migrations = m
+
 			cfg, err := render.Run(cmd.Context())
 			if err != nil {
 				log.Fatal(err)
@@ -65,7 +81,12 @@ database files.
 		},
 	}
 	cmd.Flags().StringVarP(&output, "output", "o", "json", "Output format of the streamed file-based catalog objects (json|yaml)")
-	cmd.Flags().BoolVar(&render.Migrate, "migrate", false, "Perform migrations on the rendered FBC")
+
+	cmd.Flags().StringVar(&migrateLevel, "migrate-level", "", "Name of the last migration to run (default: none)\n"+migrations.HelpText())
+	cmd.Flags().BoolVar(&oldMigrateAllFlag, "migrate", false, "Perform all available schema migrations on the rendered FBC")
+	cmd.MarkFlagsMutuallyExclusive("migrate", "migrate-level")
+
+	cmd.Long += "\n" + sqlite.DeprecationMessage
 	return cmd
 }
 

--- a/staging/operator-registry/pkg/api/api_to_model.go
+++ b/staging/operator-registry/pkg/api/api_to_model.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-
 	"github.com/operator-framework/operator-registry/alpha/model"
 	"github.com/operator-framework/operator-registry/alpha/property"
 )
@@ -108,17 +106,8 @@ func convertAPIBundleToModelProperties(b *Bundle) ([]property.Property, error) {
 		out = append(out, property.MustBuildGVKRequired(p.Group, p.Version, p.Kind))
 	}
 
-	// If there is a bundle image reference and a valid CSV, create an
-	// olm.csv.metadata property. Otherwise, create a bundle object property for
-	// each object in the bundle.
-	var csv v1alpha1.ClusterServiceVersion
-	csvErr := json.Unmarshal([]byte(b.CsvJson), &csv)
-	if csvErr == nil && b.BundlePath != "" {
-		out = append(out, property.MustBuildCSVMetadata(csv))
-	} else {
-		for _, obj := range b.Object {
-			out = append(out, property.MustBuildBundleObject([]byte(obj)))
-		}
+	for _, obj := range b.Object {
+		out = append(out, property.MustBuildBundleObject([]byte(obj)))
 	}
 
 	sort.Slice(out, func(i, j int) bool {

--- a/staging/operator-registry/pkg/api/conversion_test.go
+++ b/staging/operator-registry/pkg/api/conversion_test.go
@@ -59,7 +59,10 @@ func testModelBundle(t *testing.T) model.Bundle {
 			property.MustBuildPackageRequired("test", ">=1.2.3 <2.0.0-0"),
 			property.MustBuildGVKRequired("testapi.coreos.com", "v1", "Testapi"),
 			property.MustBuildGVK("etcd.database.coreos.com", "v1beta2", "EtcdBackup"),
-			property.MustBuildCSVMetadata(csv),
+			property.MustBuildBundleObject([]byte(crdbackups)),
+			property.MustBuildBundleObject([]byte(crdclusters)),
+			property.MustBuildBundleObject([]byte(csvJson)),
+			property.MustBuildBundleObject([]byte(crdrestores)),
 		},
 		CsvJSON: csvJson,
 		Objects: []string{

--- a/staging/operator-registry/pkg/registry/registry_to_model.go
+++ b/staging/operator-registry/pkg/registry/registry_to_model.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/operator-framework/api/pkg/operators"
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-
 	"github.com/operator-framework/operator-registry/alpha/property"
 )
 
@@ -102,21 +99,8 @@ func ObjectsAndPropertiesFromBundle(b *Bundle) ([]string, []property.Property, e
 		if err != nil {
 			return nil, nil, fmt.Errorf("marshal object %s/%s (%s) to json: %v", obj.GetName(), obj.GetNamespace(), obj.GroupVersionKind(), err)
 		}
+		props = append(props, property.MustBuildBundleObject(objData))
 		objects = append(objects, string(objData))
-
-		// Make an olm.bundle.object property if there is no bundle image set.
-		// Otherwise, make a olm.csv.metadata property if the object is a CSV
-		// (and fallback to olm.bundle.object if parsing the CSV fails).
-		if b.BundleImage == "" {
-			props = append(props, property.MustBuildBundleObject(objData))
-		} else if obj.GetKind() == operators.ClusterServiceVersionKind {
-			var csv v1alpha1.ClusterServiceVersion
-			if err := json.Unmarshal(objData, &csv); err != nil {
-				props = append(props, property.MustBuildBundleObject(objData))
-			} else {
-				props = append(props, property.MustBuildCSVMetadata(csv))
-			}
-		}
 	}
 
 	if packageProvidedProperty == nil {

--- a/staging/operator-registry/pkg/registry/registry_to_model_test.go
+++ b/staging/operator-registry/pkg/registry/registry_to_model_test.go
@@ -57,7 +57,9 @@ func testExpectedProperties(t *testing.T) []property.Property {
 			Type:  "olm.constraint",
 			Value: json.RawMessage(`{"cel":{"rule":"properties.exists(p, p.type == \"certified\")"},"failureMessage":"require to have \"certified\""}`),
 		},
-		property.MustBuildCSVMetadata(csv),
+	}
+	for _, obj := range testExpectedObjects() {
+		props = append(props, property.MustBuildBundleObject([]byte(obj)))
 	}
 	return props
 }

--- a/staging/operator-registry/pkg/server/server_test.go
+++ b/staging/operator-registry/pkg/server/server_test.go
@@ -32,11 +32,11 @@ const (
 	dbAddress = "localhost" + dbPort
 	dbName    = "test.db"
 
-	jsonCachePort    = ":50053"
-	jsonCacheAddress = "localhost" + jsonCachePort
+	cachePort    = ":50053"
+	cacheAddress = "localhost" + cachePort
 
-	jsonDeprecationCachePort    = ":50054"
-	jsonDeprecationCacheAddress = "localhost" + jsonDeprecationCachePort
+	deprecationCachePort    = ":50054"
+	deprecationCacheAddress = "localhost" + deprecationCachePort
 )
 
 func createDBStore(dbPath string) *sqlite.SQLQuerier {
@@ -146,7 +146,7 @@ func TestMain(m *testing.M) {
 		}
 	}()
 	go func() {
-		lis, err := net.Listen("tcp", jsonCachePort)
+		lis, err := net.Listen("tcp", cachePort)
 		if err != nil {
 			logrus.Fatalf("failed to listen: %v", err)
 		}
@@ -155,7 +155,7 @@ func TestMain(m *testing.M) {
 		}
 	}()
 	go func() {
-		lis, err := net.Listen("tcp", jsonDeprecationCacheAddress)
+		lis, err := net.Listen("tcp", deprecationCacheAddress)
 		if err != nil {
 			logrus.Fatalf("failed to listen: %v", err)
 		}
@@ -186,8 +186,8 @@ func TestListPackages(t *testing.T) {
 	)
 
 	t.Run("Sqlite", testListPackages(dbAddress, listPackagesExpected))
-	t.Run("FBCJsonCache", testListPackages(jsonCacheAddress, listPackagesExpected))
-	t.Run("FBCJsonCacheWithDeprecations", testListPackages(jsonDeprecationCacheAddress, listPackagesExpectedDep))
+	t.Run("FBCJsonCache", testListPackages(cacheAddress, listPackagesExpected))
+	t.Run("FBCJsonCacheWithDeprecations", testListPackages(deprecationCacheAddress, listPackagesExpectedDep))
 }
 
 func testListPackages(addr string, expected []string) func(*testing.T) {
@@ -262,8 +262,8 @@ func TestGetPackage(t *testing.T) {
 		}
 	)
 	t.Run("Sqlite", testGetPackage(dbAddress, getPackageExpected))
-	t.Run("FBCJsonCache", testGetPackage(jsonCacheAddress, getPackageExpected))
-	t.Run("FBCJsonCacheWithDeprecations", testGetPackage(jsonDeprecationCacheAddress, getPackageExpectedDep))
+	t.Run("FBCJsonCache", testGetPackage(cacheAddress, getPackageExpected))
+	t.Run("FBCJsonCacheWithDeprecations", testGetPackage(deprecationCacheAddress, getPackageExpectedDep))
 }
 
 func testGetPackage(addr string, expected *api.Package) func(*testing.T) {
@@ -314,8 +314,8 @@ func TestGetBundle(t *testing.T) {
 		}
 	)
 	t.Run("Sqlite", testGetBundle(dbAddress, etcdoperator_v0_9_2("alpha", false, false, includeManifestsAll)))
-	t.Run("FBCJsonCache", testGetBundle(jsonCacheAddress, etcdoperator_v0_9_2("alpha", false, true, includeManifestsCSVOnly)))
-	t.Run("FBCJsonCacheWithDeprecations", testGetBundle(jsonDeprecationCacheAddress, cockroachBundle))
+	t.Run("FBCCache", testGetBundle(cacheAddress, etcdoperator_v0_9_2("alpha", false, true, includeManifestsAll)))
+	t.Run("FBCCacheWithDeprecations", testGetBundle(deprecationCacheAddress, cockroachBundle))
 }
 
 func testGetBundle(addr string, expected *api.Bundle) func(*testing.T) {
@@ -338,7 +338,7 @@ func TestGetBundleForChannel(t *testing.T) {
 			CsvJson: b.CsvJson + "\n",
 		}))
 	}
-	t.Run("FBCJsonCache", testGetBundleForChannel(jsonCacheAddress, etcdoperator_v0_9_2("alpha", false, true, includeManifestsCSVOnly)))
+	t.Run("FBCCache", testGetBundleForChannel(cacheAddress, etcdoperator_v0_9_2("alpha", false, true, includeManifestsAll)))
 }
 
 func testGetBundleForChannel(addr string, expected *api.Bundle) func(*testing.T) {
@@ -386,8 +386,8 @@ func TestGetChannelEntriesThatReplace(t *testing.T) {
 	)
 
 	t.Run("Sqlite", testGetChannelEntriesThatReplace(dbAddress, getChannelEntriesThatReplaceExpected))
-	t.Run("FBCJsonCache", testGetChannelEntriesThatReplace(jsonCacheAddress, getChannelEntriesThatReplaceExpected))
-	t.Run("FBCJsonCacheWithDeprecations", testGetChannelEntriesThatReplace(jsonDeprecationCacheAddress, getChannelEntriesThatReplaceExpectedDep))
+	t.Run("FBCJsonCache", testGetChannelEntriesThatReplace(cacheAddress, getChannelEntriesThatReplaceExpected))
+	t.Run("FBCJsonCacheWithDeprecations", testGetChannelEntriesThatReplace(deprecationCacheAddress, getChannelEntriesThatReplaceExpectedDep))
 }
 
 func testGetChannelEntriesThatReplace(addr string, expected []*api.ChannelEntry) func(*testing.T) {
@@ -443,7 +443,7 @@ func testGetChannelEntriesThatReplace(addr string, expected []*api.ChannelEntry)
 
 func TestGetBundleThatReplaces(t *testing.T) {
 	t.Run("Sqlite", testGetBundleThatReplaces(dbAddress, etcdoperator_v0_9_2("alpha", false, false, includeManifestsAll)))
-	t.Run("FBCJsonCache", testGetBundleThatReplaces(jsonCacheAddress, etcdoperator_v0_9_2("alpha", false, true, includeManifestsCSVOnly)))
+	t.Run("FBCCache", testGetBundleThatReplaces(cacheAddress, etcdoperator_v0_9_2("alpha", false, true, includeManifestsAll)))
 }
 
 func testGetBundleThatReplaces(addr string, expected *api.Bundle) func(*testing.T) {
@@ -459,7 +459,7 @@ func testGetBundleThatReplaces(addr string, expected *api.Bundle) func(*testing.
 
 func TestGetBundleThatReplacesSynthetic(t *testing.T) {
 	t.Run("Sqlite", testGetBundleThatReplacesSynthetic(dbAddress, etcdoperator_v0_9_2("alpha", false, false, includeManifestsAll)))
-	t.Run("FBCJsonCache", testGetBundleThatReplacesSynthetic(jsonCacheAddress, etcdoperator_v0_9_2("alpha", false, true, includeManifestsCSVOnly)))
+	t.Run("FBCCache", testGetBundleThatReplacesSynthetic(cacheAddress, etcdoperator_v0_9_2("alpha", false, true, includeManifestsAll)))
 }
 
 func testGetBundleThatReplacesSynthetic(addr string, expected *api.Bundle) func(*testing.T) {
@@ -476,7 +476,7 @@ func testGetBundleThatReplacesSynthetic(addr string, expected *api.Bundle) func(
 
 func TestGetChannelEntriesThatProvide(t *testing.T) {
 	t.Run("Sqlite", testGetChannelEntriesThatProvide(dbAddress))
-	t.Run("FBCJsonCache", testGetChannelEntriesThatProvide(jsonCacheAddress))
+	t.Run("FBCJsonCache", testGetChannelEntriesThatProvide(cacheAddress))
 }
 
 func testGetChannelEntriesThatProvide(addr string) func(t *testing.T) {
@@ -593,7 +593,7 @@ func testGetChannelEntriesThatProvide(addr string) func(t *testing.T) {
 
 func TestGetLatestChannelEntriesThatProvide(t *testing.T) {
 	t.Run("Sqlite", testGetLatestChannelEntriesThatProvide(dbAddress))
-	t.Run("FBCJsonCache", testGetLatestChannelEntriesThatProvide(jsonCacheAddress))
+	t.Run("FBCJsonCache", testGetLatestChannelEntriesThatProvide(cacheAddress))
 }
 
 func testGetLatestChannelEntriesThatProvide(addr string) func(t *testing.T) {
@@ -669,7 +669,7 @@ func testGetLatestChannelEntriesThatProvide(addr string) func(t *testing.T) {
 
 func TestGetDefaultBundleThatProvides(t *testing.T) {
 	t.Run("Sqlite", testGetDefaultBundleThatProvides(dbAddress, etcdoperator_v0_9_2("alpha", false, false, includeManifestsAll)))
-	t.Run("FBCJsonCache", testGetDefaultBundleThatProvides(jsonCacheAddress, etcdoperator_v0_9_2("alpha", false, true, includeManifestsCSVOnly)))
+	t.Run("FBCCache", testGetDefaultBundleThatProvides(cacheAddress, etcdoperator_v0_9_2("alpha", false, true, includeManifestsAll)))
 }
 
 func testGetDefaultBundleThatProvides(addr string, expected *api.Bundle) func(*testing.T) {
@@ -687,7 +687,7 @@ func TestListBundles(t *testing.T) {
 	t.Run("Sqlite", testListBundles(dbAddress,
 		etcdoperator_v0_9_2("alpha", true, false, includeManifestsNone),
 		etcdoperator_v0_9_2("stable", true, false, includeManifestsNone)))
-	t.Run("FBCJsonCache", testListBundles(jsonCacheAddress,
+	t.Run("FBCJsonCache", testListBundles(cacheAddress,
 		etcdoperator_v0_9_2("alpha", true, true, includeManifestsNone),
 		etcdoperator_v0_9_2("stable", true, true, includeManifestsNone)))
 }

--- a/vendor/github.com/operator-framework/operator-registry/alpha/action/migrate.go
+++ b/vendor/github.com/operator-framework/operator-registry/alpha/action/migrate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/operator-framework/operator-registry/alpha/action/migrations"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/pkg/image"
 )
@@ -12,6 +13,7 @@ import (
 type Migrate struct {
 	CatalogRef string
 	OutputDir  string
+	Migrations *migrations.Migrations
 
 	WriteFunc declcfg.WriteFunc
 	FileExt   string
@@ -28,8 +30,8 @@ func (m Migrate) Run(ctx context.Context) error {
 	}
 
 	r := Render{
-		Refs:    []string{m.CatalogRef},
-		Migrate: true,
+		Refs:       []string{m.CatalogRef},
+		Migrations: m.Migrations,
 
 		// Only allow catalogs to be migrated.
 		AllowedRefMask: RefSqliteImage | RefSqliteFile | RefDCImage | RefDCDir,

--- a/vendor/github.com/operator-framework/operator-registry/alpha/action/migrations/000_bundle_object_to_csv_metadata.go
+++ b/vendor/github.com/operator-framework/operator-registry/alpha/action/migrations/000_bundle_object_to_csv_metadata.go
@@ -1,0 +1,47 @@
+package migrations
+
+import (
+	"encoding/json"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
+	"github.com/operator-framework/operator-registry/alpha/property"
+)
+
+func bundleObjectToCSVMetadata(cfg *declcfg.DeclarativeConfig) error {
+	convertBundleObjectToCSVMetadata := func(b *declcfg.Bundle) error {
+		if b.Image == "" || b.CsvJSON == "" {
+			return nil
+		}
+
+		var csv v1alpha1.ClusterServiceVersion
+		if err := json.Unmarshal([]byte(b.CsvJSON), &csv); err != nil {
+			return err
+		}
+
+		props := b.Properties[:0]
+		for _, p := range b.Properties {
+			switch p.Type {
+			case property.TypeBundleObject:
+				// Get rid of the bundle objects
+			case property.TypeCSVMetadata:
+				// If this bundle already has a CSV metadata
+				// property, we won't mutate the bundle at all.
+				return nil
+			default:
+				// Keep all of the other properties
+				props = append(props, p)
+			}
+		}
+		b.Properties = append(props, property.MustBuildCSVMetadata(csv))
+		return nil
+	}
+
+	for bi := range cfg.Bundles {
+		if err := convertBundleObjectToCSVMetadata(&cfg.Bundles[bi]); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/operator-framework/operator-registry/alpha/action/migrations/migrations.go
+++ b/vendor/github.com/operator-framework/operator-registry/alpha/action/migrations/migrations.go
@@ -1,0 +1,109 @@
+package migrations
+
+import (
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
+)
+
+type MigrationToken string
+
+const (
+	invalidMigration string = ""
+	NoMigrations     string = "none"
+	AllMigrations    string = "all"
+)
+
+type Migration interface {
+	Token() MigrationToken
+	Help() string
+	Migrate(*declcfg.DeclarativeConfig) error
+}
+
+func newMigration(token string, help string, fn func(config *declcfg.DeclarativeConfig) error) Migration {
+	return &simpleMigration{token: MigrationToken(token), help: help, fn: fn}
+}
+
+type simpleMigration struct {
+	token MigrationToken
+	help  string
+	fn    func(*declcfg.DeclarativeConfig) error
+}
+
+func (s simpleMigration) Token() MigrationToken {
+	return s.token
+}
+
+func (s simpleMigration) Migrate(config *declcfg.DeclarativeConfig) error {
+	return s.fn(config)
+}
+
+func (s simpleMigration) Help() string {
+	return s.help
+}
+
+type Migrations struct {
+	Migrations []Migration
+}
+
+// CloneAllMigrations returns a shallow copy of allMigrations
+// since slices.Clone is not available in the current golang version
+func CloneAllMigrations() []Migration {
+	return append(allMigrations[:0:0], allMigrations...)
+}
+
+// allMigrations represents the migration catalog
+// the order of these migrations is important
+var allMigrations = []Migration{
+	newMigration(NoMigrations, "do nothing", func(_ *declcfg.DeclarativeConfig) error { return nil }),
+	newMigration("bundle-object-to-csv-metadata", `migrates bundles' "olm.bundle.object" to "olm.csv.metadata"`, bundleObjectToCSVMetadata),
+}
+
+func NewMigrations(name string) (*Migrations, error) {
+	if name == AllMigrations {
+		return &Migrations{Migrations: CloneAllMigrations()}, nil
+	}
+
+	migrations := CloneAllMigrations()
+
+	found := false
+	keep := migrations[:0]
+	for _, migration := range migrations {
+		keep = append(keep, migration)
+		if migration.Token() == MigrationToken(name) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil, fmt.Errorf("unknown migration level %q", name)
+	}
+	return &Migrations{Migrations: keep}, nil
+}
+
+func HelpText() string {
+	var help strings.Builder
+	help.WriteString("\nThe migrator will run all migrations up to and including the selected level.\n\n")
+	help.WriteString("Available migrators:\n")
+	if len(allMigrations) == 0 {
+		help.WriteString("   (no migrations available in this version)\n")
+	}
+
+	tabber := tabwriter.NewWriter(&help, 0, 0, 1, ' ', 0)
+	for _, migration := range allMigrations {
+		fmt.Fprintf(tabber, "  - %s\t: %s\n", migration.Token(), migration.Help())
+	}
+	tabber.Flush()
+	return help.String()
+}
+
+func (m *Migrations) Migrate(config *declcfg.DeclarativeConfig) error {
+	for _, migration := range m.Migrations {
+		if err := migration.Migrate(config); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/operator-framework/operator-registry/alpha/action/render.go
+++ b/vendor/github.com/operator-framework/operator-registry/alpha/action/render.go
@@ -15,10 +15,10 @@ import (
 
 	"github.com/h2non/filetype"
 	"github.com/h2non/filetype/matchers"
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/operator-framework/operator-registry/alpha/action/migrations"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/alpha/property"
 	"github.com/operator-framework/operator-registry/pkg/containertools"
@@ -50,10 +50,10 @@ func (r RefType) Allowed(refType RefType) bool {
 var ErrNotAllowed = errors.New("not allowed")
 
 type Render struct {
-	Refs           []string
-	Registry       image.Registry
-	AllowedRefMask RefType
-	Migrate        bool
+	Refs             []string
+	Registry         image.Registry
+	AllowedRefMask   RefType
+	Migrations       *migrations.Migrations
 
 	skipSqliteDeprecationLog bool
 }
@@ -92,10 +92,8 @@ func (r Render) Run(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
 			})
 		}
 
-		if r.Migrate {
-			if err := migrate(cfg); err != nil {
-				return nil, fmt.Errorf("migrate: %v", err)
-			}
+		if err := r.migrate(cfg); err != nil {
+			return nil, fmt.Errorf("migrate: %v", err)
 		}
 
 		cfgs = append(cfgs, *cfg)
@@ -403,48 +401,12 @@ func moveBundleObjectsToEndOfPropertySlices(cfg *declcfg.DeclarativeConfig) {
 	}
 }
 
-func migrate(cfg *declcfg.DeclarativeConfig) error {
-	migrations := []func(*declcfg.DeclarativeConfig) error{
-		convertObjectsToCSVMetadata,
+func (r Render) migrate(cfg *declcfg.DeclarativeConfig) error {
+	// If there are no migrations, do nothing.
+	if r.Migrations == nil {
+		return nil
 	}
-
-	for _, m := range migrations {
-		if err := m(cfg); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func convertObjectsToCSVMetadata(cfg *declcfg.DeclarativeConfig) error {
-BundleLoop:
-	for bi, b := range cfg.Bundles {
-		if b.Image == "" || b.CsvJSON == "" {
-			continue
-		}
-
-		var csv v1alpha1.ClusterServiceVersion
-		if err := json.Unmarshal([]byte(b.CsvJSON), &csv); err != nil {
-			return err
-		}
-
-		props := b.Properties[:0]
-		for _, p := range b.Properties {
-			switch p.Type {
-			case property.TypeBundleObject:
-				// Get rid of the bundle objects
-			case property.TypeCSVMetadata:
-				// If this bundle already has a CSV metadata
-				// property, we won't mutate the bundle at all.
-				continue BundleLoop
-			default:
-				// Keep all of the other properties
-				props = append(props, p)
-			}
-		}
-		cfg.Bundles[bi].Properties = append(props, property.MustBuildCSVMetadata(csv))
-	}
-	return nil
+	return r.Migrations.Migrate(cfg)
 }
 
 func combineConfigs(cfgs []declcfg.DeclarativeConfig) *declcfg.DeclarativeConfig {

--- a/vendor/github.com/operator-framework/operator-registry/alpha/template/basic/basic.go
+++ b/vendor/github.com/operator-framework/operator-registry/alpha/template/basic/basic.go
@@ -6,12 +6,14 @@ import (
 	"io"
 
 	"github.com/operator-framework/operator-registry/alpha/action"
+	"github.com/operator-framework/operator-registry/alpha/action/migrations"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/pkg/image"
 )
 
 type Template struct {
-	Registry image.Registry
+	Registry   image.Registry
+	Migrations *migrations.Migrations
 }
 
 func (t Template) Render(ctx context.Context, reader io.Reader) (*declcfg.DeclarativeConfig, error) {
@@ -25,6 +27,7 @@ func (t Template) Render(ctx context.Context, reader io.Reader) (*declcfg.Declar
 	r := action.Render{
 		Registry:       t.Registry,
 		AllowedRefMask: action.RefBundleImage,
+		Migrations:     t.Migrations,
 	}
 
 	for _, b := range cfg.Bundles {

--- a/vendor/github.com/operator-framework/operator-registry/alpha/template/composite/builder.go
+++ b/vendor/github.com/operator-framework/operator-registry/alpha/template/composite/builder.go
@@ -13,6 +13,7 @@ import (
 
 	"sigs.k8s.io/yaml"
 
+	"github.com/operator-framework/operator-registry/alpha/action/migrations"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	basictemplate "github.com/operator-framework/operator-registry/alpha/template/basic"
 	semvertemplate "github.com/operator-framework/operator-registry/alpha/template/semver"
@@ -78,6 +79,12 @@ func (bb *BasicBuilder) Build(ctx context.Context, reg image.Registry, dir strin
 	}
 
 	b := basictemplate.Template{Registry: reg}
+	migrations, err := migrations.NewMigrations(migrations.AllMigrations)
+	if err != nil {
+		return fmt.Errorf("error creating migrations: %v", err)
+	}
+	b.Migrations = migrations
+
 	reader, err := os.Open(basicConfig.Input)
 	if err != nil {
 		return fmt.Errorf("error reading basic template: %v", err)
@@ -145,6 +152,11 @@ func (sb *SemverBuilder) Build(ctx context.Context, reg image.Registry, dir stri
 	defer reader.Close()
 
 	s := semvertemplate.Template{Registry: reg, Data: reader}
+	migrations, err := migrations.NewMigrations(migrations.AllMigrations)
+	if err != nil {
+		return fmt.Errorf("error creating migrations: %v", err)
+	}
+	s.Migrations = migrations
 
 	dcfg, err := s.Render(ctx)
 	if err != nil {

--- a/vendor/github.com/operator-framework/operator-registry/alpha/template/semver/semver.go
+++ b/vendor/github.com/operator-framework/operator-registry/alpha/template/semver/semver.go
@@ -7,12 +7,13 @@ import (
 	"sort"
 
 	"github.com/blang/semver/v4"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/yaml"
+
 	"github.com/operator-framework/operator-registry/alpha/action"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/alpha/property"
-	"k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 func (t Template) Render(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
@@ -35,6 +36,7 @@ func (t Template) Render(ctx context.Context) (*declcfg.DeclarativeConfig, error
 			AllowedRefMask: action.RefBundleImage,
 			Refs:           []string{b},
 			Registry:       t.Registry,
+			Migrations:     t.Migrations,
 		}
 		c, err := r.Run(ctx)
 		if err != nil {

--- a/vendor/github.com/operator-framework/operator-registry/alpha/template/semver/types.go
+++ b/vendor/github.com/operator-framework/operator-registry/alpha/template/semver/types.go
@@ -5,13 +5,16 @@ import (
 	"io"
 
 	"github.com/blang/semver/v4"
+
+	"github.com/operator-framework/operator-registry/alpha/action/migrations"
 	"github.com/operator-framework/operator-registry/pkg/image"
 )
 
 // data passed into this module externally
 type Template struct {
-	Data     io.Reader
-	Registry image.Registry
+	Data       io.Reader
+	Registry   image.Registry
+	Migrations *migrations.Migrations
 }
 
 // IO structs -- BEGIN

--- a/vendor/github.com/operator-framework/operator-registry/cmd/opm/alpha/render-graph/cmd.go
+++ b/vendor/github.com/operator-framework/operator-registry/cmd/opm/alpha/render-graph/cmd.go
@@ -5,11 +5,12 @@ import (
 	"log"
 	"os"
 
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/operator-framework/operator-registry/alpha/action"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/cmd/opm/internal/util"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 func NewCmd() *cobra.Command {

--- a/vendor/github.com/operator-framework/operator-registry/cmd/opm/alpha/template/basic.go
+++ b/vendor/github.com/operator-framework/operator-registry/cmd/opm/alpha/template/basic.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/operator-framework/operator-registry/alpha/action/migrations"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/alpha/template/basic"
 	"github.com/operator-framework/operator-registry/cmd/opm/internal/util"
@@ -15,8 +16,9 @@ import (
 
 func newBasicTemplateCmd() *cobra.Command {
 	var (
-		template basic.Template
-		output   string
+		template     basic.Template
+		output       string
+		migrateLevel string
 	)
 	cmd := &cobra.Command{
 		Use: "basic basic-template-file",
@@ -59,6 +61,14 @@ When FILE is '-' or not provided, the template is read from standard input`,
 
 			template.Registry = reg
 
+			if migrateLevel != "" {
+				m, err := migrations.NewMigrations(migrateLevel)
+				if err != nil {
+					log.Fatal(err)
+				}
+				template.Migrations = m
+			}
+
 			// only taking first file argument
 			cfg, err := template.Render(cmd.Context(), data)
 			if err != nil {
@@ -71,5 +81,7 @@ When FILE is '-' or not provided, the template is read from standard input`,
 		},
 	}
 	cmd.Flags().StringVarP(&output, "output", "o", "json", "Output format (json|yaml)")
+	cmd.Flags().StringVar(&migrateLevel, "migrate-level", "", "Name of the last migration to run (default: none)\n"+migrations.HelpText())
+
 	return cmd
 }

--- a/vendor/github.com/operator-framework/operator-registry/cmd/opm/alpha/template/semver.go
+++ b/vendor/github.com/operator-framework/operator-registry/cmd/opm/alpha/template/semver.go
@@ -7,15 +7,20 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 
+	"github.com/operator-framework/operator-registry/alpha/action/migrations"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/alpha/template/semver"
 	"github.com/operator-framework/operator-registry/cmd/opm/internal/util"
-	"github.com/spf13/cobra"
 )
 
 func newSemverTemplateCmd() *cobra.Command {
-	output := ""
+	var (
+		output       string
+		migrateLevel string
+	)
+
 	cmd := &cobra.Command{
 		Use: "semver [FILE]",
 		Short: `Generate a file-based catalog from a single 'semver template' file
@@ -64,6 +69,13 @@ When FILE is '-' or not provided, the template is read from standard input`,
 				Data:     data,
 				Registry: reg,
 			}
+			if migrateLevel != "" {
+				m, err := migrations.NewMigrations(migrateLevel)
+				if err != nil {
+					log.Fatal(err)
+				}
+				template.Migrations = m
+			}
 			out, err := template.Render(cmd.Context())
 			if err != nil {
 				log.Fatalf("semver %q: %v", source, err)
@@ -79,6 +91,8 @@ When FILE is '-' or not provided, the template is read from standard input`,
 		},
 	}
 
+	cmd.Flags().StringVar(&migrateLevel, "migrate-level", "", "Name of the last migration to run (default: none)\n"+migrations.HelpText())
 	cmd.Flags().StringVarP(&output, "output", "o", "json", "Output format (json|yaml|mermaid)")
+
 	return cmd
 }

--- a/vendor/github.com/operator-framework/operator-registry/cmd/opm/render/cmd.go
+++ b/vendor/github.com/operator-framework/operator-registry/cmd/opm/render/cmd.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/operator-framework/operator-registry/alpha/action"
+	"github.com/operator-framework/operator-registry/alpha/action/migrations"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/cmd/opm/internal/util"
 	"github.com/operator-framework/operator-registry/pkg/sqlite"
@@ -16,8 +17,11 @@ import (
 
 func NewCmd() *cobra.Command {
 	var (
-		render action.Render
-		output string
+		render           action.Render
+		output           string
+
+		oldMigrateAllFlag bool
+		migrateLevel      string
 	)
 	cmd := &cobra.Command{
 		Use:   "render [index-image | bundle-image | sqlite-file]...",
@@ -54,6 +58,18 @@ database files.
 
 			render.Registry = reg
 
+			// if the deprecated flag was used, set the level explicitly to the last migration to perform all migrations
+			var m *migrations.Migrations
+			if oldMigrateAllFlag {
+				m, err = migrations.NewMigrations(migrations.AllMigrations)
+			} else if migrateLevel != "" {
+				m, err = migrations.NewMigrations(migrateLevel)
+			}
+			if err != nil {
+				log.Fatal(err)
+			}
+			render.Migrations = m
+
 			cfg, err := render.Run(cmd.Context())
 			if err != nil {
 				log.Fatal(err)
@@ -65,7 +81,12 @@ database files.
 		},
 	}
 	cmd.Flags().StringVarP(&output, "output", "o", "json", "Output format of the streamed file-based catalog objects (json|yaml)")
-	cmd.Flags().BoolVar(&render.Migrate, "migrate", false, "Perform migrations on the rendered FBC")
+
+	cmd.Flags().StringVar(&migrateLevel, "migrate-level", "", "Name of the last migration to run (default: none)\n"+migrations.HelpText())
+	cmd.Flags().BoolVar(&oldMigrateAllFlag, "migrate", false, "Perform all available schema migrations on the rendered FBC")
+	cmd.MarkFlagsMutuallyExclusive("migrate", "migrate-level")
+
+	cmd.Long += "\n" + sqlite.DeprecationMessage
 	return cmd
 }
 

--- a/vendor/github.com/operator-framework/operator-registry/pkg/api/api_to_model.go
+++ b/vendor/github.com/operator-framework/operator-registry/pkg/api/api_to_model.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-
 	"github.com/operator-framework/operator-registry/alpha/model"
 	"github.com/operator-framework/operator-registry/alpha/property"
 )
@@ -108,17 +106,8 @@ func convertAPIBundleToModelProperties(b *Bundle) ([]property.Property, error) {
 		out = append(out, property.MustBuildGVKRequired(p.Group, p.Version, p.Kind))
 	}
 
-	// If there is a bundle image reference and a valid CSV, create an
-	// olm.csv.metadata property. Otherwise, create a bundle object property for
-	// each object in the bundle.
-	var csv v1alpha1.ClusterServiceVersion
-	csvErr := json.Unmarshal([]byte(b.CsvJson), &csv)
-	if csvErr == nil && b.BundlePath != "" {
-		out = append(out, property.MustBuildCSVMetadata(csv))
-	} else {
-		for _, obj := range b.Object {
-			out = append(out, property.MustBuildBundleObject([]byte(obj)))
-		}
+	for _, obj := range b.Object {
+		out = append(out, property.MustBuildBundleObject([]byte(obj)))
 	}
 
 	sort.Slice(out, func(i, j int) bool {

--- a/vendor/github.com/operator-framework/operator-registry/pkg/registry/registry_to_model.go
+++ b/vendor/github.com/operator-framework/operator-registry/pkg/registry/registry_to_model.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/operator-framework/api/pkg/operators"
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-
 	"github.com/operator-framework/operator-registry/alpha/property"
 )
 
@@ -102,21 +99,8 @@ func ObjectsAndPropertiesFromBundle(b *Bundle) ([]string, []property.Property, e
 		if err != nil {
 			return nil, nil, fmt.Errorf("marshal object %s/%s (%s) to json: %v", obj.GetName(), obj.GetNamespace(), obj.GroupVersionKind(), err)
 		}
+		props = append(props, property.MustBuildBundleObject(objData))
 		objects = append(objects, string(objData))
-
-		// Make an olm.bundle.object property if there is no bundle image set.
-		// Otherwise, make a olm.csv.metadata property if the object is a CSV
-		// (and fallback to olm.bundle.object if parsing the CSV fails).
-		if b.BundleImage == "" {
-			props = append(props, property.MustBuildBundleObject(objData))
-		} else if obj.GetKind() == operators.ClusterServiceVersionKind {
-			var csv v1alpha1.ClusterServiceVersion
-			if err := json.Unmarshal(objData, &csv); err != nil {
-				props = append(props, property.MustBuildBundleObject(objData))
-			} else {
-				props = append(props, property.MustBuildCSVMetadata(csv))
-			}
-		}
 	}
 
 	if packageProvidedProperty == nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -837,6 +837,7 @@ github.com/operator-framework/operator-lifecycle-manager/util/cpb
 # github.com/operator-framework/operator-registry v1.33.0 => ./staging/operator-registry
 ## explicit; go 1.20
 github.com/operator-framework/operator-registry/alpha/action
+github.com/operator-framework/operator-registry/alpha/action/migrations
 github.com/operator-framework/operator-registry/alpha/declcfg
 github.com/operator-framework/operator-registry/alpha/model
 github.com/operator-framework/operator-registry/alpha/property


### PR DESCRIPTION
Fix-up of #870 

    Allow disabling of migrations for bundles and sqlite DBs
    intro new migrations package
    schema migration optional; default to olm.bundle.object
    review resolutions
    use a type to protect migration interactions
    review revisions

Upstream-repository: operator-registry
Upstream-commit: c80e8751e716c069017b55279a0f29d0254d426a