### PR TITLE
OCPBUGS-32262: couldn't find unpacked step

### DIFF
--- a/staging/operator-lifecycle-manager/go.mod
+++ b/staging/operator-lifecycle-manager/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/containers/image/v5 v5.34.0
 	github.com/coreos/go-semver v0.3.1
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/distribution/reference v0.6.0
 	github.com/evanphx/json-patch v5.9.11+incompatible
 	github.com/fsnotify/fsnotify v1.8.0
@@ -83,7 +84,6 @@ require (
 	github.com/containers/ocicrypt v1.2.1 // indirect
 	github.com/containers/storage v1.57.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/docker/cli v28.0.0+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker v27.5.1+incompatible // indirect

--- a/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/steps.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/resolver/steps.go
@@ -200,6 +200,13 @@ func NewServiceAccountStepResources(csv *v1alpha1.ClusterServiceVersion, catalog
 	if err != nil {
 		return nil, err
 	}
+	legacyPerms, err := LegacyRBACForClusterServiceVersion(csv)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range legacyPerms {
+		operatorPermissions[k] = v
+	}
 
 	for _, perms := range operatorPermissions {
 		if perms.ServiceAccount.Name != "default" {

--- a/staging/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/util/hash/hash.go
+++ b/staging/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/util/hash/hash.go
@@ -20,7 +20,10 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"hash"
 	"math/big"
+
+	"github.com/davecgh/go-spew/spew"
 )
 
 // DeepHashObject writes specified object to hash using the spew library
@@ -52,4 +55,15 @@ func DeepHashObject(obj interface{}) (string, error) {
 	var i big.Int
 	i.SetBytes(hash[:])
 	return i.Text(62), nil
+}
+
+func LegacyDeepHashObject(hasher hash.Hash, objectToWrite interface{}) {
+	hasher.Reset()
+	printer := spew.ConfigState{
+		Indent:         " ",
+		SortKeys:       true,
+		DisableMethods: true,
+		SpewKeys:       true,
+	}
+	printer.Fprintf(hasher, "%#v", objectToWrite)
 }

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/steps.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/resolver/steps.go
@@ -200,6 +200,13 @@ func NewServiceAccountStepResources(csv *v1alpha1.ClusterServiceVersion, catalog
 	if err != nil {
 		return nil, err
 	}
+	legacyPerms, err := LegacyRBACForClusterServiceVersion(csv)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range legacyPerms {
+		operatorPermissions[k] = v
+	}
 
 	for _, perms := range operatorPermissions {
 		if perms.ServiceAccount.Name != "default" {

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/util/hash/hash.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/lib/kubernetes/pkg/util/hash/hash.go
@@ -20,7 +20,10 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"hash"
 	"math/big"
+
+	"github.com/davecgh/go-spew/spew"
 )
 
 // DeepHashObject writes specified object to hash using the spew library
@@ -52,4 +55,15 @@ func DeepHashObject(obj interface{}) (string, error) {
 	var i big.Int
 	i.SetBytes(hash[:])
 	return i.Text(62), nil
+}
+
+func LegacyDeepHashObject(hasher hash.Hash, objectToWrite interface{}) {
+	hasher.Reset()
+	printer := spew.ConfigState{
+		Indent:         " ",
+		SortKeys:       true,
+		DisableMethods: true,
+		SpewKeys:       true,
+	}
+	printer.Fprintf(hasher, "%#v", objectToWrite)
 }


### PR DESCRIPTION
### Description

Because of [changes](https://github.com/openshift/operator-framework-olm/commit/e248469f170ddb8ccf03fa714924e75efb9de946#diff-885d1e95e50eb8ece2643ba380c0449ab1adaeba14cf461a0a58b1afcc61f228so) to the hashing algorithm that identifies manifests that need to be applied during install / upgrade, the unpack steps for bundles that have been installed using the old hashing algorithm cannot be found as they have a different name.

This code reintroduces the legacy hashing algorithm to resolve only objects that have been installed using this legacy process so they are not stranded. It adds the legacy steps to the map of steps. If the install was made using the new algorithm, these olds steps are unused. If the install was made using the old algorithm, the new steps are unused.