### PR TITLE
OCPBUGS-77984: test(olm): skip ppc64le/s390x for tests using single-arch images

### DIFF
--- a/tests-extension/test/qe/specs/olmv0_opm.go
+++ b/tests-extension/test/qe/specs/olmv0_opm.go
@@ -10,6 +10,7 @@ import (
 	o "github.com/onsi/gomega"
 
 	exutil "github.com/openshift/operator-framework-olm/tests-extension/test/qe/util"
+	"github.com/openshift/operator-framework-olm/tests-extension/test/qe/util/architecture"
 	"github.com/openshift/operator-framework-olm/tests-extension/test/qe/util/opmcli"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
@@ -373,6 +374,7 @@ var _ = g.Describe("[sig-operator][Jira:OLM] OLMv0 opm should", g.Label("NonHype
 	})
 
 	g.It("PolarionID:54168-[OTP][Skipped:Disconnected] opm support '--use-http' global flag", g.Label("original-name:[sig-operator][Jira:OLM] OLMv0 opm should PolarionID:54168-[Skipped:Disconnected] opm support '--use-http' global flag"), func() {
+		architecture.SkipArchitectures(oc, architecture.PPC64LE, architecture.S390X)
 		err := opmcli.EnsureContainerPolicy()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -489,6 +491,7 @@ var _ = g.Describe("[sig-operator][Jira:OLM] OLMv0 opm should", g.Label("NonHype
 	})
 
 	g.It("PolarionID:53869-[OTP][Skipped:Disconnected] opm supports creating a catalog using basic veneer", g.Label("original-name:[sig-operator][Jira:OLM] OLMv0 opm should PolarionID:53869-[Skipped:Disconnected] opm supports creating a catalog using basic veneer"), func() {
+		architecture.SkipArchitectures(oc, architecture.PPC64LE, architecture.S390X)
 		err := opmcli.EnsureContainerPolicy()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -553,6 +556,7 @@ var _ = g.Describe("[sig-operator][Jira:OLM] OLMv0 opm should", g.Label("NonHype
 	})
 
 	g.It("PolarionID:53871-PolarionID:53915-PolarionID:53996-[OTP][Skipped:Disconnected][Slow] opm supports creating a catalog using semver veneer [Slow]", g.Label("original-name:[sig-operator][Jira:OLM] OLMv0 opm should PolarionID:53871-PolarionID:53915-PolarionID:53996-[Skipped:Disconnected][Slow] opm supports creating a catalog using semver veneer [Slow]"), func() {
+		architecture.SkipArchitectures(oc, architecture.PPC64LE, architecture.S390X)
 		if os.Getenv("HTTP_PROXY") != "" || os.Getenv("http_proxy") != "" {
 			g.Skip("HTTP_PROXY is not empty - skipping test ...")
 		}

--- a/tests-extension/test/qe/specs/olmv0_stress.go
+++ b/tests-extension/test/qe/specs/olmv0_stress.go
@@ -14,6 +14,7 @@ import (
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 
 	exutil "github.com/openshift/operator-framework-olm/tests-extension/test/qe/util"
+	"github.com/openshift/operator-framework-olm/tests-extension/test/qe/util/architecture"
 	olmv0util "github.com/openshift/operator-framework-olm/tests-extension/test/qe/util/olmv0util"
 )
 
@@ -173,6 +174,7 @@ var _ = g.Describe("[sig-operator][Jira:OLM] OLM v0 for stress", func() {
 	})
 
 	g.It("PolarionID:80413-[OTP][Skipped:Disconnected][OlmStress]install operator repeatedly serially with same ns [Slow][Timeout:180m]", g.Label("StressTest"), g.Label("NonHyperShiftHOST"), func() {
+		architecture.SkipArchitectures(oc, architecture.PPC64LE, architecture.S390X)
 		var (
 			itName              = g.CurrentSpecReport().FullText()
 			buildPruningBaseDir = exutil.FixturePath("testdata", "olm")


### PR DESCRIPTION
Fixes OCPBUGS-77984: replace single-arch catalog image in stress test 80413 with multi-arch nginx-operator-index-24664, and skip OPM tests 53869/53871/54168 on ppc64le/s390x where bundle images are amd64-only.