### PR TITLE
OCPBUGS-59258: 🐛 add catalog-operator control-plane-specific tolerations to unpack jobs

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/bundle/bundle_unpacker.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/bundle/bundle_unpacker.go
@@ -233,6 +233,7 @@ func (c *ConfigMapUnpacker) job(cmRef *corev1.ObjectReference, bundlePath string
 						"kubernetes.io/os": "linux",
 					},
 					Tolerations: []corev1.Toleration{
+						// arch-specific tolerations
 						{
 							Key:      "kubernetes.io/arch",
 							Value:    "amd64",
@@ -252,6 +253,24 @@ func (c *ConfigMapUnpacker) job(cmRef *corev1.ObjectReference, bundlePath string
 							Key:      "kubernetes.io/arch",
 							Value:    "s390x",
 							Operator: "Equal",
+						},
+						// control-plane-specific tolerations
+						{
+							Key:      "node-role.kubernetes.io/master",
+							Operator: "Exists",
+							Effect:   "NoSchedule",
+						},
+						{
+							Key:               "node.kubernetes.io/unreachable",
+							Operator:          "Exists",
+							Effect:            "NoExecute",
+							TolerationSeconds: ptr.To[int64](120),
+						},
+						{
+							Key:               "node.kubernetes.io/not-ready",
+							Operator:          "Exists",
+							Effect:            "NoExecute",
+							TolerationSeconds: ptr.To[int64](120),
 						},
 					},
 				},

--- a/staging/operator-lifecycle-manager/pkg/controller/bundle/bundle_unpacker_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/bundle/bundle_unpacker_test.go
@@ -59,6 +59,48 @@ func TestConfigMapUnpacker(t *testing.T) {
 	customAnnotationDuration := 2 * time.Minute
 	customAnnotationTimeoutSeconds := int64(customAnnotationDuration.Seconds())
 
+	podTolerations := []corev1.Toleration{
+		// arch-specific tolerations
+		{
+			Key:      "kubernetes.io/arch",
+			Value:    "amd64",
+			Operator: "Equal",
+		},
+		{
+			Key:      "kubernetes.io/arch",
+			Value:    "arm64",
+			Operator: "Equal",
+		},
+		{
+			Key:      "kubernetes.io/arch",
+			Value:    "ppc64le",
+			Operator: "Equal",
+		},
+		{
+			Key:      "kubernetes.io/arch",
+			Value:    "s390x",
+			Operator: "Equal",
+		},
+		// control-plane-specific tolerations
+		{
+			Key:      "node-role.kubernetes.io/master",
+			Operator: "Exists",
+			Effect:   "NoSchedule",
+		},
+		{
+			Key:               "node.kubernetes.io/unreachable",
+			Operator:          "Exists",
+			Effect:            "NoExecute",
+			TolerationSeconds: ptr.To[int64](120),
+		},
+		{
+			Key:               "node.kubernetes.io/not-ready",
+			Operator:          "Exists",
+			Effect:            "NoExecute",
+			TolerationSeconds: ptr.To[int64](120),
+		},
+	}
+
 	type fields struct {
 		objs []runtime.Object
 		crs  []runtime.Object
@@ -342,28 +384,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 									NodeSelector: map[string]string{
 										"kubernetes.io/os": "linux",
 									},
-									Tolerations: []corev1.Toleration{
-										{
-											Key:      "kubernetes.io/arch",
-											Value:    "amd64",
-											Operator: "Equal",
-										},
-										{
-											Key:      "kubernetes.io/arch",
-											Value:    "arm64",
-											Operator: "Equal",
-										},
-										{
-											Key:      "kubernetes.io/arch",
-											Value:    "ppc64le",
-											Operator: "Equal",
-										},
-										{
-											Key:      "kubernetes.io/arch",
-											Value:    "s390x",
-											Operator: "Equal",
-										},
-									},
+									Tolerations: podTolerations,
 								},
 							},
 						},
@@ -576,28 +597,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 									NodeSelector: map[string]string{
 										"kubernetes.io/os": "linux",
 									},
-									Tolerations: []corev1.Toleration{
-										{
-											Key:      "kubernetes.io/arch",
-											Value:    "amd64",
-											Operator: "Equal",
-										},
-										{
-											Key:      "kubernetes.io/arch",
-											Value:    "arm64",
-											Operator: "Equal",
-										},
-										{
-											Key:      "kubernetes.io/arch",
-											Value:    "ppc64le",
-											Operator: "Equal",
-										},
-										{
-											Key:      "kubernetes.io/arch",
-											Value:    "s390x",
-											Operator: "Equal",
-										},
-									},
+									Tolerations: podTolerations,
 								},
 							},
 						},
