### PR TITLE
WIP: OCPBUGS-59768: add kube-rbac-proxy sidecars to olm and catalog operators 

### DIFF
--- a/manifests/0000_50_olm_03-services.yaml
+++ b/manifests/0000_50_olm_03-services.yaml
@@ -17,7 +17,7 @@ spec:
     - name: https-metrics
       port: 8443
       protocol: TCP
-      targetPort: 8443
+      targetPort: 9443
   selector:
     app: olm-operator
 ---
@@ -40,6 +40,6 @@ spec:
     - name: https-metrics
       port: 8443
       protocol: TCP
-      targetPort: 8443
+      targetPort: 9443
   selector:
     app: catalog-operator

--- a/manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
+++ b/manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
@@ -38,6 +38,9 @@ spec:
             secretName: pprof-cert
         - name: tmpfs
           emptyDir: {}
+        - name: olm-operator-serving-cert
+          secret:
+            secretName: olm-operator-serving-cert
       containers:
         - name: olm-operator
           securityContext:
@@ -100,6 +103,37 @@ spec:
             requests:
               cpu: 10m
               memory: 160Mi
+        - args:
+            - --secure-listen-address=0.0.0.0:9443
+            - --upstream=https://127.0.0.1:8443/
+            - --tls-cert-file=/etc/tls/private/tls.crt
+            - --tls-private-key-file=/etc/tls/private/tls.key
+            - --upstream-ca-file=/srv-cert/tls.crt
+            - --logtostderr=true
+          image: quay.io/openshift/origin-kube-rbac-proxy:latest
+          imagePullPolicy: IfNotPresent
+          name: kube-rbac-proxy
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - containerPort: 9443
+              name: metrics
+              protocol: TCP
+          resources:
+            requests:
+              memory: 20Mi
+              cpu: 10m
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - mountPath: /etc/tls/private
+              name: olm-operator-serving-cert
+            - mountPath: /srv-cert
+              name: srv-cert
+              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:

--- a/manifests/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/manifests/0000_50_olm_07-olm-operator.deployment.yaml
@@ -37,6 +37,9 @@ spec:
             secretName: pprof-cert
         - name: tmpfs
           emptyDir: {}
+        - name: olm-operator-serving-cert
+          secret:
+            secretName: olm-operator-serving-cert
       containers:
         - name: olm-operator
           securityContext:
@@ -99,6 +102,37 @@ spec:
             requests:
               cpu: 10m
               memory: 160Mi
+        - args:
+            - --secure-listen-address=0.0.0.0:9443
+            - --upstream=https://127.0.0.1:8443/
+            - --tls-cert-file=/etc/tls/private/tls.crt
+            - --tls-private-key-file=/etc/tls/private/tls.key
+            - --upstream-ca-file=/srv-cert/tls.crt
+            - --logtostderr=true
+          image: quay.io/openshift/origin-kube-rbac-proxy:latest
+          imagePullPolicy: IfNotPresent
+          name: kube-rbac-proxy
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - containerPort: 9443
+              name: metrics
+              protocol: TCP
+          resources:
+            requests:
+              memory: 20Mi
+              cpu: 10m
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - mountPath: /etc/tls/private
+              name: olm-operator-serving-cert
+            - mountPath: /srv-cert
+              name: srv-cert
+              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
         node-role.kubernetes.io/master: ""

--- a/manifests/0000_50_olm_08-catalog-operator.deployment.ibm-cloud-managed.yaml
+++ b/manifests/0000_50_olm_08-catalog-operator.deployment.ibm-cloud-managed.yaml
@@ -38,6 +38,9 @@ spec:
             secretName: pprof-cert
         - name: tmpfs
           emptyDir: {}
+        - name: catalog-operator-serving-cert
+          secret:
+            secretName: catalog-operator-serving-cert
       containers:
         - name: catalog-operator
           securityContext:
@@ -95,6 +98,37 @@ spec:
           env:
             - name: RELEASE_VERSION
               value: "0.0.1-snapshot"
