### PR TITLE
OCPBUGS-38610: (fix) Resolver: list CatSrc using client, instead of referring to registry-server cache (#3349)

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
@@ -193,7 +193,7 @@ func NewOperator(ctx context.Context, kubeconfigPath string, clock utilclock.Clo
 		clientFactory:            clients.NewFactory(config),
 	}
 	op.sources = grpc.NewSourceStore(logger, 10*time.Second, 10*time.Minute, op.syncSourceState)
-	op.sourceInvalidator = resolver.SourceProviderFromRegistryClientProvider(op.sources, logger)
+	op.sourceInvalidator = resolver.SourceProviderFromRegistryClientProvider(op.sources, lister.OperatorsV1alpha1().CatalogSourceLister(), logger)
 	resolverSourceProvider := NewOperatorGroupToggleSourceProvider(op.sourceInvalidator, logger, op.lister.OperatorsV1().OperatorGroupLister())
 	op.reconciler = reconciler.NewRegistryReconcilerFactory(lister, opClient, configmapRegistryImage, op.now, ssaClient, workloadUserID)
 	res := resolver.NewOperatorStepResolver(lister, crClient, operatorNamespace, resolverSourceProvider, logger)

--- a/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/cache/cache.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/cache/cache.go
@@ -139,7 +139,7 @@ func (c *NamespacedOperatorCache) Error() error {
 		err := snapshot.err
 		snapshot.m.RUnlock()
 		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to populate resolver cache from source %v: %w", key.String(), err))
+			errs = append(errs, fmt.Errorf("error using catalogsource %s/%s: %w", key.Namespace, key.Name, err))
 		}
 	}
 	return errors.NewAggregate(errs)

--- a/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/cache/cache_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/cache/cache_test.go
@@ -238,5 +238,5 @@ func TestNamespaceOperatorCacheError(t *testing.T) {
 		key: ErrorSource{Error: errors.New("testing")},
 	})
 
-	require.EqualError(t, c.Namespaced("dummynamespace").Error(), "failed to populate resolver cache from source dummyname/dummynamespace: testing")
+	require.EqualError(t, c.Namespaced("dummynamespace").Error(), "error using catalogsource dummynamespace/dummyname: testing")
 }

--- a/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/step_resolver.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/step_resolver.go
@@ -9,9 +9,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	v1listers "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1"
 	v1alpha1listers "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
 	controllerbundle "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/bundle"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
