### PR TITLE
use ubi instead of scratch

### DIFF
--- a/staging/operator-registry/pkg/lib/bundle/generate.go
+++ b/staging/operator-registry/pkg/lib/bundle/generate.go
@@ -335,7 +335,7 @@ func GenerateDockerfile(mediaType, manifests, metadata, copyManifestDir, copyMet
 	relativeMetadataDirectory = filepath.ToSlash(relativeMetadataDirectory)
 
 	// FROM
-	fileContent += "FROM scratch\n\n"
+	fileContent += "FROM registry.access.redhat.com/ubi9:latest\n\n"
 
 	// LABEL
 	fileContent += fmt.Sprintf("LABEL %s=%s\n", MediatypeLabel, mediaType)


### PR DESCRIPTION
I'm not sure if I should modify the downstream directly, but some users have conerns when using the `scratch`, especially when building the multi-arch image. They have to modify the Dockfile after `opm alpha bundle generate xxx`. They will get an error if they forget to update the base image. So, I just submitted this PR, any comments are welcome! Thanks!
```console
[yapei@yapei-mac apicast (operators)]$ opm alpha bundle validate --tag quay.io/yapei/apicast-operators-bundle:latest --image-builder podman
Command "validate" is deprecated, This subcommand is deprecated and will be removed in a future release. Migrate to operator-sdk bundle validate
INFO[0000] Create a temp directory at /var/folders/gw/6ckgw32n7rz4yncmkkpsvjl80000gn/T/bundle-2170207577  container-tool=podman
DEBU[0000] Pulling and unpacking container image         container-tool=podman
INFO[0000] running /opt/podman/bin/podman pull quay.io/yapei/apicast-operators-bundle:latest  container-tool=podman
ERRO[0002] Trying to pull quay.io/yapei/apicast-operators-bundle:latest...
Error: choosing an image from manifest list docker://quay.io/yapei/apicast-operators-bundle:latest: no image found in image index for architecture "amd64", variant "", OS "linux"  container-tool=podman
Error: error pulling image: Trying to pull quay.io/yapei/apicast-operators-bundle:latest...
Error: choosing an image from manifest list docker://quay.io/yapei/apicast-operators-bundle:latest: no image found in image index for architecture "amd64", variant "", OS "linux"
...
```