### PR TITLE
[release-4.17] OCPBUGS-43965: Return an error when the IP status cannot be updated

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
@@ -2070,9 +2070,8 @@ func (o *Operator) setInstallPlanInstalledCond(ip *v1alpha1.InstallPlan, reason 
 	ip.Status.SetCondition(v1alpha1.ConditionFailed(v1alpha1.InstallPlanInstalled, reason, message, &now))
 	outIP, err := o.client.OperatorsV1alpha1().InstallPlans(ip.GetNamespace()).UpdateStatus(context.TODO(), ip, metav1.UpdateOptions{})
 	if err != nil {
-		logger = logger.WithField("updateError", err.Error())
-		logger.Errorf("error updating InstallPlan status")
-		return nil, nil
+		logger.WithError(err).Error("error updating InstallPlan status")
+		return nil, fmt.Errorf("error updating InstallPlan status: %w", err)
 	}
 	return outIP, nil
 }

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/operator.go
@@ -2070,9 +2070,8 @@ func (o *Operator) setInstallPlanInstalledCond(ip *v1alpha1.InstallPlan, reason 
 	ip.Status.SetCondition(v1alpha1.ConditionFailed(v1alpha1.InstallPlanInstalled, reason, message, &now))
 	outIP, err := o.client.OperatorsV1alpha1().InstallPlans(ip.GetNamespace()).UpdateStatus(context.TODO(), ip, metav1.UpdateOptions{})
 	if err != nil {
-		logger = logger.WithField("updateError", err.Error())
-		logger.Errorf("error updating InstallPlan status")
-		return nil, nil
+		logger.WithError(err).Error("error updating InstallPlan status")
+		return nil, fmt.Errorf("error updating InstallPlan status: %w", err)
 	}
 	return outIP, nil
 }


### PR DESCRIPTION
This status update function was not returning an error when an error occured, and could lead to a crash due returning nil for the IP.

Signed-off-by: Todd Short <todd.short@me.com>
Upstream-repository: operator-lifecycle-manager
Upstream-commit: a63b449eb6ee44d716e6e21aae639db217ebb6e1 (cherry picked from commit 9500f2725e2c55b9b958625307f3863160236774)