### PR TITLE
OCPQE-29415:enhance filters to add more suites

### DIFF
--- a/tests-extension/test/qe/util/filters/filters.go
+++ b/tests-extension/test/qe/util/filters/filters.go
@@ -1,0 +1,60 @@
+// Package filters provides utilities for generating test suite qualifiers
+// used in the OpenShift OLMv1 test extension framework.
+package filters
+
+import (
+	"fmt"
+	"strings"
+)
+
+// and combines multiple filters using logical AND operator.
+// Returns a parenthesized expression joining all filters with " && ".
+func and(filters ...string) string {
+	return fmt.Sprintf("(%s)", strings.Join(filters, " && "))
+}
+
+// buildFilter combines a base filter with an optional additional filter.
+// If additionalFilter is empty, returns only the base filter wrapped in parentheses.
+// Otherwise, combines both filters using logical AND.
+func buildFilter(baseFilter, additionalFilter string) string {
+	if additionalFilter == "" {
+		return fmt.Sprintf("(%s)", baseFilter)
+	}
+	return and(fmt.Sprintf("(%s)", baseFilter), fmt.Sprintf("(%s)", additionalFilter))
+}
+
+// BasedStandardTests generates a qualifier for standard tests.
+// Includes: non-Extended tests OR Extended tests marked as ReleaseGate.
+// Additional filter can be applied to further narrow the selection.
+func BasedStandardTests(filter string) string {
+	standardFilter := `(!labels.exists(l, l=="Extended")) || (labels.exists(l, l=="Extended") && labels.exists(l, l=="ReleaseGate"))`
+	return buildFilter(standardFilter, filter)
+}
+// BasedExtendedTests generates a qualifier for all extended tests.
+// Includes: all tests marked with "Extended" label.
+// Additional filter can be applied to further narrow the selection.
+func BasedExtendedTests(filter string) string {
+	extendedFilter := `labels.exists(l, l=="Extended")`
+	return buildFilter(extendedFilter, filter)
+}
+// BasedExtendedReleaseGateTests generates a qualifier for extended release gate tests.
+// Includes: Extended tests that are also marked as ReleaseGate.
+// Additional filter can be applied to further narrow the selection.
+func BasedExtendedReleaseGateTests(filter string) string {
+	extendedReleaseGateFilter := `labels.exists(l, l=="Extended") && labels.exists(l, l=="ReleaseGate")`
+	return buildFilter(extendedReleaseGateFilter, filter)
+}
+// BasedExtendedCandidateTests generates a qualifier for extended candidate tests.
+// Includes: Extended tests that are NOT marked as ReleaseGate.
+// Additional filter can be applied to further narrow the selection.
+func BasedExtendedCandidateTests(filter string) string {
+	extendedCandidateFilter := `labels.exists(l, l=="Extended") && !labels.exists(l, l=="ReleaseGate")`
+	return buildFilter(extendedCandidateFilter, filter)
+}
+// BasedExtendedCandidateFuncTests generates a qualifier for extended candidate functional tests.
+// Includes: Extended tests that are NOT ReleaseGate and NOT StressTest.
+// Additional filter can be applied to further narrow the selection.
+func BasedExtendedCandidateFuncTests(filter string) string {
+	extendedCandidateFuncFilter := `labels.exists(l, l=="Extended") && !labels.exists(l, l=="ReleaseGate") && !labels.exists(l, l=="StressTest")`
+	return buildFilter(extendedCandidateFuncFilter, filter)
+}


### PR DESCRIPTION
  Summary

  This PR enhances the test filtering capabilities in the tests-extension module to support additional test suites with more granular selection options.

  Changes

  - Enhanced cmd/main.go: Extended the main command with improved filter logic and expanded functionality (75 lines of changes)
  - Added test/qe/util/filters/filters.go: New filtering module that provides enhanced test suite selection capabilities (60 lines of new code)

  Benefits

  - More flexible test suite management
  - Improved test execution control
  - Better support for selective test running

  Files Changed

  - tests-extension/cmd/main.go - Enhanced main command functionality
  - tests-extension/test/qe/util/filters/filters.go - New filtering utilities

  Testing

