### PR TITLE
OCPBUGS-42526: The openshift-operator-lifecycle-manager namespaces still use old pod-security.kubernetes.io/*-version v1.24 and v1.25 respectively

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,16 @@ vendor:
 .PHONY: manifests
 manifests: ## Generate manifests
 	OLM_VERSION=$(OLM_VERSION) ./scripts/generate_crds_manifests.sh
+	$(MAKE) update-k8s-manifests
+
+# Minor Kubernetes version to build against derived from the client-go dependency version
+KUBE_MINOR ?= $(shell go list -m k8s.io/client-go | cut -d" " -f2 | sed 's/^v0\.\([[:digit:]]\{1,\}\)\.[[:digit:]]\{1,\}$$/1.\1/')
+
+.PHONY: update-k8s-manifests # HELP Update pod security versions in manifests with Kubernetes version
+update-k8s-manifests:
+	find manifests microshift-manifests -type f -name '*.yaml' -exec \
+	sed -i.bak -E 's/(pod-security.kubernetes.io\/[a-zA-Z-]+-version:).*/\1 "v$(KUBE_MINOR)"/g' {} +;
+	find manifests microshift-manifests -type f -name '*.yaml.bak' -delete
 
 .PHONY: generate-manifests
 generate-manifests: OLM_VERSION=0.0.1-snapshot

--- a/manifests/0000_50_olm_00-namespace.yaml
+++ b/manifests/0000_50_olm_00-namespace.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openshift-operator-lifecycle-manager
   labels:
     pod-security.kubernetes.io/enforce: restricted
-    pod-security.kubernetes.io/enforce-version: "v1.24"
+    pod-security.kubernetes.io/enforce-version: "v1.32"
     openshift.io/scc: ""
     openshift.io/cluster-monitoring: "true"
   annotations:
@@ -21,7 +21,7 @@ metadata:
   name: openshift-operators
   labels:
     pod-security.kubernetes.io/enforce: privileged
-    pod-security.kubernetes.io/enforce-version: "v1.24"
+    pod-security.kubernetes.io/enforce-version: "v1.32"
     openshift.io/scc: ""
   annotations:
     openshift.io/node-selector: ""

--- a/microshift-manifests/0000_50_olm_00-namespace.yaml
+++ b/microshift-manifests/0000_50_olm_00-namespace.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openshift-operator-lifecycle-manager
   labels:
     pod-security.kubernetes.io/enforce: restricted
-    pod-security.kubernetes.io/enforce-version: "v1.24"
+    pod-security.kubernetes.io/enforce-version: "v1.32"
     openshift.io/scc: ""
     openshift.io/cluster-monitoring: "true"
   annotations:
@@ -21,7 +21,7 @@ metadata:
   name: openshift-operators
   labels:
     pod-security.kubernetes.io/enforce: privileged
-    pod-security.kubernetes.io/enforce-version: "v1.24"
+    pod-security.kubernetes.io/enforce-version: "v1.32"
     openshift.io/scc: ""
   annotations:
     openshift.io/node-selector: ""


### PR DESCRIPTION
See that we have also a PR to change the files used in upstream: https://github.com/openshift/operator-framework-olm/pull/966
However, this one is specific to downstream/OCP manifests