### PR TITLE
OCPBUGS-79397: Fix SA restore resourceVersion conflict error

### DIFF
--- a/tests-extension/test/qe/util/olmv0util/sa.go
+++ b/tests-extension/test/qe/util/olmv0util/sa.go
@@ -96,11 +96,13 @@ func (sa *serviceAccountDescription) Delete(oc *exutil.CLI) {
 
 // Reapply recreates the ServiceAccount using the previously exported definition
 // This method restores a ServiceAccount from its saved configuration file
+// Uses 'replace --force' to handle race conditions where OLM may have already
+// recreated the SA with a different resourceVersion
 //
 // Parameters:
 //   - oc: OpenShift CLI client for executing commands
 func (sa *serviceAccountDescription) Reapply(oc *exutil.CLI) {
-	err := oc.AsAdmin().WithoutNamespace().Run("apply").Args("-f", sa.definitionfile).Execute()
+	err := oc.AsAdmin().WithoutNamespace().Run("replace").Args("--force", "-f", sa.definitionfile).Execute()
 	o.Expect(err).NotTo(o.HaveOccurred())
 }
 


### PR DESCRIPTION
/cc @jianzhangbjz @Xia-Zhao-rh @bandrade 

It fixes the https://redhat.atlassian.net/browse/OCPQE-31262 and https://redhat.atlassian.net/browse/OCPQE-31846

```console
./bin/olmv0-tests-ext run-test "[sig-operator][Jira:OLM] OLMv0 within a namespace PolarionID:21404-[OTP][Skipped:Disconnected]csv will be RequirementsNotMet after sa is delete"
  I0323 14:47:29.866954 77685 test_context.go:566] The --provider flag is not set. Continuing as if --provider=skeleton had been used.
  Running Suite:  - /Users/kuiwang/GoProject/go-origin/src/github.com/openshift/operator-framework-olm/tests-extension
  ====================================================================================================================
  Random Seed: 1774248449 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-operator][Jira:OLM] OLMv0 within a namespace PolarionID:21404-[OTP][Skipped:Disconnected]csv will be RequirementsNotMet after sa is delete [original-name:[sig-operator][Jira:OLM] OLMv0 within a namespace PolarionID:21404-[Skipped:Disconnected]csv will be RequirementsNotMet after sa is delete]
  /Users/kuiwang/GoProject/go-origin/src/github.com/openshift/operator-framework-olm/tests-extension/test/qe/specs/olmv0_nonallns.go:1387
    STEP: Creating a kubernetes client @ 03/23/26 14:47:29.867
  I0323 14:47:34.872002 77685 client.go:1221] Found admin context: admin
  I0323 14:47:34.872143 77685 client.go:1236] Cached admin context for all test suites: admin
  I0323 14:47:34.872878 77685 client.go:829] Running 'oc --context=admin --kubeconfig=/var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/admin-config-4085530928 explain template.apiVersion'
  I0323 14:47:36.350890 77685 client.go:391] do not know if it is external oidc cluster or not, and try to check it again
  I0323 14:47:36.351111 77685 client.go:888] showInfo is true
  I0323 14:47:36.351162 77685 client.go:889] Running 'oc --context=admin --kubeconfig=/var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/admin-config-4085530928 get authentication/cluster -o=jsonpath={.spec.type}'
  I0323 14:47:36.977070 77685 clusters.go:572] Found authentication type used: 
  I0323 14:47:38.795535 77685 client.go:233] configPath is now "/var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/configfile3252074885"
  I0323 14:47:38.795653 77685 client.go:405] The user is now "e2e-test-default-t7zg6-user"
  I0323 14:47:38.795672 77685 client.go:408] Creating project "e2e-test-default-t7zg6"
  I0323 14:47:39.049962 77685 client.go:417] Waiting on permissions in project "e2e-test-default-t7zg6" ...
  I0323 14:47:39.755147 77685 client.go:478] Waiting for ServiceAccount "default" to be provisioned...
  I0323 14:47:40.041766 77685 client.go:478] Waiting for ServiceAccount "builder" to be provisioned...
  I0323 14:47:40.330343 77685 client.go:478] Waiting for ServiceAccount "deployer" to be provisioned...
  I0323 14:47:40.618453 77685 client.go:488] Waiting for RoleBinding "system:image-builders" to be provisioned...
  I0323 14:47:40.986197 77685 client.go:488] Waiting for RoleBinding "system:deployers" to be provisioned...
  I0323 14:47:41.356958 77685 client.go:488] Waiting for RoleBinding "system:image-pullers" to be provisioned...
  I0323 14:47:41.724426 77685 client.go:519] Project "e2e-test-default-t7zg6" has been fully provisioned.
  I0323 14:47:42.412401 77685 client.go:829] Running 'oc --context=admin --kubeconfig=/var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/admin-config-4085530928 get nodes -o=jsonpath={.items[*].status.nodeInfo.architecture}'
  I0323 14:47:43.546907 77685 client.go:829] Running 'oc --context=admin --kubeconfig=/var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/admin-config-4085530928 get clusterversion version -o=jsonpath={.spec.capabilities.baselineCapabilitySet}'
  I0323 14:47:44.162445 77685 client.go:829] Running 'oc --context=admin --kubeconfig=/var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/admin-config-4085530928 get node -l node-role.kubernetes.io/master -o jsonpath='{.items[*].metadata.name}''
  I0323 14:47:45.171522 77685 client.go:829] Running 'oc --context=admin --kubeconfig=/var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/admin-config-4085530928 get node -l node-role.kubernetes.io/worker -o jsonpath='{.items[*].metadata.name}''
  I0323 14:47:46.158186 77685 client.go:829] Running 'oc --context=admin --kubeconfig=/var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/admin-config-4085530928 get infrastructure cluster -o=jsonpath={.status.platformStatus.type}'
  I0323 14:47:46.737510 77685 client.go:829] Running 'oc --context=admin --kubeconfig=/var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/admin-config-4085530928 get proxy cluster -o=jsonpath={.status.httpProxy}{.status.httpsProxy}'
  I0323 14:47:47.327562 77685 client.go:829] Running 'oc --context=admin --kubeconfig=/var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/admin-config-4085530928 get node -l node-role.kubernetes.io/master -o jsonpath='{.items[*].metadata.name}''
  I0323 14:47:48.379083 77685 client.go:829] Running 'oc --context=admin --kubeconfig=/var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/admin-config-4085530928 get node -l node-role.kubernetes.io/worker -o jsonpath='{.items[*].metadata.name}''
  I0323 14:47:49.359898 77685 client.go:391] do not know if it is external oidc cluster or not, and try to check it again
  I0323 14:47:49.360192 77685 client.go:888] showInfo is true
  I0323 14:47:49.360225 77685 client.go:889] Running 'oc --context=admin --kubeconfig=/var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/admin-config-4085530928 get authentication/cluster -o=jsonpath={.spec.type}'
  I0323 14:47:49.946462 77685 clusters.go:572] Found authentication type used: 
  I0323 14:47:51.054503 77685 client.go:233] configPath is now "/var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/configfile298062878"
  I0323 14:47:51.054637 77685 client.go:405] The user is now "e2e-test-default-sv9bs-user"
  I0323 14:47:51.054654 77685 client.go:408] Creating project "e2e-test-default-sv9bs"
  I0323 14:47:51.311030 77685 client.go:417] Waiting on permissions in project "e2e-test-default-sv9bs" ...
  I0323 14:47:52.022094 77685 client.go:478] Waiting for ServiceAccount "default" to be provisioned...
  I0323 14:47:52.310392 77685 client.go:478] Waiting for ServiceAccount "builder" to be provisioned...
  I0323 14:47:52.597334 77685 client.go:478] Waiting for ServiceAccount "deployer" to be provisioned...
  I0323 14:47:52.877794 77685 client.go:488] Waiting for RoleBinding "system:image-builders" to be provisioned...
  I0323 14:47:53.237720 77685 client.go:488] Waiting for RoleBinding "system:deployers" to be provisioned...
  I0323 14:47:53.601860 77685 client.go:488] Waiting for RoleBinding "system:image-pullers" to be provisioned...
  I0323 14:47:53.961017 77685 client.go:519] Project "e2e-test-default-sv9bs" has been fully provisioned.
    STEP: create catalog source @ 03/23/26 14:47:53.961
  I0323 14:47:53.961463 77685 catalog_source.go:50] set interval to be 10m0s
  I0323 14:47:56.963672 77685 client.go:829] Running 'oc --namespace=e2e-test-default-sv9bs --context=admin --kubeconfig=/var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/admin-config-4085530928 process --ignore-unknown-parameters=true -f /var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/fixture-testdata-dir2875937626/test/qe/testdata/olm/catalogsource-image.yaml -p NAME=catsrc-operator NAMESPACE=e2e-test-default-sv9bs ADDRESS=quay.io/olmqe/olm-index:OLM-2378-Oadp-GoodOne-withCache SECRET= DISPLAYNAME="Test Catsrc Operators" PUBLISHER="Red Hat" SOURCETYPE=grpc INTERVAL=10m0s IMAGETEMPLATE=""'
  I0323 14:47:57.536372 77685 helper.go:102] the file of resource is /var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/e2e-test-default-sv9bs-e3fb3da2olm-config.json
  I0323 14:47:57.536603 77685 client.go:829] Running 'oc --context=admin --kubeconfig=/var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/admin-config-4085530928 apply -f /var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/e2e-test-default-sv9bs-e3fb3da2olm-config.json'
  catalogsource.operators.coreos.com/catsrc-operator created
  I0323 14:47:58.861391 77685 client.go:829] Running 'oc --context=admin --kubeconfig=/var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/admin-config-4085530928 get infrastructures.config.openshift.io cluster -o=jsonpath={.status.controlPlaneTopology}'
  I0323 14:48:00.409469 77685 clusters.go:464] topology is HighlyAvailable
  I0323 14:48:00.409874 77685 client.go:829] Running 'oc --context=admin --kubeconfig=/var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/admin-config-4085530928 get configmaps -n openshift-kube-apiserver config -o=jsonpath={.data.config\.yaml}'
  I0323 14:48:01.258997 77685 catalog_source.go:109] pod-security.kubernetes.io/enforce is restricted
  I0323 14:48:01.259618 77685 client.go:829] Running 'oc --context=admin --kubeconfig=/var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/admin-config-4085530928 get catsrc catsrc-operator -n e2e-test-default-sv9bs -o=jsonpath={.spec.grpcPodConfig.securityContextConfig}'
  I0323 14:48:01.852550 77685 catalog_source.go:115] spec.grpcPodConfig.securityContextConfig is 
  I0323 14:48:01.852673 77685 catalog_source.go:118] set spec.grpcPodConfig.securityContextConfig to be restricted
  I0323 14:48:01.853055 77685 client.go:829] Running 'oc --context=admin --kubeconfig=/var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/admin-config-4085530928 patch catsrc catsrc-operator -n e2e-test-default-sv9bs --type=merge -p {"spec":{"grpcPodConfig":{"securityContextConfig":"restricted"}}}'
  catalogsource.operators.coreos.com/catsrc-operator patched
  I0323 14:48:02.579091 77685 catalog_source.go:74] create catsrc catsrc-operator SUCCESS
  I0323 14:48:12.580678 77685 client.go:829] Running 'oc --context=admin --kubeconfig=/var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/admin-config-4085530928 get catsrc catsrc-operator -n e2e-test-default-sv9bs -o=jsonpath={.status..lastObservedState}'
  I0323 14:48:13.140216 77685 catalog_source.go:158] catsrc catsrc-operator lastObservedState is TRANSIENT_FAILURE, not READY
  I0323 14:48:22.580566 77685 client.go:829] Running 'oc --context=admin --kubeconfig=/var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/admin-config-4085530928 get catsrc catsrc-operator -n e2e-test-default-sv9bs -o=jsonpath={.status..lastObservedState}'
  I0323 14:48:23.200179 77685 catalog_source.go:175] catsrc catsrc-operator lastObservedState is READY
    STEP: Create og @ 03/23/26 14:48:23.2
  I0323 14:48:26.201277 77685 client.go:829] Running 'oc --namespace=e2e-test-default-sv9bs --context=admin --kubeconfig=/var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/admin-config-4085530928 process --ignore-unknown-parameters=true -f /var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/fixture-testdata-dir2875937626/test/qe/testdata/olm/operatorgroup.yaml -p NAME=og-singlenamespace NAMESPACE=e2e-test-default-sv9bs'
  I0323 14:48:26.788408 77685 helper.go:102] the file of resource is /var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/e2e-test-default-sv9bs-d3e021bdolm-config.json
  I0323 14:48:26.788591 77685 client.go:829] Running 'oc --context=admin --kubeconfig=/var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/admin-config-4085530928 apply -f /var/folders/wl/t8n9cyz511q96jx5xvjfwkn40000gn/T/e2e-test-default-sv9bs-d3e021bdolm-config.json'
  operatorgroup.operators.coreos.com/og-singlenamespace created
  I0323 14:48:28.056306 77685 og.go:89] create og og-singlenamespace success
    STEP: Create operator @ 03/23/26 14:48:28.056
...
  I0323 14:49:26.966958 77685 resource.go:96] cleanup resource csv,   oadp-operator.v0.5.3
  I0323 14:49:26.967025 77685 helper.go:277] removeResource: parameters contain '-n' flag, parameters: [csv oadp-operator.v0.5.3 -n e2e-test-default-sv9bs]
  I0323 14:49:26.967377 77685 client.go:829] Running 'oc --context=admin --kubeconfig=/Users/kuiwang/work/bin/jb/kubeconf/kubeconfig delete csv oadp-operator.v0.5.3 -n e2e-test-default-sv9bs'
  I0323 14:49:33.090760 77685 client.go:829] Running 'oc --context=admin --kubeconfig=/Users/kuiwang/work/bin/jb/kubeconf/kubeconfig get csv oadp-operator.v0.5.3 -n e2e-test-default-sv9bs'
  I0323 14:49:33.966311 77685 client.go:863] Error running oc --context=admin --kubeconfig=/Users/kuiwang/work/bin/jb/kubeconf/kubeconfig get csv oadp-operator.v0.5.3 -n e2e-test-default-sv9bs:
  Error from server (NotFound): clusterserviceversions.operators.coreos.com "oadp-operator.v0.5.3" not found
  I0323 14:49:33.966430 77685 helper.go:293] the resource is delete successfully
  I0323 14:49:33.966497 77685 resource.go:96] cleanup resource catsrc,   catsrc-operator
  I0323 14:49:33.966522 77685 helper.go:277] removeResource: parameters contain '-n' flag, parameters: [catsrc catsrc-operator -n e2e-test-default-sv9bs]
  I0323 14:49:33.966901 77685 client.go:829] Running 'oc --context=admin --kubeconfig=/Users/kuiwang/work/bin/jb/kubeconf/kubeconfig delete catsrc catsrc-operator -n e2e-test-default-sv9bs'
  I0323 14:49:39.719320 77685 client.go:829] Running 'oc --context=admin --kubeconfig=/Users/kuiwang/work/bin/jb/kubeconf/kubeconfig get catsrc catsrc-operator -n e2e-test-default-sv9bs'
  I0323 14:49:40.495310 77685 client.go:863] Error running oc --context=admin --kubeconfig=/Users/kuiwang/work/bin/jb/kubeconf/kubeconfig get catsrc catsrc-operator -n e2e-test-default-sv9bs:
  Error from server (NotFound): catalogsources.operators.coreos.com "catsrc-operator" not found
  I0323 14:49:40.495483 77685 helper.go:293] the resource is delete successfully
  I0323 14:49:40.495565 77685 resource.go:96] cleanup resource og,   og-singlenamespace
  I0323 14:49:40.495595 77685 helper.go:277] removeResource: parameters contain '-n' flag, parameters: [og og-singlenamespace -n e2e-test-default-sv9bs]
  I0323 14:49:40.496023 77685 client.go:829] Running 'oc --context=admin --kubeconfig=/Users/kuiwang/work/bin/jb/kubeconf/kubeconfig delete og og-singlenamespace -n e2e-test-default-sv9bs'
  I0323 14:49:46.279852 77685 client.go:829] Running 'oc --context=admin --kubeconfig=/Users/kuiwang/work/bin/jb/kubeconf/kubeconfig get og og-singlenamespace -n e2e-test-default-sv9bs'
  I0323 14:49:47.123826 77685 client.go:863] Error running oc --context=admin --kubeconfig=/Users/kuiwang/work/bin/jb/kubeconf/kubeconfig get og og-singlenamespace -n e2e-test-default-sv9bs:
  Error from server (NotFound): operatorgroups.operators.coreos.com "og-singlenamespace" not found
  I0323 14:49:47.123887 77685 helper.go:293] the resource is delete successfully
    STEP: Destroying namespace "e2e-test-default-t7zg6" for this suite. @ 03/23/26 14:49:47.124
    STEP: Destroying namespace "e2e-test-default-sv9bs" for this suite. @ 03/23/26 14:49:47.3
  • [137.609 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 137.610 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped

```

Assisted-By: Claude Code