+        - args:
+            - --secure-listen-address=0.0.0.0:9443
+            - --upstream=https://127.0.0.1:8443/
+            - --tls-cert-file=/etc/tls/private/tls.crt
+            - --tls-private-key-file=/etc/tls/private/tls.key
+            - --upstream-ca-file=/srv-cert/tls.crt
+            - --logtostderr=true
+          image: quay.io/openshift/origin-kube-rbac-proxy:latest
+          imagePullPolicy: IfNotPresent
+          name: kube-rbac-proxy
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - containerPort: 9443
+              name: metrics
+              protocol: TCP
+          resources:
+            requests:
+              memory: 20Mi
+              cpu: 10m
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - mountPath: /etc/tls/private
+              name: catalog-operator-serving-cert
+            - mountPath: /srv-cert
+              name: srv-cert
+              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:

--- a/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/manifests/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -37,6 +37,9 @@ spec:
             secretName: pprof-cert
         - name: tmpfs
           emptyDir: {}
+        - name: catalog-operator-serving-cert
+          secret:
+            secretName: catalog-operator-serving-cert
       containers:
         - name: catalog-operator
           securityContext:
@@ -94,6 +97,37 @@ spec:
           env:
             - name: RELEASE_VERSION
               value: "0.0.1-snapshot"
+        - args:
+            - --secure-listen-address=0.0.0.0:9443
+            - --upstream=https://127.0.0.1:8443/
+            - --tls-cert-file=/etc/tls/private/tls.crt
+            - --tls-private-key-file=/etc/tls/private/tls.key
+            - --upstream-ca-file=/srv-cert/tls.crt
+            - --logtostderr=true
+          image: quay.io/openshift/origin-kube-rbac-proxy:latest
+          imagePullPolicy: IfNotPresent
+          name: kube-rbac-proxy
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - containerPort: 9443
+              name: metrics
+              protocol: TCP
+          resources:
+            requests:
+              memory: 20Mi
+              cpu: 10m
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - mountPath: /etc/tls/private
+              name: catalog-operator-serving-cert
+            - mountPath: /srv-cert
+              name: srv-cert
+              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
         node-role.kubernetes.io/master: ""

--- a/microshift-manifests/0000_50_olm_03-services.yaml
+++ b/microshift-manifests/0000_50_olm_03-services.yaml
@@ -17,7 +17,7 @@ spec:
     - name: https-metrics
       port: 8443
       protocol: TCP
-      targetPort: 8443
+      targetPort: 9443
   selector:
     app: olm-operator
 ---
@@ -40,6 +40,6 @@ spec:
     - name: https-metrics
       port: 8443
       protocol: TCP
-      targetPort: 8443
+      targetPort: 9443
   selector:
     app: catalog-operator

--- a/microshift-manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
+++ b/microshift-manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
@@ -38,6 +38,9 @@ spec:
             secretName: pprof-cert
         - name: tmpfs
           emptyDir: {}
+        - name: olm-operator-serving-cert
+          secret:
+            secretName: olm-operator-serving-cert
       containers:
         - name: olm-operator
           securityContext:
@@ -100,6 +103,37 @@ spec:
             requests:
               cpu: 10m
               memory: 160Mi
+        - args:
+            - --secure-listen-address=0.0.0.0:9443
+            - --upstream=https://127.0.0.1:8443/
+            - --tls-cert-file=/etc/tls/private/tls.crt
+            - --tls-private-key-file=/etc/tls/private/tls.key
+            - --upstream-ca-file=/srv-cert/tls.crt
+            - --logtostderr=true
+          image: quay.io/openshift/origin-kube-rbac-proxy:latest
+          imagePullPolicy: IfNotPresent
+          name: kube-rbac-proxy
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - containerPort: 9443
+              name: metrics
+              protocol: TCP
+          resources:
+            requests:
+              memory: 20Mi
+              cpu: 10m
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - mountPath: /etc/tls/private
+              name: olm-operator-serving-cert
+            - mountPath: /srv-cert
+              name: srv-cert
+              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:

--- a/microshift-manifests/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/microshift-manifests/0000_50_olm_07-olm-operator.deployment.yaml
@@ -37,6 +37,9 @@ spec:
             secretName: pprof-cert
         - name: tmpfs
           emptyDir: {}
+        - name: olm-operator-serving-cert
+          secret:
+            secretName: olm-operator-serving-cert
       containers:
         - name: olm-operator
           securityContext:
@@ -95,6 +98,37 @@ spec:
             requests:
               cpu: 10m
               memory: 160Mi