@@ -850,28 +850,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 									NodeSelector: map[string]string{
 										"kubernetes.io/os": "linux",
 									},
-									Tolerations: []corev1.Toleration{
-										{
-											Key:      "kubernetes.io/arch",
-											Value:    "amd64",
-											Operator: "Equal",
-										},
-										{
-											Key:      "kubernetes.io/arch",
-											Value:    "arm64",
-											Operator: "Equal",
-										},
-										{
-											Key:      "kubernetes.io/arch",
-											Value:    "ppc64le",
-											Operator: "Equal",
-										},
-										{
-											Key:      "kubernetes.io/arch",
-											Value:    "s390x",
-											Operator: "Equal",
-										},
-									},
+									Tolerations: podTolerations,
 								},
 							},
 						},
@@ -1119,28 +1098,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 									NodeSelector: map[string]string{
 										"kubernetes.io/os": "linux",
 									},
-									Tolerations: []corev1.Toleration{
-										{
-											Key:      "kubernetes.io/arch",
-											Value:    "amd64",
-											Operator: "Equal",
-										},
-										{
-											Key:      "kubernetes.io/arch",
-											Value:    "arm64",
-											Operator: "Equal",
-										},
-										{
-											Key:      "kubernetes.io/arch",
-											Value:    "ppc64le",
-											Operator: "Equal",
-										},
-										{
-											Key:      "kubernetes.io/arch",
-											Value:    "s390x",
-											Operator: "Equal",
-										},
-									},
+									Tolerations: podTolerations,
 								},
 							},
 						},
@@ -1358,28 +1316,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 									NodeSelector: map[string]string{
 										"kubernetes.io/os": "linux",
 									},
-									Tolerations: []corev1.Toleration{
-										{
-											Key:      "kubernetes.io/arch",
-											Value:    "amd64",
-											Operator: "Equal",
-										},
-										{
-											Key:      "kubernetes.io/arch",
-											Value:    "arm64",
-											Operator: "Equal",
-										},
-										{
-											Key:      "kubernetes.io/arch",
-											Value:    "ppc64le",
-											Operator: "Equal",
-										},
-										{
-											Key:      "kubernetes.io/arch",
-											Value:    "s390x",
-											Operator: "Equal",
-										},
-									},
+									Tolerations: podTolerations,
 								},
 							},
 						},
@@ -1610,28 +1547,7 @@ func TestConfigMapUnpacker(t *testing.T) {
 									NodeSelector: map[string]string{
 										"kubernetes.io/os": "linux",
 									},
-									Tolerations: []corev1.Toleration{
-										{
-											Key:      "kubernetes.io/arch",
-											Value:    "amd64",
-											Operator: "Equal",
-										},
-										{
-											Key:      "kubernetes.io/arch",
-											Value:    "arm64",
-											Operator: "Equal",
-										},
-										{
-											Key:      "kubernetes.io/arch",
-											Value:    "ppc64le",
-											Operator: "Equal",
-										},
-										{
-											Key:      "kubernetes.io/arch",
-											Value:    "s390x",
-											Operator: "Equal",
-										},
-									},
+									Tolerations: podTolerations,
 								},
 							},
 						},

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/bundle/bundle_unpacker.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/bundle/bundle_unpacker.go
@@ -233,6 +233,7 @@ func (c *ConfigMapUnpacker) job(cmRef *corev1.ObjectReference, bundlePath string
 						"kubernetes.io/os": "linux",
 					},
 					Tolerations: []corev1.Toleration{
+						// arch-specific tolerations
 						{
 							Key:      "kubernetes.io/arch",
 							Value:    "amd64",
@@ -252,6 +253,24 @@ func (c *ConfigMapUnpacker) job(cmRef *corev1.ObjectReference, bundlePath string
 							Key:      "kubernetes.io/arch",
 							Value:    "s390x",
 							Operator: "Equal",
+						},
+						// control-plane-specific tolerations
+						{
+							Key:      "node-role.kubernetes.io/master",
+							Operator: "Exists",
+							Effect:   "NoSchedule",
+						},
+						{
+							Key:               "node.kubernetes.io/unreachable",
+							Operator:          "Exists",
+							Effect:            "NoExecute",
+							TolerationSeconds: ptr.To[int64](120),
+						},
+						{
+							Key:               "node.kubernetes.io/not-ready",
+							Operator:          "Exists",
+							Effect:            "NoExecute",
+							TolerationSeconds: ptr.To[int64](120),
 						},
 					},
 				},


### PR DESCRIPTION

* add catalog-operator control-plane-specific tolerations to unpack jobs
* refactored common in test
---------
Upstream-repository: operator-lifecycle-manager
Upstream-commit: 57e6b8c8b381be1d6432718905b9825495836470
