### PR TITLE
NO-ISSUE: UPSTREAM: <carry>: make downstream csv namespace labeler plugin e2e more resilient to race conditions [4.20]

### DIFF
--- a/staging/operator-lifecycle-manager/test/e2e/util.go
+++ b/staging/operator-lifecycle-manager/test/e2e/util.go
@@ -1068,7 +1068,7 @@ func HaveMessage(goal string) gtypes.GomegaMatcher {
 func SetupGeneratedTestNamespaceWithOperatorGroup(name string, og operatorsv1.OperatorGroup) corev1.Namespace {
 	ns := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:   name,
 			Labels: map[string]string{},
 		},
 	}

--- a/staging/operator-lifecycle-manager/test/e2e/util/e2e_determined_client.go
+++ b/staging/operator-lifecycle-manager/test/e2e/util/e2e_determined_client.go
@@ -28,6 +28,11 @@ func (m *DeterminedE2EClient) Create(context context.Context, obj k8scontrollerc
 	return nil
 }
 
+// Update retries update operation until success or timeout
+//
+// Deprecation: do not use this method as it's not resilient to the case where the resource has changed out of band
+// it will conflict until it times out.
+// There's no priority to fix this client implementation - please use regular client instead
 func (m *DeterminedE2EClient) Update(context context.Context, obj k8scontrollerclient.Object, options ...k8scontrollerclient.UpdateOption) error {
 	m.keepTrying(func() error {
 		return m.E2EKubeClient.Update(context, obj, options...)


### PR DESCRIPTION
Backport of #1074 