```console
./bin/olmv0-tests-ext list suites
[
  {
    "name": "olmv0/parallel",
    "description": "",
    "parents": [
      "openshift/conformance/parallel"
    ],
    "qualifiers": [
      "(source == \"openshift:payload:olmv0\") \u0026\u0026 ((((!labels.exists(l, l==\"Extended\")) || (labels.exists(l, l==\"Extended\") \u0026\u0026 labels.exists(l, l==\"ReleaseGate\"))) \u0026\u0026 (!(name.contains(\"[Serial]\") || name.contains(\"[Slow]\")))))"
    ]
  },
  {
    "name": "olmv0/serial",
    "description": "",
    "parents": [
      "openshift/conformance/serial"
    ],
    "qualifiers": [
      "(source == \"openshift:payload:olmv0\") \u0026\u0026 ((((!labels.exists(l, l==\"Extended\")) || (labels.exists(l, l==\"Extended\") \u0026\u0026 labels.exists(l, l==\"ReleaseGate\"))) \u0026\u0026 ((name.contains(\"[Serial]\") \u0026\u0026 !name.contains(\"[Disruptive]\") \u0026\u0026 !name.contains(\"[Slow]\")))))"
    ]
  },
  {
    "name": "olmv0/slow",
    "description": "",
    "parents": [
      "openshift/optional/slow"
    ],
    "qualifiers": [
      "(source == \"openshift:payload:olmv0\") \u0026\u0026 ((((!labels.exists(l, l==\"Extended\")) || (labels.exists(l, l==\"Extended\") \u0026\u0026 labels.exists(l, l==\"ReleaseGate\"))) \u0026\u0026 (name.contains(\"[Slow]\"))))"
    ]
  },
  {
    "name": "olmv0/all",
    "description": "",
    "qualifiers": [
      "(source == \"openshift:payload:olmv0\") \u0026\u0026 (((!labels.exists(l, l==\"Extended\")) || (labels.exists(l, l==\"Extended\") \u0026\u0026 labels.exists(l, l==\"ReleaseGate\"))))"
    ]
  },
  {
    "name": "olmv0/extended",
    "description": "",
    "qualifiers": [
      "(source == \"openshift:payload:olmv0\") \u0026\u0026 ((labels.exists(l, l==\"Extended\")))"
    ]
  },
  {
    "name": "olmv0/extended/releasegate",
    "description": "",
    "qualifiers": [
      "(source == \"openshift:payload:olmv0\") \u0026\u0026 ((labels.exists(l, l==\"Extended\") \u0026\u0026 labels.exists(l, l==\"ReleaseGate\")))"
    ]
  },
  {
    "name": "olmv0/extended/candidate",
    "description": "",
    "qualifiers": [
      "(source == \"openshift:payload:olmv0\") \u0026\u0026 ((labels.exists(l, l==\"Extended\") \u0026\u0026 !labels.exists(l, l==\"ReleaseGate\")))"
    ]
  },
  {
    "name": "olmv1/extended/candidate/function",
    "description": "",
    "qualifiers": [
      "(source == \"openshift:payload:olmv0\") \u0026\u0026 ((labels.exists(l, l==\"Extended\") \u0026\u0026 !labels.exists(l, l==\"ReleaseGate\") \u0026\u0026 !labels.exists(l, l==\"StressTest\")))"
    ]
  },
  {
    "name": "olmv0/extended/candidate/parallel",
    "description": "",
    "qualifiers": [
      "(source == \"openshift:payload:olmv0\") \u0026\u0026 (((labels.exists(l, l==\"Extended\") \u0026\u0026 !labels.exists(l, l==\"ReleaseGate\") \u0026\u0026 !labels.exists(l, l==\"StressTest\")) \u0026\u0026 (!(name.contains(\"[Serial]\") || name.contains(\"[Slow]\")))))"
    ]
  },
  {
    "name": "olmv0/extended/candidate/serial",
    "description": "",
    "qualifiers": [
      "(source == \"openshift:payload:olmv0\") \u0026\u0026 (((labels.exists(l, l==\"Extended\") \u0026\u0026 !labels.exists(l, l==\"ReleaseGate\") \u0026\u0026 !labels.exists(l, l==\"StressTest\")) \u0026\u0026 ((name.contains(\"[Serial]\") \u0026\u0026 !name.contains(\"[Slow]\")))))"
    ]
  },
  {
    "name": "olmv1/extended/candidate/fast",
    "description": "",
    "qualifiers": [
      "(source == \"openshift:payload:olmv0\") \u0026\u0026 (((labels.exists(l, l==\"Extended\") \u0026\u0026 !labels.exists(l, l==\"ReleaseGate\") \u0026\u0026 !labels.exists(l, l==\"StressTest\")) \u0026\u0026 (!name.contains(\"[Slow]\"))))"
    ]
  },
  {
    "name": "olmv0/extended/candidate/slow",
    "description": "",
    "qualifiers": [
      "(source == \"openshift:payload:olmv0\") \u0026\u0026 (((labels.exists(l, l==\"Extended\") \u0026\u0026 !labels.exists(l, l==\"ReleaseGate\") \u0026\u0026 !labels.exists(l, l==\"StressTest\")) \u0026\u0026 (name.contains(\"[Slow]\"))))"
    ]
  },
  {
    "name": "olmv0/extended/candidate/stress",
    "description": "",
    "qualifiers": [
      "(source == \"openshift:payload:olmv0\") \u0026\u0026 (((labels.exists(l, l==\"Extended\") \u0026\u0026 !labels.exists(l, l==\"ReleaseGate\")) \u0026\u0026 (labels.exists(l, l==\"StressTest\"))))"
    ]
  }
]

```