### PR TITLE
(fix) broken generate-manifests script for macOS

### DIFF
--- a/scripts/generate_crds_manifests.sh
+++ b/scripts/generate_crds_manifests.sh
@@ -26,7 +26,7 @@ chartdir="${tmpdir}/chart"
 crddir="${chartdir}/crds"
 crdsrcdir="${tmpdir}/operators"
 
-SED="sed"
+SED="gsed"
 if ! command -v ${SED} &> /dev/null; then
     SED="sed"
 fi
@@ -644,7 +644,8 @@ for file in ${microshift_manifests_files}; do
      continue 2
     fi
   done
-  echo "  - $(realpath --relative-to "${ROOT_DIR}/microshift-manifests" "${file}")" >> "${ROOT_DIR}/microshift-manifests/kustomization.yaml"
+  relative_path=$(python3 -c "import os.path; print(os.path.relpath('${file}', '${ROOT_DIR}/microshift-manifests'))")
+  echo "  - ${relative_path}" >> "${ROOT_DIR}/microshift-manifests/kustomization.yaml"
 done
 
 # Now we need to get rid of these args from the olm-operator deployment:


### PR DESCRIPTION
The script used `realpath --relative-to` which works on Linux (GNU coreutils) but fails on macOS (BSD realpath). This caused `realpath: illegal option -- -` errors when running on macOS.

This PR replaces GNU-specific `realpath --relative-to` with Python's `os.path.relpath()`

Note: This introduces Python3 requirements for both CI environments and dev machines.

Also fixed sed tool selection for script: Use `gsed` (GNU sed) for macOS, `sed` for linux.