### PR TITLE
OCPQE-31553: continue to adjust case per collect-profiles change

### DIFF
--- a/tests-extension/test/qe/specs/olmv0_networkpolicy.go
+++ b/tests-extension/test/qe/specs/olmv0_networkpolicy.go
@@ -156,10 +156,10 @@ var _ = g.Describe("[sig-operator][Jira:OLM] OLMv0 networkpolicy", func() {
 		}
 
 		// Dynamically add collect-profiles policy if the pods exist
-		if _, err := oc.AsAdmin().WithoutNamespace().
+		if output, err := oc.AsAdmin().WithoutNamespace().
 			Run("get").
-			Args("pods", "-n", "openshift-operator-lifecycle-manager", "-l", "app=olm-collect-profiles").
-			Output(); err == nil {
+			Args("pods", "-n", "openshift-operator-lifecycle-manager", "-l", "app=olm-collect-profiles", "-o", "name").
+			Output(); err == nil && strings.Contains(output, "collect-profiles") {
 			policies = append(policies, olmv0util.NpExpecter{
 				Name:          "collect-profiles",
 				Namespace:     "openshift-operator-lifecycle-manager",
@@ -369,10 +369,10 @@ var _ = g.Describe("[sig-operator][Jira:OLM] OLMv0 networkpolicy", func() {
 		}
 
 		// Dynamically add collect-profiles policy if the pods exist
-		if _, err := oc.AsAdmin().WithoutNamespace().
+		if output, err := oc.AsAdmin().WithoutNamespace().
 			Run("get").
-			Args("pods", "-n", "openshift-operator-lifecycle-manager", "-l", "app=olm-collect-profiles").
-			Output(); err == nil {
+			Args("pods", "-n", "openshift-operator-lifecycle-manager", "-l", "app=olm-collect-profiles", "-o", "name").
+			Output(); err == nil && strings.Contains(output, "collect-profiles") {
 			policies = append(policies, olmv0util.NpExpecter{
 				Name:          "collect-profiles",
 				Namespace:     "openshift-operator-lifecycle-manager",


### PR DESCRIPTION
following #1216 , it continue to fix the cases.

/cc @jianzhangbjz @Xia-Zhao-rh @bandrade 

cc @tmshort @grokspawn 

the original code still return nil if there is no pod because the command executes successfully.

it resolves #1215 prow job failing.

```console
  [sig-operator][Jira:OLM] OLMv0 networkpolicy PolarionID:83105-[OTP][Skipped:Disconnected]olmv0 static networkpolicy on ocp [NonHyperShiftHOST, ReleaseGate, original-name:[sig-operator][Jira:OLM] OLMv0 should PolarionID:83105-[Skipped:Disconnected]olmv0 static networkpolicy on ocp]
  /Users/kuiwang/GoProject/go-origin/src/github.com/openshift/operator-framework-olm/tests-extension/test/qe/specs/olmv0_networkpolicy.go:29
    STEP: Creating a kubernetes client @ 02/04/26 13:35:37.117
  I0204 13:35:42.126704 57276 client.go:761] Running 'oc --kubeconfig=/Users/kuiwang/work/bin/jb/kubeconf/kubeconfig explain template.apiVersion'
  I0204 13:35:46.937644 57276 client.go:761] Running 'oc --kubeconfig=/Users/kuiwang/work/bin/jb/kubeconf/kubeconfig get pods -n openshift-operator-lifecycle-manager -l app=olm-collect-profiles -o name'
  I0204 13:35:47.712759 57276 client.go:761] Running 'oc --kubeconfig=/Users/kuiwang/work/bin/jb/kubeconf/kubeconfig get catsrc redhat-operators -n openshift-marketplace'
  I0204 13:35:48.451051 57276 client.go:761] Running 'oc --kubeconfig=/Users/kuiwang/work/bin/jb/kubeconf/kubeconfig get catsrc redhat-operators -n openshift-marketplace -o=jsonpath={.status.connectionState.lastObservedState}'
    STEP: Checking NP default-allow-all in openshift-operators @ 02/04/26 13:35:49.199
  I0204 13:35:49.201759 57276 client.go:761] Running 'oc --kubeconfig=/Users/kuiwang/work/bin/jb/kubeconf/kubeconfig get networkpolicy default-allow-all -n openshift-operators -o=jsonpath={.spec}'
  I0204 13:35:49.990586 57276 olmv0_networkpolicy.go:240] specs: {"egress":[{}],"ingress":[{}],"podSelector":{},"policyTypes":["Ingress","Egress"]}
    STEP: Checking NP catalog-operator in openshift-operator-lifecycle-manager @ 02/04/26 13:35:49.992
  I0204 13:35:49.993204 57276 client.go:761] Running 'oc --kubeconfig=/Users/kuiwang/work/bin/jb/kubeconf/kubeconfig get networkpolicy catalog-operator -n openshift-operator-lifecycle-manager -o=jsonpath={.spec}'
  I0204 13:35:50.739688 57276 olmv0_networkpolicy.go:240] specs: {"egress":[{"ports":[{"port":6443,"protocol":"TCP"}]},{"ports":[{"port":"dns-tcp","protocol":"TCP"},{"port":"dns","protocol":"UDP"}],"to":[{"namespaceSelector":{"matchLabels":{"kubernetes.io/metadata.name":"openshift-dns"}}}]},{"ports":[{"port":50051,"protocol":"TCP"}]}],"ingress":[{"ports":[{"port":"metrics","protocol":"TCP"}]}],"podSelector":{"matchLabels":{"app":"catalog-operator"}},"policyTypes":["Ingress","Egress"]}
    STEP: Checking NP default-deny-all-traffic in openshift-operator-lifecycle-manager @ 02/04/26 13:35:50.74
  I0204 13:35:50.740564 57276 client.go:761] Running 'oc --kubeconfig=/Users/kuiwang/work/bin/jb/kubeconf/kubeconfig get networkpolicy default-deny-all-traffic -n openshift-operator-lifecycle-manager -o=jsonpath={.spec}'
  I0204 13:35:51.488444 57276 olmv0_networkpolicy.go:240] specs: {"podSelector":{},"policyTypes":["Ingress","Egress"]}
    STEP: Checking NP olm-operator in openshift-operator-lifecycle-manager @ 02/04/26 13:35:51.488
  I0204 13:35:51.489185 57276 client.go:761] Running 'oc --kubeconfig=/Users/kuiwang/work/bin/jb/kubeconf/kubeconfig get networkpolicy olm-operator -n openshift-operator-lifecycle-manager -o=jsonpath={.spec}'
  I0204 13:35:52.251654 57276 olmv0_networkpolicy.go:240] specs: {"egress":[{"ports":[{"port":6443,"protocol":"TCP"}]},{"ports":[{"port":"dns-tcp","protocol":"TCP"},{"port":"dns","protocol":"UDP"}],"to":[{"namespaceSelector":{"matchLabels":{"kubernetes.io/metadata.name":"openshift-dns"}}}]}],"ingress":[{"ports":[{"port":"metrics","protocol":"TCP"}]}],"podSelector":{"matchLabels":{"app":"olm-operator"}},"policyTypes":["Ingress","Egress"]}
    STEP: Checking NP package-server-manager in openshift-operator-lifecycle-manager @ 02/04/26 13:35:52.252
  I0204 13:35:52.252513 57276 client.go:761] Running 'oc --kubeconfig=/Users/kuiwang/work/bin/jb/kubeconf/kubeconfig get networkpolicy package-server-manager -n openshift-operator-lifecycle-manager -o=jsonpath={.spec}'
  I0204 13:35:52.982710 57276 olmv0_networkpolicy.go:240] specs: {"egress":[{"ports":[{"port":6443,"protocol":"TCP"}]},{"ports":[{"port":"dns-tcp","protocol":"TCP"},{"port":"dns","protocol":"UDP"}],"to":[{"namespaceSelector":{"matchLabels":{"kubernetes.io/metadata.name":"openshift-dns"}}}]}],"ingress":[{"ports":[{"port":8443,"protocol":"TCP"}]}],"podSelector":{"matchLabels":{"app":"package-server-manager"}},"policyTypes":["Ingress","Egress"]}
    STEP: Checking NP packageserver in openshift-operator-lifecycle-manager @ 02/04/26 13:35:52.983
  I0204 13:35:52.983511 57276 client.go:761] Running 'oc --kubeconfig=/Users/kuiwang/work/bin/jb/kubeconf/kubeconfig get networkpolicy packageserver -n openshift-operator-lifecycle-manager -o=jsonpath={.spec}'
  I0204 13:35:53.758233 57276 olmv0_networkpolicy.go:240] specs: {"egress":[{"ports":[{"port":6443,"protocol":"TCP"}]},{"ports":[{"port":"dns-tcp","protocol":"TCP"},{"port":"dns","protocol":"UDP"}],"to":[{"namespaceSelector":{"matchLabels":{"kubernetes.io/metadata.name":"openshift-dns"}}}]},{"ports":[{"port":50051,"protocol":"TCP"}]}],"ingress":[{"ports":[{"port":5443,"protocol":"TCP"}]}],"podSelector":{"matchLabels":{"app":"packageserver"}},"policyTypes":["Ingress","Egress"]}
    STEP: Checking NP redhat-operators-grpc-server in openshift-marketplace @ 02/04/26 13:35:53.758
  I0204 13:35:53.759048 57276 client.go:761] Running 'oc --kubeconfig=/Users/kuiwang/work/bin/jb/kubeconf/kubeconfig get networkpolicy redhat-operators-grpc-server -n openshift-marketplace -o=jsonpath={.spec}'
  I0204 13:35:54.501702 57276 olmv0_networkpolicy.go:240] specs: {"ingress":[{"ports":[{"port":50051,"protocol":"TCP"}]}],"podSelector":{"matchLabels":{"olm.catalogSource":"redhat-operators","olm.managed":"true"}},"policyTypes":["Ingress","Egress"]}
  I0204 13:35:54.502031 57276 client.go:761] Running 'oc --kubeconfig=/Users/kuiwang/work/bin/jb/kubeconf/kubeconfig get packagemanifests -n openshift-marketplace --selector=catalog=redhat-operators'
  NAME                                             CATALOG             AGE
  odf-dependencies                                 Red Hat Operators   131m
  kubernetes-nmstate-operator                      Red Hat Operators   131m
  web-terminal                                     Red Hat Operators   131m
  mtv-operator                                     Red Hat Operators   131m
  dpu-operator                                     Red Hat Operators   131m
  authorino-operator                               Red Hat Operators   131m
  vertical-pod-autoscaler                          Red Hat Operators   131m
  red-hat-camel-k                                  Red Hat Operators   131m
  windows-machine-config-operator                  Red Hat Operators   131m
  aws-load-balancer-operator                       Red Hat Operators   131m
  recipe                                           Red Hat Operators   131m
  local-storage-operator                           Red Hat Operators   131m
  external-dns-operator                            Red Hat Operators   131m
  advanced-cluster-management                      Red Hat Operators   131m
  amq-broker-rhel9                                 Red Hat Operators   131m
  metallb-operator                                 Red Hat Operators   131m
  ptp-operator                                     Red Hat Operators   131m
  eap                                              Red Hat Operators   131m
  node-maintenance-operator                        Red Hat Operators   131m
  bamoe-kogito-operator                            Red Hat Operators   131m
  apicurio-registry-3                              Red Hat Operators   131m
  mtr-operator                                     Red Hat Operators   131m
  openshift-cert-manager-operator                  Red Hat Operators   131m
  bamoe-businessautomation-operator                Red Hat Operators   131m
  cli-manager                                      Red Hat Operators   131m
  cluster-observability-operator                   Red Hat Operators   131m
  devworkspace-operator                            Red Hat Operators   131m
  rhods-operator                                   Red Hat Operators   131m
  job-set                                          Red Hat Operators   131m
  kernel-module-management-hub                     Red Hat Operators   131m
  skupper-operator                                 Red Hat Operators   131m
  kueue-operator                                   Red Hat Operators   131m
  cephcsi-operator                                 Red Hat Operators   131m
  policy-controller-operator                       Red Hat Operators   131m
  businessautomation-operator                      Red Hat Operators   131m
  rook-ceph-operator                               Red Hat Operators   131m
  amq-broker-rhel8                                 Red Hat Operators   131m
  3scale-operator                                  Red Hat Operators   131m
  ocs-client-operator                              Red Hat Operators   131m
  odr-hub-operator                                 Red Hat Operators   131m
  rhbk-operator                                    Red Hat Operators   131m
  rhdh                                             Red Hat Operators   131m
  dpu-network-operator                             Red Hat Operators   131m
  odf-operator                                     Red Hat Operators   131m
  quay-operator                                    Red Hat Operators   131m
  costmanagement-metrics-operator                  Red Hat Operators   131m
  watcher-operator                                 Red Hat Operators   131m
  mta-operator                                     Red Hat Operators   131m
  orchestrator-operator                            Red Hat Operators   131m
  cincinnati-operator                              Red Hat Operators   131m
  opentelemetry-product                            Red Hat Operators   131m
  rh-service-binding-operator                      Red Hat Operators   131m
  logic-operator-rhel8                             Red Hat Operators   131m
  openshift-secondary-scheduler-operator           Red Hat Operators   131m
  submariner                                       Red Hat Operators   131m
  ansible-cloud-addons-operator                    Red Hat Operators   131m
  servicemeshoperator3                             Red Hat Operators   131m
  container-security-operator                      Red Hat Operators   131m
  odf-prometheus-operator                          Red Hat Operators   131m
  lightspeed-operator                              Red Hat Operators   131m
  fuse-online                                      Red Hat Operators   131m
  apicast-operator                                 Red Hat Operators   131m
  loki-operator                                    Red Hat Operators   131m
  red-hat-hawtio-operator                          Red Hat Operators   131m
  openshift-zero-trust-workload-identity-manager   Red Hat Operators   131m
  openstack-operator                               Red Hat Operators   131m
  kiali-ossm                                       Red Hat Operators   131m
  multiarch-tuning-operator                        Red Hat Operators   131m
  gcp-filestore-csi-driver-operator                Red Hat Operators   131m
  amq-streams-proxy                                Red Hat Operators   131m
  deployment-validation-operator                   Red Hat Operators   131m
  nfd                                              Red Hat Operators   131m
  cluster-logging                                  Red Hat Operators   131m
  runtimes-inventory-operator                      Red Hat Operators   131m
  rhtas-operator                                   Red Hat Operators   131m
  openshift-pipelines-operator-rh                  Red Hat Operators   131m
  compliance-operator                              Red Hat Operators   131m
  jaeger-product                                   Red Hat Operators   131m
  netobserv-operator                               Red Hat Operators   131m
  aws-efs-csi-driver-operator                      Red Hat Operators   131m
  clusterresourceoverride                          Red Hat Operators   131m
  odf-multicluster-orchestrator                    Red Hat Operators   131m
  smart-gateway-operator                           Red Hat Operators   131m
  tempo-product                                    Red Hat Operators   131m
  leader-worker-set                                Red Hat Operators   131m
  security-profiles-operator                       Red Hat Operators   131m
  mtc-operator                                     Red Hat Operators   131m
  elasticsearch-operator                           Red Hat Operators   131m
  cryostat-operator                                Red Hat Operators   131m
  model-validation-operator                        Red Hat Operators   131m
  lifecycle-agent                                  Red Hat Operators   131m
  self-node-remediation                            Red Hat Operators   131m
  skupper-netobs-operator                          Red Hat Operators   131m
  multicluster-engine                              Red Hat Operators   131m
  ingress-node-firewall                            Red Hat Operators   131m
  nbde-tang-server                                 Red Hat Operators   131m
  datagrid                                         Red Hat Operators   131m
  node-healthcheck-operator                        Red Hat Operators   131m
  smb-csi-driver-operator                          Red Hat Operators   131m
  service-telemetry-operator                       Red Hat Operators   131m
  servicemeshoperator                              Red Hat Operators   131m
  multicluster-global-hub-operator-rh              Red Hat Operators   131m
  file-integrity-operator                          Red Hat Operators   131m
  sandboxed-containers-operator                    Red Hat Operators   131m
  bpfman-operator                                  Red Hat Operators   131m
  fuse-console                                     Red Hat Operators   131m
  devspaces                                        Red Hat Operators   131m
  numaresources-operator                           Red Hat Operators   131m
  rhtpa-operator                                   Red Hat Operators   131m
  mcg-operator                                     Red Hat Operators   131m
  redhat-oadp-operator                             Red Hat Operators   131m
  odf-csi-addons-operator                          Red Hat Operators   131m
  amq-streams-console                              Red Hat Operators   131m
  rhacs-operator                                   Red Hat Operators   131m
  topology-aware-lifecycle-manager                 Red Hat Operators   131m
  quay-bridge-operator                             Red Hat Operators   131m
  power-monitoring-operator                        Red Hat Operators   131m
  volsync-product                                  Red Hat Operators   131m
  rhcl-operator                                    Red Hat Operators   131m
  gatekeeper-operator-product                      Red Hat Operators   131m
  dns-operator                                     Red Hat Operators   131m
  logic-operator                                   Red Hat Operators   131m
  odr-cluster-operator                             Red Hat Operators   131m
  rhpam-kogito-operator                            Red Hat Operators   131m
  fuse-apicurito                                   Red Hat Operators   131m
  kubevirt-hyperconverged                          Red Hat Operators   131m
  openshift-gitops-operator                        Red Hat Operators   131m
  serverless-operator                              Red Hat Operators   131m
  cluster-kube-descheduler-operator                Red Hat Operators   131m
  ansible-automation-platform-operator             Red Hat Operators   131m
  trustee-operator                                 Red Hat Operators   131m
  machine-deletion-remediation                     Red Hat Operators   131m
  limitador-operator                               Red Hat Operators   131m
  secrets-store-csi-driver-operator                Red Hat Operators   131m
  openshift-builds-operator                        Red Hat Operators   131m
  sriov-network-operator                           Red Hat Operators   131m
  amq-streams                                      Red Hat Operators   131m
  jws-operator                                     Red Hat Operators   131m
  openshift-custom-metrics-autoscaler-operator     Red Hat Operators   131m
  service-registry-operator                        Red Hat Operators   131m
  node-observability-operator                      Red Hat Operators   131m
  rhsso-operator                                   Red Hat Operators   131m
  amq7-interconnect-operator                       Red Hat Operators   131m
  kernel-module-management                         Red Hat Operators   131m
  pf-status-relay-operator                         Red Hat Operators   131m
  lvms-operator                                    Red Hat Operators   131m
  tang-operator                                    Red Hat Operators   131m
  run-once-duration-override-operator              Red Hat Operators   131m
  ocs-operator                                     Red Hat Operators   131m
  fence-agents-remediation                         Red Hat Operators   131m
    STEP: Checking NP redhat-operators-unpack-bundles in openshift-marketplace @ 02/04/26 13:35:55.737
  I0204 13:35:55.738110 57276 client.go:761] Running 'oc --kubeconfig=/Users/kuiwang/work/bin/jb/kubeconf/kubeconfig get networkpolicy redhat-operators-unpack-bundles -n openshift-marketplace -o=jsonpath={.spec}'
  I0204 13:35:56.605043 57276 olmv0_networkpolicy.go:240] specs: {"egress":[{"ports":[{"port":6443,"protocol":"TCP"}]}],"podSelector":{"matchExpressions":[{"key":"operatorframework.io/bundle-unpack-ref","operator":"Exists"},{"key":"olm.managed","operator":"In","values":["true"]}]},"policyTypes":["Ingress","Egress"]}
  • [19.493 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 19.494 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped

```

Assisted-By: Claude Code