### PR TITLE
Bump olm for ConsolePlugin resource support

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/supportedresources.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/catalog/supportedresources.go
@@ -10,6 +10,7 @@ const (
 	ConsoleQuickStartKind     = "ConsoleQuickStart"
 	ConsoleCLIDownloadKind    = "ConsoleCLIDownload"
 	ConsoleLinkKind           = "ConsoleLink"
+	ConsolePlugin             = "ConsolePlugin"
 )
 
 var supportedKinds = map[string]struct{}{
@@ -22,6 +23,7 @@ var supportedKinds = map[string]struct{}{
 	ConsoleQuickStartKind:     {},
 	ConsoleCLIDownloadKind:    {},
 	ConsoleLinkKind:           {},
+	ConsolePlugin:             {},
 }
 
 // isSupported returns true if OLM supports this type of CustomResource.

--- a/staging/operator-registry/pkg/lib/bundle/supported_resources.go
+++ b/staging/operator-registry/pkg/lib/bundle/supported_resources.go
@@ -20,6 +20,7 @@ const (
 	ConsoleQuickStartKind     = "ConsoleQuickStart"
 	ConsoleCLIDownloadKind    = "ConsoleCLIDownload"
 	ConsoleLinkKind           = "ConsoleLink"
+	ConsolePlugin             = "ConsolePlugin"
 )
 
 // Namespaced indicates whether the resource is namespace scoped (true) or cluster-scoped (false).
@@ -47,6 +48,7 @@ var supportedResources = map[string]Namespaced{
 	ConsoleQuickStartKind:     false,
 	ConsoleCLIDownloadKind:    false,
 	ConsoleLinkKind:           false,
+	ConsolePlugin:             false,
 }
 
 // IsSupported checks if the object kind is OLM-supported and if it is namespaced

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/supportedresources.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/catalog/supportedresources.go
@@ -10,6 +10,7 @@ const (
 	ConsoleQuickStartKind     = "ConsoleQuickStart"
 	ConsoleCLIDownloadKind    = "ConsoleCLIDownload"
 	ConsoleLinkKind           = "ConsoleLink"
+	ConsolePlugin             = "ConsolePlugin"
 )
 
 var supportedKinds = map[string]struct{}{
@@ -22,6 +23,7 @@ var supportedKinds = map[string]struct{}{
 	ConsoleQuickStartKind:     {},
 	ConsoleCLIDownloadKind:    {},
 	ConsoleLinkKind:           {},
+	ConsolePlugin:             {},
 }
 
 // isSupported returns true if OLM supports this type of CustomResource.

--- a/vendor/github.com/operator-framework/operator-registry/pkg/lib/bundle/supported_resources.go
+++ b/vendor/github.com/operator-framework/operator-registry/pkg/lib/bundle/supported_resources.go
@@ -20,6 +20,7 @@ const (
 	ConsoleQuickStartKind     = "ConsoleQuickStart"
 	ConsoleCLIDownloadKind    = "ConsoleCLIDownload"
 	ConsoleLinkKind           = "ConsoleLink"
+	ConsolePlugin             = "ConsolePlugin"
 )
 
 // Namespaced indicates whether the resource is namespace scoped (true) or cluster-scoped (false).
@@ -47,6 +48,7 @@ var supportedResources = map[string]Namespaced{
 	ConsoleQuickStartKind:     false,
 	ConsoleCLIDownloadKind:    false,
 	ConsoleLinkKind:           false,
+	ConsolePlugin:             false,
 }
 
 // IsSupported checks if the object kind is OLM-supported and if it is namespaced


### PR DESCRIPTION
Testing https://github.com/operator-framework/operator-lifecycle-manager/pull/3551 & https://github.com/operator-framework/operator-registry/pull/1634 changes using https://github.com/netobserv/network-observability-operator/pull/1374 bundle

Clusterbot
- build: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-origin-installer-launch-aws-modern/1909607438126944256
- launch: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-origin-installer-launch-aws-modern/1909607467831005184

Console plugin is created successfully however, it is disabled by default: 
![image](https://github.com/user-attachments/assets/8293917b-7648-48c8-b937-ad7634b1bcc6)

Ideally that should be controlled by the Console Plugin Enabled toggle at operator installation:
![image](https://github.com/user-attachments/assets/588f1886-9f6c-4838-a825-2a098c2feec7)

When the operator is uninstalled, the ConsolePlugin resource is not removed despite the olm.managed label is present:
![image](https://github.com/user-attachments/assets/e78f6384-6232-4dc7-8f86-d8ab9eede8e5)

I wonder if `ownerReferences` would make sense here ?