+        - args:
+            - --secure-listen-address=0.0.0.0:9443
+            - --upstream=https://127.0.0.1:8443/
+            - --tls-cert-file=/etc/tls/private/tls.crt
+            - --tls-private-key-file=/etc/tls/private/tls.key
+            - --upstream-ca-file=/srv-cert/tls.crt
+            - --logtostderr=true
+          image: quay.io/openshift/origin-kube-rbac-proxy:latest
+          imagePullPolicy: IfNotPresent
+          name: kube-rbac-proxy
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - containerPort: 9443
+              name: metrics
+              protocol: TCP
+          resources:
+            requests:
+              memory: 20Mi
+              cpu: 10m
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - mountPath: /etc/tls/private
+              name: olm-operator-serving-cert
+            - mountPath: /srv-cert
+              name: srv-cert
+              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
         node-role.kubernetes.io/master: ""

--- a/microshift-manifests/0000_50_olm_08-catalog-operator.deployment.ibm-cloud-managed.yaml
+++ b/microshift-manifests/0000_50_olm_08-catalog-operator.deployment.ibm-cloud-managed.yaml
@@ -38,6 +38,9 @@ spec:
             secretName: pprof-cert
         - name: tmpfs
           emptyDir: {}
+        - name: catalog-operator-serving-cert
+          secret:
+            secretName: catalog-operator-serving-cert
       containers:
         - name: catalog-operator
           securityContext:
@@ -95,6 +98,37 @@ spec:
           env:
             - name: RELEASE_VERSION
               value: "0.0.1-snapshot"
+        - args:
+            - --secure-listen-address=0.0.0.0:9443
+            - --upstream=https://127.0.0.1:8443/
+            - --tls-cert-file=/etc/tls/private/tls.crt
+            - --tls-private-key-file=/etc/tls/private/tls.key
+            - --upstream-ca-file=/srv-cert/tls.crt
+            - --logtostderr=true
+          image: quay.io/openshift/origin-kube-rbac-proxy:latest
+          imagePullPolicy: IfNotPresent
+          name: kube-rbac-proxy
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - containerPort: 9443
+              name: metrics
+              protocol: TCP
+          resources:
+            requests:
+              memory: 20Mi
+              cpu: 10m
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - mountPath: /etc/tls/private
+              name: catalog-operator-serving-cert
+            - mountPath: /srv-cert
+              name: srv-cert
+              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:

--- a/microshift-manifests/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/microshift-manifests/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -37,6 +37,9 @@ spec:
             secretName: pprof-cert
         - name: tmpfs
           emptyDir: {}
+        - name: catalog-operator-serving-cert
+          secret:
+            secretName: catalog-operator-serving-cert
       containers:
         - name: catalog-operator
           securityContext:
@@ -94,6 +97,37 @@ spec:
           env:
             - name: RELEASE_VERSION
               value: "0.0.1-snapshot"
+        - args:
+            - --secure-listen-address=0.0.0.0:9443
+            - --upstream=https://127.0.0.1:8443/
+            - --tls-cert-file=/etc/tls/private/tls.crt
+            - --tls-private-key-file=/etc/tls/private/tls.key
+            - --upstream-ca-file=/srv-cert/tls.crt
+            - --logtostderr=true
+          image: quay.io/openshift/origin-kube-rbac-proxy:latest
+          imagePullPolicy: IfNotPresent
+          name: kube-rbac-proxy
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - containerPort: 9443
+              name: metrics
+              protocol: TCP
+          resources:
+            requests:
+              memory: 20Mi
+              cpu: 10m
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - mountPath: /etc/tls/private
+              name: catalog-operator-serving-cert
+            - mountPath: /srv-cert
+              name: srv-cert
+              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
         node-role.kubernetes.io/master: ""

--- a/scripts/catalog-deployment.patch.yaml
+++ b/scripts/catalog-deployment.patch.yaml
@@ -24,3 +24,58 @@
     runAsNonRoot: true
     seccompProfile:
       type: RuntimeDefault
