### PR TITLE
OCPBUGS-58275: Fix networkpolicy filter for microshift manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ vendor:
 	go mod verify
 
 .PHONY: manifests
-manifests: ## Generate manifests
+manifests: $(HELM) ## Generate manifests
 	OLM_VERSION=$(OLM_VERSION) ./scripts/generate_crds_manifests.sh
 
 .PHONY: generate-manifests

--- a/microshift-manifests/0000_50_olm_01-networkpolicies.yaml
+++ b/microshift-manifests/0000_50_olm_01-networkpolicies.yaml
@@ -87,3 +87,23 @@ spec:
   policyTypes:
     - Ingress
     - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-allow-all
+  namespace: openshift-operators
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    capability.openshift.io/name: "OperatorLifecycleManager"
+    include.release.openshift.io/hypershift: "true"
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - {}
+  egress:
+    - {}

--- a/scripts/generate_crds_manifests.sh
+++ b/scripts/generate_crds_manifests.sh
@@ -663,7 +663,8 @@ filtered_yaml="${ROOT_DIR}/microshift-manifests/0000_50_olm_01-networkpolicies.y
 
 # loop through each NetworkPolicy definition in the input multi-document yaml
 rm -f "${filtered_yaml}"
-doc_count=$(${YQ} r -l "$yaml_file")
+
+doc_count=$(${YQ} r -d'*' -l "$yaml_file" | wc -l)
 for (( i=0; i<doc_count; i++ )); do
     current_doc=$(${YQ} r -d "$i" "$yaml_file")
     resource_name="$(echo "$current_doc" | ${YQ} r - metadata.name)"


### PR DESCRIPTION
Fixes generate_crd_manifest script to properly determine the number of documents in the networkpolicy multi-document yaml and thereby addresses the missing default_allow_all policy in openshift-operators namespace in the the microshift manifest set.