### PR TITLE
replace rhel8 builder pullspec after great purge

### DIFF
--- a/operator-framework-tools.Dockerfile
+++ b/operator-framework-tools.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.23-openshift-4.19 AS builder-rhel8
+FROM quay.io/openshift/ci:ocp_builder_rhel-9-golang-1.23-openshift-4.19 AS builder-rhel8
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 WORKDIR /src


### PR DESCRIPTION
CI failures around branch cut resulted in a lot of images being purged from test registries.  This switches the rhel8 builder to use the canonical location (which was purged) going forward.  
