### PR TITLE
[release-4.16] OCPBUGS-48696: Fix excessive catalog source snapshots cause severe performance regression

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/subscription/config.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/subscription/config.go
@@ -27,7 +27,7 @@ type syncerConfig struct {
 	reconcilers               kubestate.ReconcilerChain
 	registryReconcilerFactory reconciler.RegistryReconcilerFactory
 	globalCatalogNamespace    string
-	sourceProvider            resolverCache.SourceProvider
+	operatorCacheProvider     resolverCache.OperatorCacheProvider
 }
 
 // SyncerOption is a configuration option for a subscription syncer.
@@ -130,9 +130,9 @@ func WithGlobalCatalogNamespace(namespace string) SyncerOption {
 	}
 }
 
-func WithSourceProvider(provider resolverCache.SourceProvider) SyncerOption {
+func WithOperatorCacheProvider(provider resolverCache.OperatorCacheProvider) SyncerOption {
 	return func(config *syncerConfig) {
-		config.sourceProvider = provider
+		config.operatorCacheProvider = provider
 	}
 }
 

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/subscription/syncer.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/subscription/syncer.go
@@ -16,7 +16,6 @@ import (
 	"github.com/operator-framework/api/pkg/operators/install"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	listers "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
-	resolverCache "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubestate"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/metrics"
@@ -38,7 +37,6 @@ type subscriptionSyncer struct {
 	installPlanLister      listers.InstallPlanLister
 	globalCatalogNamespace string
 	notify                 kubestate.NotifyFunc
-	sourceProvider         resolverCache.SourceProvider
 }
 
 // now returns the Syncer's current time.
@@ -218,7 +216,6 @@ func newSyncerWithConfig(ctx context.Context, config *syncerConfig) (kubestate.S
 		reconcilers:       config.reconcilers,
 		subscriptionCache: config.subscriptionInformer.GetIndexer(),
 		installPlanLister: config.lister.OperatorsV1alpha1().InstallPlanLister(),
-		sourceProvider:    config.sourceProvider,
 		notify: func(event types.NamespacedName) {
 			// Notify Subscriptions by enqueuing to the Subscription queue.
 			config.subscriptionQueue.Add(event)
@@ -256,7 +253,8 @@ func newSyncerWithConfig(ctx context.Context, config *syncerConfig) (kubestate.S
 			catalogLister:             config.lister.OperatorsV1alpha1().CatalogSourceLister(),
 			registryReconcilerFactory: config.registryReconcilerFactory,
 			globalCatalogNamespace:    config.globalCatalogNamespace,
-			sourceProvider:            config.sourceProvider,
+			operatorCacheProvider:     config.operatorCacheProvider,
+			logger:                    config.logger,
 		},
 	}
 	s.reconcilers = append(defaultReconcilers, s.reconcilers...)

--- a/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/resolver.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/resolver.go
@@ -29,15 +29,15 @@ type constraintProvider interface {
 }
 
 type Resolver struct {
-	cache                     *cache.Cache
+	cache                     cache.OperatorCacheProvider
 	log                       logrus.FieldLogger
 	pc                        *predicateConverter
 	systemConstraintsProvider constraintProvider
 }
 
-func NewDefaultResolver(rcp cache.SourceProvider, sourcePriorityProvider cache.SourcePriorityProvider, logger logrus.FieldLogger) *Resolver {
+func NewDefaultResolver(cacheProvider cache.OperatorCacheProvider, logger logrus.FieldLogger) *Resolver {
 	return &Resolver{
-		cache: cache.New(rcp, cache.WithLogger(logger), cache.WithSourcePriorityProvider(sourcePriorityProvider)),
+		cache: cacheProvider,
 		log:   logger,
 		pc: &predicateConverter{
 			celEnv: constraints.NewCelEnvironment(),

--- a/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/resolver.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -513,11 +514,13 @@ func (r *Resolver) addInvariants(namespacedCache cache.MultiCatalogOperatorFinde
 	}
 
 	for gvk, is := range gvkConflictToVariable {
+		slices.Sort(is)
 		s := NewSingleAPIProviderVariable(gvk.Group, gvk.Version, gvk.Kind, is)
 		variables[s.Identifier()] = s
 	}
 
 	for pkg, is := range packageConflictToVariable {
+		slices.Sort(is)
 		s := NewSinglePackageInstanceVariable(pkg, is)
 		variables[s.Identifier()] = s
 	}

--- a/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/solver/lit_mapping.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/solver/lit_mapping.go
@@ -1,7 +1,9 @@
 package solver
 
 import (
+	"cmp"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/go-air/gini/inter"
@@ -203,5 +205,8 @@ func (d *litMapping) Conflicts(g inter.Assumable) []AppliedConstraint {
 			as = append(as, a)
 		}
 	}
+	slices.SortFunc(as, func(a, b AppliedConstraint) int {
+		return cmp.Compare(a.String(), b.String())
+	})
 	return as
 }

--- a/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/source_registry.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/source_registry.go
@@ -12,6 +12,7 @@ import (
 	v1alpha1listers "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/metrics"
 	"github.com/operator-framework/operator-registry/pkg/api"
 	"github.com/operator-framework/operator-registry/pkg/client"
 	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
@@ -143,6 +144,9 @@ type registrySource struct {
 }
 
 func (s *registrySource) Snapshot(ctx context.Context) (*cache.Snapshot, error) {
+	s.logger.Printf("requesting snapshot for catalog source %s/%s", s.key.Namespace, s.key.Name)
+	metrics.IncrementCatalogSourceSnapshotsTotal(s.key.Name, s.key.Namespace)
+
 	// Fetching default channels this way makes many round trips
 	// -- may need to either add a new API to fetch all at once,
 	// or embed the information into Bundle.

--- a/staging/operator-lifecycle-manager/pkg/metrics/metrics.go
+++ b/staging/operator-lifecycle-manager/pkg/metrics/metrics.go
@@ -152,6 +152,14 @@ var (
 		[]string{NamespaceLabel, NameLabel},
 	)
 
+	catalogSourceSnapshotsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "catalog_source_snapshots_total",
+			Help: "The number of times the catalog operator has requested a snapshot of data from a catalog source",
+		},
+		[]string{NamespaceLabel, NameLabel},
+	)
+
 	// exported since it's not handled by HandleMetrics
 	CSVUpgradeCount = prometheus.NewCounter(
 		prometheus.CounterOpts{
@@ -250,6 +258,7 @@ func RegisterCatalog() {
 	prometheus.MustRegister(subscriptionCount)
 	prometheus.MustRegister(catalogSourceCount)
 	prometheus.MustRegister(catalogSourceReady)
+	prometheus.MustRegister(catalogSourceSnapshotsTotal)
 	prometheus.MustRegister(SubscriptionSyncCount)
 	prometheus.MustRegister(dependencyResolutionSummary)
 	prometheus.MustRegister(installPlanWarningCount)
@@ -270,6 +279,18 @@ func RegisterCatalogSourceState(name, namespace string, state connectivity.State
 
 func DeleteCatalogSourceStateMetric(name, namespace string) {
 	catalogSourceReady.DeleteLabelValues(namespace, name)
+}
+
+func RegisterCatalogSourceSnapshotsTotal(name, namespace string) {
+	catalogSourceSnapshotsTotal.WithLabelValues(namespace, name).Add(0)
+}
+
+func IncrementCatalogSourceSnapshotsTotal(name, namespace string) {
+	catalogSourceSnapshotsTotal.WithLabelValues(namespace, name).Inc()
+}
+
+func DeleteCatalogSourceSnapshotsTotal(name, namespace string) {
+	catalogSourceSnapshotsTotal.DeleteLabelValues(namespace, name)
 }
 
 func DeleteCSVMetric(oldCSV *operatorsv1alpha1.ClusterServiceVersion) {

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/subscription/config.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/subscription/config.go
@@ -27,7 +27,7 @@ type syncerConfig struct {
 	reconcilers               kubestate.ReconcilerChain
 	registryReconcilerFactory reconciler.RegistryReconcilerFactory
 	globalCatalogNamespace    string
-	sourceProvider            resolverCache.SourceProvider
+	operatorCacheProvider     resolverCache.OperatorCacheProvider
 }
 
 // SyncerOption is a configuration option for a subscription syncer.
@@ -130,9 +130,9 @@ func WithGlobalCatalogNamespace(namespace string) SyncerOption {
 	}
 }
 
-func WithSourceProvider(provider resolverCache.SourceProvider) SyncerOption {
+func WithOperatorCacheProvider(provider resolverCache.OperatorCacheProvider) SyncerOption {
 	return func(config *syncerConfig) {
-		config.sourceProvider = provider
+		config.operatorCacheProvider = provider
 	}
 }
 

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/subscription/syncer.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/subscription/syncer.go
@@ -16,7 +16,6 @@ import (
 	"github.com/operator-framework/api/pkg/operators/install"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	listers "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
-	resolverCache "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubestate"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/metrics"
@@ -38,7 +37,6 @@ type subscriptionSyncer struct {
 	installPlanLister      listers.InstallPlanLister
 	globalCatalogNamespace string
 	notify                 kubestate.NotifyFunc
-	sourceProvider         resolverCache.SourceProvider
 }
 
 // now returns the Syncer's current time.
@@ -218,7 +216,6 @@ func newSyncerWithConfig(ctx context.Context, config *syncerConfig) (kubestate.S
 		reconcilers:       config.reconcilers,
 		subscriptionCache: config.subscriptionInformer.GetIndexer(),
 		installPlanLister: config.lister.OperatorsV1alpha1().InstallPlanLister(),
-		sourceProvider:    config.sourceProvider,
 		notify: func(event types.NamespacedName) {
 			// Notify Subscriptions by enqueuing to the Subscription queue.
 			config.subscriptionQueue.Add(event)
@@ -256,7 +253,8 @@ func newSyncerWithConfig(ctx context.Context, config *syncerConfig) (kubestate.S
 			catalogLister:             config.lister.OperatorsV1alpha1().CatalogSourceLister(),
 			registryReconcilerFactory: config.registryReconcilerFactory,
 			globalCatalogNamespace:    config.globalCatalogNamespace,
-			sourceProvider:            config.sourceProvider,
+			operatorCacheProvider:     config.operatorCacheProvider,
+			logger:                    config.logger,
 		},
 	}
 	s.reconcilers = append(defaultReconcilers, s.reconcilers...)

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/resolver.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/resolver.go
@@ -29,15 +29,15 @@ type constraintProvider interface {
 }
 
 type Resolver struct {
-	cache                     *cache.Cache
+	cache                     cache.OperatorCacheProvider
 	log                       logrus.FieldLogger
 	pc                        *predicateConverter
 	systemConstraintsProvider constraintProvider
 }
 
-func NewDefaultResolver(rcp cache.SourceProvider, sourcePriorityProvider cache.SourcePriorityProvider, logger logrus.FieldLogger) *Resolver {
+func NewDefaultResolver(cacheProvider cache.OperatorCacheProvider, logger logrus.FieldLogger) *Resolver {
 	return &Resolver{
-		cache: cache.New(rcp, cache.WithLogger(logger), cache.WithSourcePriorityProvider(sourcePriorityProvider)),
+		cache: cacheProvider,
 		log:   logger,
 		pc: &predicateConverter{
 			celEnv: constraints.NewCelEnvironment(),

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/resolver.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -513,11 +514,13 @@ func (r *Resolver) addInvariants(namespacedCache cache.MultiCatalogOperatorFinde
 	}
 
 	for gvk, is := range gvkConflictToVariable {
+		slices.Sort(is)
 		s := NewSingleAPIProviderVariable(gvk.Group, gvk.Version, gvk.Kind, is)
 		variables[s.Identifier()] = s
 	}
 
 	for pkg, is := range packageConflictToVariable {
+		slices.Sort(is)
 		s := NewSinglePackageInstanceVariable(pkg, is)
 		variables[s.Identifier()] = s
 	}

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/solver/lit_mapping.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/solver/lit_mapping.go
@@ -1,7 +1,9 @@
 package solver
 
 import (
+	"cmp"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/go-air/gini/inter"
@@ -203,5 +205,8 @@ func (d *litMapping) Conflicts(g inter.Assumable) []AppliedConstraint {
 			as = append(as, a)
 		}
 	}
+	slices.SortFunc(as, func(a, b AppliedConstraint) int {
+		return cmp.Compare(a.String(), b.String())
+	})
 	return as
 }

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/source_registry.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/source_registry.go
@@ -12,6 +12,7 @@ import (
 	v1alpha1listers "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/listers/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/cache"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/metrics"
 	"github.com/operator-framework/operator-registry/pkg/api"
 	"github.com/operator-framework/operator-registry/pkg/client"
 	opregistry "github.com/operator-framework/operator-registry/pkg/registry"
@@ -143,6 +144,9 @@ type registrySource struct {
 }
 
 func (s *registrySource) Snapshot(ctx context.Context) (*cache.Snapshot, error) {
+	s.logger.Printf("requesting snapshot for catalog source %s/%s", s.key.Namespace, s.key.Name)
+	metrics.IncrementCatalogSourceSnapshotsTotal(s.key.Name, s.key.Namespace)
+
 	// Fetching default channels this way makes many round trips
 	// -- may need to either add a new API to fetch all at once,
 	// or embed the information into Bundle.

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/metrics/metrics.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/metrics/metrics.go
@@ -152,6 +152,14 @@ var (
 		[]string{NamespaceLabel, NameLabel},
 	)
 
+	catalogSourceSnapshotsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "catalog_source_snapshots_total",
+			Help: "The number of times the catalog operator has requested a snapshot of data from a catalog source",
+		},
+		[]string{NamespaceLabel, NameLabel},
+	)
+
 	// exported since it's not handled by HandleMetrics
 	CSVUpgradeCount = prometheus.NewCounter(
 		prometheus.CounterOpts{
@@ -250,6 +258,7 @@ func RegisterCatalog() {
 	prometheus.MustRegister(subscriptionCount)
 	prometheus.MustRegister(catalogSourceCount)
 	prometheus.MustRegister(catalogSourceReady)
+	prometheus.MustRegister(catalogSourceSnapshotsTotal)
 	prometheus.MustRegister(SubscriptionSyncCount)
 	prometheus.MustRegister(dependencyResolutionSummary)
 	prometheus.MustRegister(installPlanWarningCount)
@@ -270,6 +279,18 @@ func RegisterCatalogSourceState(name, namespace string, state connectivity.State
 
 func DeleteCatalogSourceStateMetric(name, namespace string) {
 	catalogSourceReady.DeleteLabelValues(namespace, name)
+}
+
+func RegisterCatalogSourceSnapshotsTotal(name, namespace string) {
+	catalogSourceSnapshotsTotal.WithLabelValues(namespace, name).Add(0)
+}
+
+func IncrementCatalogSourceSnapshotsTotal(name, namespace string) {
+	catalogSourceSnapshotsTotal.WithLabelValues(namespace, name).Inc()
+}
+
+func DeleteCatalogSourceSnapshotsTotal(name, namespace string) {
+	catalogSourceSnapshotsTotal.DeleteLabelValues(namespace, name)
 }
 
 func DeleteCSVMetric(oldCSV *operatorsv1alpha1.ClusterServiceVersion) {


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/operator-framework-olm/pull/937