### PR TITLE
NO-ISSUE: set package-server-manager as default container

### DIFF
--- a/manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
+++ b/manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
@@ -20,6 +20,7 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
         openshift.io/required-scc: restricted-v2
+        kubectl.kubernetes.io/default-container: package-server-manager
       labels:
         app: package-server-manager
     spec:

--- a/manifests/0000_50_olm_06-psm-operator.deployment.yaml
+++ b/manifests/0000_50_olm_06-psm-operator.deployment.yaml
@@ -20,6 +20,7 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
         openshift.io/required-scc: restricted-v2
+        kubectl.kubernetes.io/default-container: package-server-manager
       labels:
         app: package-server-manager
     spec:

--- a/microshift-manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
+++ b/microshift-manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
@@ -20,6 +20,7 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
         openshift.io/required-scc: restricted-v2
+        kubectl.kubernetes.io/default-container: package-server-manager
       labels:
         app: package-server-manager
     spec:

--- a/microshift-manifests/0000_50_olm_06-psm-operator.deployment.yaml
+++ b/microshift-manifests/0000_50_olm_06-psm-operator.deployment.yaml
@@ -20,6 +20,7 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
         openshift.io/required-scc: restricted-v2
+        kubectl.kubernetes.io/default-container: package-server-manager
       labels:
         app: package-server-manager
     spec:

--- a/scripts/generate_crds_manifests.sh
+++ b/scripts/generate_crds_manifests.sh
@@ -181,6 +181,7 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
         openshift.io/required-scc: restricted-v2
+        kubectl.kubernetes.io/default-container: package-server-manager
       labels:
         app: package-server-manager
     spec:


### PR DESCRIPTION
As we use `kubectl logs -n openshift-operator-lifecycle-manager package-server-manager-5f47cc476f-vlwhw `, we see the default container logs is `kube-rbac-proxy`, like :

```
kubectl logs -n openshift-operator-lifecycle-manager package-server-manager-5f47cc476f-vlwhw 
Defaulted container "kube-rbac-proxy" out of: kube-rbac-proxy, package-server-manager
W0707 04:28:36.737827       1 deprecated.go:66] 
==== Removed Flag Warning ======================

logtostderr is removed in the k8s upstream and has no effect any more.

===============================================

I0707 04:28:36.738391       1 kube-rbac-proxy.go:233] Valid token audiences: 
I0707 04:28:36.738440       1 kube-rbac-proxy.go:347] Reading certificate files
I0707 04:28:36.738810       1 kube-rbac-proxy.go:395] Starting TCP socket on 0.0.0.0:8443
I0707 04:28:36.739099       1 kube-rbac-proxy.go:402] Listening securely on 0.0.0.0:8443
```

However, most of the time we just care about the container `package-server-manager` logs , not the `kube-rbac-proxy`