@@ -21,6 +23,7 @@ import (
 
 const (
 	BundleLookupConditionPacked v1alpha1.BundleLookupConditionType = "BundleLookupNotPersisted"
+	exclusionAnnotation         string                             = "olm.operatorframework.io/exclude-global-namespace-resolution"
 )
 
 // init hooks provides the downstream a way to modify the upstream behavior
@@ -33,6 +36,7 @@ type StepResolver interface {
 type OperatorStepResolver struct {
 	subLister              v1alpha1listers.SubscriptionLister
 	csvLister              v1alpha1listers.ClusterServiceVersionLister
+	ogLister               v1listers.OperatorGroupLister
 	client                 versioned.Interface
 	globalCatalogNamespace string
 	resolver               *Resolver
@@ -69,6 +73,7 @@ func NewOperatorStepResolver(lister operatorlister.OperatorLister, client versio
 	stepResolver := &OperatorStepResolver{
 		subLister:              lister.OperatorsV1alpha1().SubscriptionLister(),
 		csvLister:              lister.OperatorsV1alpha1().ClusterServiceVersionLister(),
+		ogLister:               lister.OperatorsV1().OperatorGroupLister(),
 		client:                 client,
 		globalCatalogNamespace: globalCatalogNamespace,
 		resolver:               NewDefaultResolver(cacheSourceProvider, catsrcPriorityProvider{lister: lister.OperatorsV1alpha1().CatalogSourceLister()}, log),
@@ -91,7 +96,22 @@ func (r *OperatorStepResolver) ResolveSteps(namespace string) ([]*v1alpha1.Step,
 		return nil, nil, nil, err
 	}
 
-	namespaces := []string{namespace, r.globalCatalogNamespace}
+	namespaces := []string{namespace}
+	ogs, err := r.ogLister.OperatorGroups(namespace).List(labels.Everything())
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("listing operatorgroups in namespace %s: %s", namespace, err)
+	}
+	if len(ogs) != 1 {
+		return nil, nil, nil, fmt.Errorf("expected 1 OperatorGroup in the namespace, found %d", len(ogs))
+	}
+	og := ogs[0]
+	if val, ok := og.Annotations[exclusionAnnotation]; ok && val == "true" {
+		// Exclusion specified
+		// Ignore the globalNamespace for the purposes of resolution in this namespace
+		r.log.Printf("excluding global catalogs from resolution in namespace %s", namespace)
+	} else {
+		namespaces = append(namespaces, r.globalCatalogNamespace)
+	}
 	operators, err := r.resolver.Resolve(namespaces, subs)
 	if err != nil {
 		return nil, nil, nil, err

--- a/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/step_resolver_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/step_resolver_test.go
@@ -335,6 +335,7 @@ func TestResolver(t *testing.T) {
 			name: "SubscriptionOmitsChannel",
 			clusterState: []runtime.Object{
 				newSub(namespace, "package", "", catalog),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{
 				catalog: {
@@ -354,6 +355,7 @@ func TestResolver(t *testing.T) {
 			name: "SubscriptionWithNoCandidates/Error",
 			clusterState: []runtime.Object{
 				newSub(namespace, "a", "alpha", catalog),
+				newOperatorGroup("foo", namespace),
 			},
 			out: resolverTestOut{
 				solverError: solver.NotSatisfiable{
@@ -372,6 +374,7 @@ func TestResolver(t *testing.T) {
 			name: "SubscriptionWithNoCandidatesInPackage/Error",
 			clusterState: []runtime.Object{
 				newSub(namespace, "a", "alpha", catalog),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{
 				catalog: {
@@ -395,6 +398,7 @@ func TestResolver(t *testing.T) {
 			name: "SubscriptionWithNoCandidatesInChannel/Error",
 			clusterState: []runtime.Object{
 				newSub(namespace, "a", "alpha", catalog),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{
 				catalog: {
@@ -418,6 +422,7 @@ func TestResolver(t *testing.T) {
 			name: "SubscriptionWithNoCandidatesWithStartingCSVName/Error",
 			clusterState: []runtime.Object{
 				newSub(namespace, "a", "alpha", catalog, withStartingCSV("notfound")),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{
 				catalog: {
@@ -441,6 +446,7 @@ func TestResolver(t *testing.T) {
 			name: "SingleNewSubscription/NoDeps",
 			clusterState: []runtime.Object{
 				newSub(namespace, "a", "alpha", catalog),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{
 				catalog: {
@@ -460,6 +466,7 @@ func TestResolver(t *testing.T) {
 			name: "SingleNewSubscription/ResolveOne",
 			clusterState: []runtime.Object{
 				newSub(namespace, "a", "alpha", catalog),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{
 				catalog: {
@@ -482,6 +489,7 @@ func TestResolver(t *testing.T) {
 			name: "SingleNewSubscription/ResolveOne/BundlePath",
 			clusterState: []runtime.Object{
 				newSub(namespace, "a", "alpha", catalog),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{
 				catalog: {
@@ -528,6 +536,7 @@ func TestResolver(t *testing.T) {
 			name: "SingleNewSubscription/ResolveOne/AdditionalBundleObjects",
 			clusterState: []runtime.Object{
 				newSub(namespace, "a", "alpha", catalog),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{
 				catalog: {
@@ -550,6 +559,7 @@ func TestResolver(t *testing.T) {
 			name: "SingleNewSubscription/ResolveOne/AdditionalBundleObjects/Service",
 			clusterState: []runtime.Object{
 				newSub(namespace, "a", "alpha", catalog),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{
 				catalog: {
@@ -572,6 +582,7 @@ func TestResolver(t *testing.T) {
 			name: "SingleNewSubscription/DependencyMissing",
 			clusterState: []runtime.Object{
 				newSub(namespace, "a", "alpha", catalog),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{
 				catalog: {
@@ -606,6 +617,7 @@ func TestResolver(t *testing.T) {
 			clusterState: []runtime.Object{
 				existingSub(namespace, "a.v1", "a", "alpha", catalog),
 				existingOperator(namespace, "a.v1", "a", "alpha", "", Provides1, nil, nil, nil),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{
 				catalog: {
@@ -620,6 +632,7 @@ func TestResolver(t *testing.T) {
 				existingSub(namespace, "a.v1", "a", "alpha", catalog),
 				existingSub(namespace, "b.v1", "b", "alpha", catalog),
 				existingOperator(namespace, "a.v1", "a", "alpha", "", Provides1, nil, nil, nil),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{
 				catalog: {
@@ -638,6 +651,7 @@ func TestResolver(t *testing.T) {
 			clusterState: []runtime.Object{
 				newSub(namespace, "a", "alpha", catalog),
 				newSub(namespace, "a", "beta", catalog),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{
 				catalog: {
@@ -664,6 +678,7 @@ func TestResolver(t *testing.T) {
 					s.Name = s.Name + "-2"
 					return
 				}(),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{
 				catalog: {
@@ -689,6 +704,7 @@ func TestResolver(t *testing.T) {
 			clusterState: []runtime.Object{
 				existingOperator("ns1", "a.v1", "a", "alpha", "", nil, nil, nil, nil),
 				existingOperator("ns2", "a.v1", "a", "alpha", "", nil, nil, nil, nil),
+				newOperatorGroup("foo", namespace),
 			},
 			out: nothing,
 		},
@@ -697,6 +713,7 @@ func TestResolver(t *testing.T) {
 			clusterState: []runtime.Object{
 				existingSub(namespace, "a.v1", "a", "alpha", catalog),
 				existingOperator(namespace, "a.v1", "a", "alpha", "", Provides1, nil, nil, nil),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{
 				catalog: {
@@ -718,6 +735,7 @@ func TestResolver(t *testing.T) {
 			clusterState: []runtime.Object{
 				existingSub(namespace, "a.v1", "a", "alpha", catalog),
 				existingOperator(namespace, "a.v1", "a", "alpha", "", Provides1, nil, nil, nil),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{catalog: {
 				stripManifests(withBundlePath(bundle("a.v2", "a", "alpha", "a.v1", Provides1, nil, nil, nil), "quay.io/test/bundle@sha256:abcd"))},
@@ -759,6 +777,7 @@ func TestResolver(t *testing.T) {
 			name: "InstalledSub/NoRunningOperator",
 			clusterState: []runtime.Object{
 				existingSub(namespace, "a.v1", "a", "alpha", catalog),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{
 				catalog: {
@@ -778,6 +797,7 @@ func TestResolver(t *testing.T) {
 			clusterState: []runtime.Object{
 				existingSub(namespace, "a.v1", "a", "alpha", catalog),
 				existingOperator(namespace, "a.v1", "a", "alpha", "", Provides1, nil, nil, nil),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{
 				catalog: {
@@ -802,6 +822,7 @@ func TestResolver(t *testing.T) {
 			clusterState: []runtime.Object{
 				existingSub(namespace, "a.v1", "a", "alpha", catalog),
 				existingOperator(namespace, "a.v1", "a", "alpha", "", nil, nil, Provides1, nil),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{
 				catalog: {
@@ -827,6 +848,7 @@ func TestResolver(t *testing.T) {
 				existingSub(namespace, "a.v1", "a", "alpha", catalog),
 				existingOperator(namespace, "a.v1", "a", "alpha", "", Provides1, nil, nil, nil),
 				newSub(namespace, "b", "beta", catalog),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{
 				catalog: {
@@ -851,6 +873,7 @@ func TestResolver(t *testing.T) {
 			clusterState: []runtime.Object{
 				existingSub(namespace, "a.v1", "a", "alpha", catalog),
 				newSub(namespace, "b", "beta", catalog),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{
 				catalog: {
@@ -873,6 +896,7 @@ func TestResolver(t *testing.T) {
 			clusterState: []runtime.Object{
 				existingSub(namespace, "a.v1", "a", "alpha", catalog),
 				newSub(namespace, "b", "beta", catalog),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{
 				catalog: {
@@ -898,6 +922,7 @@ func TestResolver(t *testing.T) {
 				existingOperator(namespace, "a.v1", "a", "alpha", "", Provides1, Requires2, nil, nil),
 				existingSub(namespace, "b.v1", "b", "alpha", catalog),
 				existingOperator(namespace, "b.v1", "b", "alpha", "", Provides2, Requires1, nil, nil),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{
 				catalog: {
@@ -924,6 +949,7 @@ func TestResolver(t *testing.T) {
 				existingOperator(namespace, "a.v1", "a", "alpha", "", Provides1, nil, nil, nil),
 				existingSub(namespace, "b.v1", "b", "alpha", catalog),
 				existingOperator(namespace, "b.v1", "b", "alpha", "", nil, Requires1, nil, nil),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{
 				catalog: {
@@ -946,6 +972,7 @@ func TestResolver(t *testing.T) {
 			name: "PicksOlderProvider",
 			clusterState: []runtime.Object{
 				newSub(namespace, "b", "alpha", catalog),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{
 				catalog: {
@@ -970,6 +997,7 @@ func TestResolver(t *testing.T) {
 			clusterState: []runtime.Object{
 				existingSub(namespace, "a.v1", "a", "alpha", catalog),
 				existingOperator(namespace, "a.v1", "a", "alpha", "", Provides1, nil, nil, nil),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{catalog: {
 				bundle("a.v3", "a", "alpha", "a.v2", nil, nil, nil, nil, withVersion("1.0.0"), withSkipRange("< 1.0.0")),
@@ -990,6 +1018,7 @@ func TestResolver(t *testing.T) {
 				existingSub(namespace, "b.v1", "b", "beta", catalog),
 				existingOperator(namespace, "a.v1", "a", "alpha", "", nil, Requires1, nil, nil),
 				existingOperator(namespace, "b.v1", "b", "beta", "", Provides1, nil, nil, nil),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{
 				catalog: {
@@ -1015,6 +1044,7 @@ func TestResolver(t *testing.T) {
 			clusterState: []runtime.Object{
 				existingSub(namespace, "a.v1", "a", "alpha", catalog),
 				existingOperator(namespace, "a.v1", "a", "alpha", "", Provides1, nil, nil, nil),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{catalog: {
 				bundle("a.v2", "a", "alpha", "", nil, nil, nil, nil, withVersion("1.0.0"), withSkipRange("< 1.0.0")),
@@ -1034,6 +1064,7 @@ func TestResolver(t *testing.T) {
 			name: "NewSub/StartingCSV",
 			clusterState: []runtime.Object{
 				newSub(namespace, "a", "alpha", catalog, withStartingCSV("a.v2")),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{catalog: {
 				bundle("a.v1", "a", "alpha", "", nil, nil, nil, nil),
@@ -1054,6 +1085,7 @@ func TestResolver(t *testing.T) {
 			clusterState: []runtime.Object{
 				existingSub(namespace, "a.v1", "a", "alpha", catalog),
 				existingOperator(namespace, "a.v1", "a", "alpha", "", Provides1, nil, nil, nil),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{catalog: {
 				bundle("a.v2", "a", "alpha", "", nil, nil, nil, nil, withVersion("1.0.0"), withSkips([]string{"a.v1"})),
@@ -1074,6 +1106,7 @@ func TestResolver(t *testing.T) {
 				existingSub(namespace, "a.v2", "a", "alpha", catalog),
 				existingOperator(namespace, "a.v1", "a", "alpha", "", Provides1, nil, nil, nil, withPhase(v1alpha1.CSVPhaseReplacing)),
 				existingOperator(namespace, "a.v2", "a", "alpha", "a.v1", Provides1, nil, nil, nil, withPhase(v1alpha1.CSVPhaseFailed)),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{catalog: {
 				bundle("a.v1", "a", "alpha", "", Provides1, nil, nil, nil, withVersion("1.0.0")),
@@ -1121,6 +1154,7 @@ func TestResolver(t *testing.T) {
 				existingOperator(namespace, "a.v1", "a", "alpha", "", Provides1, nil, nil, nil, withPhase(v1alpha1.CSVPhaseReplacing)),
 				existingOperator(namespace, "a.v2", "a", "alpha", "a.v1", Provides1, nil, nil, nil, withPhase(v1alpha1.CSVPhaseReplacing)),
 				existingOperator(namespace, "a.v3", "a", "alpha", "a.v2", Provides1, nil, nil, nil, withPhase(v1alpha1.CSVPhaseFailed)),
+				newOperatorGroup("foo", namespace),
 			},
 			bundlesByCatalog: map[resolvercache.SourceKey][]*api.Bundle{catalog: {
 				bundle("a.v1", "a", "alpha", "", Provides1, nil, nil, nil, withVersion("1.0.0")),
@@ -1182,7 +1216,7 @@ func TestResolver(t *testing.T) {
 				steps: [][]*v1alpha1.Step{},
 				subs:  []*v1alpha1.Subscription{},
 				errAssert: func(t *testing.T, err error) {
-					assert.Contains(t, err.Error(), "failed to populate resolver cache from source @existing/catsrc-namespace: csv catsrc-namespace/a.v1")
+					assert.Contains(t, err.Error(), "error using catalogsource catsrc-namespace/@existing: csv")
 					assert.Contains(t, err.Error(), "in phase Failed instead of Replacing")
 				},
 			},
@@ -1328,6 +1362,7 @@ func TestNamespaceResolverRBAC(t *testing.T) {
 			name: "NewSubscription/Permissions/ClusterPermissions",
 			clusterState: []runtime.Object{
 				newSub(namespace, "a", "alpha", catalog),
+				newOperatorGroup("test-og", namespace),
 			},
 			bundlesInCatalog: []*api.Bundle{bundle},
 			out: out{
@@ -1343,6 +1378,7 @@ func TestNamespaceResolverRBAC(t *testing.T) {
 			name: "don't create default service accounts",
 			clusterState: []runtime.Object{
 				newSub(namespace, "a", "alpha", catalog),
+				newOperatorGroup("test-og", namespace),
 			},
 			bundlesInCatalog: []*api.Bundle{bundleWithDefaultServiceAccount},
 			out: out{
@@ -1369,6 +1405,7 @@ func TestNamespaceResolverRBAC(t *testing.T) {
 			lister := operatorlister.NewLister()
 			lister.OperatorsV1alpha1().RegisterSubscriptionLister(namespace, informerFactory.Operators().V1alpha1().Subscriptions().Lister())
 			lister.OperatorsV1alpha1().RegisterClusterServiceVersionLister(namespace, informerFactory.Operators().V1alpha1().ClusterServiceVersions().Lister())
+			lister.OperatorsV1().RegisterOperatorGroupLister(namespace, informerFactory.Operators().V1().OperatorGroups().Lister())
 
 			stubSnapshot := &resolvercache.Snapshot{}
 			for _, bundle := range tt.bundlesInCatalog {

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
@@ -193,7 +193,7 @@ func NewOperator(ctx context.Context, kubeconfigPath string, clock utilclock.Clo
 		clientFactory:            clients.NewFactory(config),
 	}
 	op.sources = grpc.NewSourceStore(logger, 10*time.Second, 10*time.Minute, op.syncSourceState)
-	op.sourceInvalidator = resolver.SourceProviderFromRegistryClientProvider(op.sources, logger)
+	op.sourceInvalidator = resolver.SourceProviderFromRegistryClientProvider(op.sources, lister.OperatorsV1alpha1().CatalogSourceLister(), logger)
 	resolverSourceProvider := NewOperatorGroupToggleSourceProvider(op.sourceInvalidator, logger, op.lister.OperatorsV1().OperatorGroupLister())
 	op.reconciler = reconciler.NewRegistryReconcilerFactory(lister, opClient, configmapRegistryImage, op.now, ssaClient, workloadUserID)
 	res := resolver.NewOperatorStepResolver(lister, crClient, operatorNamespace, resolverSourceProvider, logger)

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache/cache.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache/cache.go
@@ -139,7 +139,7 @@ func (c *NamespacedOperatorCache) Error() error {
 		err := snapshot.err
 		snapshot.m.RUnlock()
 		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to populate resolver cache from source %v: %w", key.String(), err))
+			errs = append(errs, fmt.Errorf("error using catalogsource %s/%s: %w", key.Namespace, key.Name, err))
 		}
 	}
 	return errors.NewAggregate(errs)

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/step_resolver.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/step_resolver.go
@@ -9,9 +9,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	v1listers "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1"
 	v1alpha1listers "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
 	controllerbundle "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/bundle"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
@@ -21,6 +23,7 @@ import (
 
 const (
 	BundleLookupConditionPacked v1alpha1.BundleLookupConditionType = "BundleLookupNotPersisted"
+	exclusionAnnotation         string                             = "olm.operatorframework.io/exclude-global-namespace-resolution"
 )
 
 // init hooks provides the downstream a way to modify the upstream behavior
@@ -33,6 +36,7 @@ type StepResolver interface {
 type OperatorStepResolver struct {
 	subLister              v1alpha1listers.SubscriptionLister
 	csvLister              v1alpha1listers.ClusterServiceVersionLister
+	ogLister               v1listers.OperatorGroupLister
 	client                 versioned.Interface
 	globalCatalogNamespace string
 	resolver               *Resolver
@@ -69,6 +73,7 @@ func NewOperatorStepResolver(lister operatorlister.OperatorLister, client versio
 	stepResolver := &OperatorStepResolver{
 		subLister:              lister.OperatorsV1alpha1().SubscriptionLister(),
 		csvLister:              lister.OperatorsV1alpha1().ClusterServiceVersionLister(),
+		ogLister:               lister.OperatorsV1().OperatorGroupLister(),
 		client:                 client,
 		globalCatalogNamespace: globalCatalogNamespace,
 		resolver:               NewDefaultResolver(cacheSourceProvider, catsrcPriorityProvider{lister: lister.OperatorsV1alpha1().CatalogSourceLister()}, log),
@@ -91,7 +96,22 @@ func (r *OperatorStepResolver) ResolveSteps(namespace string) ([]*v1alpha1.Step,
 		return nil, nil, nil, err
 	}
 
-	namespaces := []string{namespace, r.globalCatalogNamespace}
+	namespaces := []string{namespace}
+	ogs, err := r.ogLister.OperatorGroups(namespace).List(labels.Everything())
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("listing operatorgroups in namespace %s: %s", namespace, err)
+	}
+	if len(ogs) != 1 {
+		return nil, nil, nil, fmt.Errorf("expected 1 OperatorGroup in the namespace, found %d", len(ogs))
+	}
+	og := ogs[0]
+	if val, ok := og.Annotations[exclusionAnnotation]; ok && val == "true" {
+		// Exclusion specified
+		// Ignore the globalNamespace for the purposes of resolution in this namespace
+		r.log.Printf("excluding global catalogs from resolution in namespace %s", namespace)
+	} else {
+		namespaces = append(namespaces, r.globalCatalogNamespace)
+	}
 	operators, err := r.resolver.Resolve(namespaces, subs)
 	if err != nil {
 		return nil, nil, nil, err


### PR DESCRIPTION
Using "available CatalogSources" information from the registry-client cache was causing cache inconsistency problems.

This has showed up multiple times in production environments over the years, manifesting itself in the form of the all subscriptions in a namespace being transitioned into an error state when a Catalogsource that the cache claims to exist, has actually been deleted from the cluster, but the cache was not updated.

The Subscriptions are transitioned to an error state because of the deleted catalogsource with the follwing error message:

"message": "failed to populate resolver cache from source <deleted-catalogsource>: failed to list
bundles: rpc error: code = Unavailable desc = connection error: desc = \"transport:
Error while dialing dial tcp: lookup <deleted-catalogsource>.<ns>.svc on 172.....: no such host\"",
                "reason": "ErrorPreventedResolution",
                "status": "True",
                "type": "ResolutionFailed"

This PR switches the information lookup from the cache, to using a client to list the CatalogSources present in the cluster.

Upstream-repository: operator-lifecycle-manager
Upstream-commit: ff9084a24b19848c02c2cd4b7d827e057f7f8b11