### PR TITLE
OPRUN-4588: use AlwaysAllow UnhealthyPodEvictionPolicy option in PDBs

### DIFF
--- a/manifests/0000_50_olm_00-packageserver.pdb.yaml
+++ b/manifests/0000_50_olm_00-packageserver.pdb.yaml
@@ -10,6 +10,7 @@ metadata:
     include.release.openshift.io/hypershift: "true"
 spec:
   maxUnavailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
   selector:
     matchLabels:
       app: packageserver

--- a/microshift-manifests/0000_50_olm_00-packageserver.pdb.yaml
+++ b/microshift-manifests/0000_50_olm_00-packageserver.pdb.yaml
@@ -10,6 +10,7 @@ metadata:
     include.release.openshift.io/hypershift: "true"
 spec:
   maxUnavailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
   selector:
     matchLabels:
       app: packageserver

--- a/scripts/packageserver-pdb.yaml
+++ b/scripts/packageserver-pdb.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-operator-lifecycle-manager
 spec:
   maxUnavailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
   selector:
     matchLabels:
       app: packageserver


### PR DESCRIPTION
Allow eviction of unhealthy (not ready) pods even if there are no disruptions
allowed on a PodDisruptionBudget. This can help to drain/maintain a node and
recover without a manual intervention when multiple instances of nodes or pods
are misbehaving.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Pod Disruption Budget configuration to allow unhealthy pods to be evicted according to system disruption policies across package management components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->