+- command: update
+  path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+  value: 8443
+- command: update
+  path: spec.template.spec.containers[0].livenessProbe.httpGet.scheme
+  value: HTTPS
+- command: update
+  path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+  value: 8443
+- command: update
+  path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+  value: HTTPS
+- command: update
+  path: spec.template.spec.containers[0].ports[0].containerPort
+  value: 8443
+- command: update
+  path: spec.template.spec.volumes[+]
+  value:
+    name: catalog-operator-serving-cert
+    secret:
+      secretName: catalog-operator-serving-cert
+- command: update
+  path: spec.template.spec.containers[+]
+  value:
+    args:
+      - --secure-listen-address=0.0.0.0:9443
+      - --upstream=https://127.0.0.1:8443/
+      - --tls-cert-file=/etc/tls/private/tls.crt
+      - --tls-private-key-file=/etc/tls/private/tls.key
+      - --upstream-ca-file=/srv-cert/tls.crt
+      - --logtostderr=true
+    image: quay.io/openshift/origin-kube-rbac-proxy:latest
+    imagePullPolicy: IfNotPresent
+    name: kube-rbac-proxy
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop: ["ALL"]
+    ports:
+      - containerPort: 9443
+        name: metrics
+        protocol: TCP
+    resources:
+      requests:
+        memory: 20Mi
+        cpu: 10m
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: FallbackToLogsOnError
+    volumeMounts:
+      - mountPath: /etc/tls/private
+        name: catalog-operator-serving-cert
+      - mountPath: /srv-cert
+        name: srv-cert
+        readOnly: true

--- a/scripts/olm-deployment.patch.yaml
+++ b/scripts/olm-deployment.patch.yaml
@@ -32,3 +32,58 @@
     runAsNonRoot: true
     seccompProfile:
       type: RuntimeDefault
+- command: update
+  path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+  value: 8443
+- command: update
+  path: spec.template.spec.containers[0].livenessProbe.httpGet.scheme
+  value: HTTPS
+- command: update
+  path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+  value: 8443
+- command: update
+  path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+  value: HTTPS
+- command: update
+  path: spec.template.spec.containers[0].ports[0].containerPort
+  value: 8443
+- command: update
+  path: spec.template.spec.volumes[+]
+  value:
+    name: olm-operator-serving-cert
+    secret:
+      secretName: olm-operator-serving-cert
+- command: update
+  path: spec.template.spec.containers[+]
+  value:
+    args:
+      - --secure-listen-address=0.0.0.0:9443
+      - --upstream=https://127.0.0.1:8443/
+      - --tls-cert-file=/etc/tls/private/tls.crt
+      - --tls-private-key-file=/etc/tls/private/tls.key
+      - --upstream-ca-file=/srv-cert/tls.crt
+      - --logtostderr=true
+    image: quay.io/openshift/origin-kube-rbac-proxy:latest
+    imagePullPolicy: IfNotPresent
+    name: kube-rbac-proxy
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop: ["ALL"]
+    ports:
+      - containerPort: 9443
+        name: metrics
+        protocol: TCP
+    resources:
+      requests:
+        memory: 20Mi
+        cpu: 10m
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: FallbackToLogsOnError
+    volumeMounts:
+      - mountPath: /etc/tls/private
+        name: olm-operator-serving-cert
+      - mountPath: /srv-cert
+        name: srv-cert
+        readOnly: true

--- a/staging/operator-lifecycle-manager/pkg/lib/server/server.go
+++ b/staging/operator-lifecycle-manager/pkg/lib/server/server.go
@@ -78,9 +78,9 @@ func (sc *serverConfig) tlsEnabled() (bool, error) {
 
 func (sc *serverConfig) getAddress(tlsEnabled bool) string {
 	if tlsEnabled {
-		return ":8443"
+		return "127.0.0.1:8443"
 	}
-	return ":8080"
+	return "127.0.0.1:8080"
 }
 
 func (sc serverConfig) getListenAndServeFunc() (func() error, error) {

--- a/values.yaml
+++ b/values.yaml
@@ -19,7 +19,7 @@ olm:
     ref: quay.io/operator-framework/olm@sha256:de396b540b82219812061d0d753440d5655250c621c753ed1dc67d6154741607
     pullPolicy: IfNotPresent
   service:
-    internalPort: 8443
+    internalPort: 9443
     externalPort: 8443
   clientCASecret: pprof-cert
   nodeSelector:
@@ -50,7 +50,7 @@ catalog:
     ref: quay.io/operator-framework/olm@sha256:de396b540b82219812061d0d753440d5655250c621c753ed1dc67d6154741607
     pullPolicy: IfNotPresent
   service:
-    internalPort: 8443
+    internalPort: 9443
     externalPort: 8443
   clientCASecret: pprof-cert
   tlsSecret: catalog-operator-serving-cert


### PR DESCRIPTION
Secure metrics endpoint access of both controllers using kube-rbac-proxy