### PR TITLE
OPRUN-4597: Fix lifecycle-server readiness probe to allow empty index

### DIFF
--- a/cmd/lifecycle-server/start.go
+++ b/cmd/lifecycle-server/start.go
@@ -134,15 +134,16 @@ func run(_ *cobra.Command, _ []string) error {
 
 	// Load lifecycle data from FBC
 	log.Info("loading lifecycle data from FBC", "path", fbcPath)
-	data, err := server.LoadLifecycleData(fbcPath, log)
-	if err != nil {
-		return fmt.Errorf("failed to load lifecycle data: %w", err)
+	data, loadErr := server.LoadLifecycleData(fbcPath, log)
+	if loadErr != nil {
+		log.Error(loadErr, "failed to load lifecycle data")
+	} else {
+		log.Info("loaded lifecycle data",
+			"packageCount", data.CountPackages(),
+			"blobCount", data.CountBlobs(),
+			"versions", data.ListVersions(),
+		)
 	}
-	log.Info("loaded lifecycle data",
-		"packageCount", data.CountPackages(),
-		"blobCount", data.CountBlobs(),
-		"versions", data.ListVersions(),
-	)
 
 	// Create HTTP apiHandler with authn/authz middleware
 	baseHandler := server.NewHandler(data, log)
@@ -153,7 +154,7 @@ func run(_ *cobra.Command, _ []string) error {
 	}
 
 	// Create health handler (no auth required)
-	healthHandler := server.NewHealthHandler(data)
+	healthHandler := server.NewHealthHandler(loadErr == nil)
 
 	// Create servers
 	apiServer := cancelableServer{

--- a/pkg/lifecycle-server/server.go
+++ b/pkg/lifecycle-server/server.go
@@ -24,17 +24,17 @@ import (
 
 // NewHealthHandler creates an HTTP handler for health and readiness probes.
 // The /healthz endpoint always returns 200. The /readyz endpoint returns 200
-// if lifecycle data is loaded, or 503 if the index is empty.
-func NewHealthHandler(data LifecycleIndex) http.Handler {
+// if isReady is true, or 503 otherwise.
+func NewHealthHandler(isReady bool) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	})
 	mux.HandleFunc("GET /readyz", func(w http.ResponseWriter, r *http.Request) {
-		if len(data) == 0 {
+		if !isReady {
 			w.WriteHeader(http.StatusServiceUnavailable)
-			_, _ = w.Write([]byte("no lifecycle data loaded"))
+			_, _ = w.Write([]byte("error processing lifecycle metadata - check logs for details"))
 			return
 		}
 		w.WriteHeader(http.StatusOK)

--- a/pkg/lifecycle-server/server_test.go
+++ b/pkg/lifecycle-server/server_test.go
@@ -195,51 +195,44 @@ func TestNewHandler_ConcurrentRequests(t *testing.T) {
 func TestNewHealthHandler(t *testing.T) {
 	tt := []struct {
 		name           string
-		data           LifecycleIndex
+		isReady        bool
 		path           string
 		expectedStatus int
 		expectedBody   string
 	}{
 		{
-			name:           "healthz always returns 200",
-			data:           LifecycleIndex{},
+			name:           "healthz returns 200 when not ready",
+			isReady:        false,
 			path:           "/healthz",
 			expectedStatus: http.StatusOK,
 			expectedBody:   "ok",
 		},
 		{
-			name:           "healthz returns 200 with data",
-			data:           LifecycleIndex{"v1": {"pkg": json.RawMessage(`{}`)}},
+			name:           "healthz returns 200 when ready",
+			isReady:        true,
 			path:           "/healthz",
 			expectedStatus: http.StatusOK,
 			expectedBody:   "ok",
 		},
 		{
-			name:           "readyz returns 503 when empty",
-			data:           LifecycleIndex{},
-			path:           "/readyz",
-			expectedStatus: http.StatusServiceUnavailable,
-			expectedBody:   "no lifecycle data loaded",
-		},
-		{
-			name:           "readyz returns 503 when nil",
-			data:           nil,
-			path:           "/readyz",
-			expectedStatus: http.StatusServiceUnavailable,
-			expectedBody:   "no lifecycle data loaded",
-		},
-		{
-			name:           "readyz returns 200 when data loaded",
-			data:           LifecycleIndex{"v1alpha1": {"my-operator": json.RawMessage(`{}`)}},
+			name:           "readyz returns 200 when ready",
+			isReady:        true,
 			path:           "/readyz",
 			expectedStatus: http.StatusOK,
 			expectedBody:   "ok",
+		},
+		{
+			name:           "readyz returns 503 when not ready",
+			isReady:        false,
+			path:           "/readyz",
+			expectedStatus: http.StatusServiceUnavailable,
+			expectedBody:   "error processing lifecycle metadata - check logs for details",
 		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			handler := NewHealthHandler(tc.data)
+			handler := NewHealthHandler(tc.isReady)
 			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
 			rec := httptest.NewRecorder()
 			handler.ServeHTTP(rec, req)


### PR DESCRIPTION
## Summary
- The readiness probe (`/readyz`) previously returned 503 when the lifecycle index was empty, treating it as unready. An empty index is a valid state (no lifecycle metadata in the catalog), so it now returns 200.
- Returns 503 only when there were actual errors building the index. The server continues to start even on load errors so the readiness probe can report the failure.
- Error logging moved from the readiness handler to FBC processing at startup, so errors are logged once instead of on every probe poll.
- Simplified `NewHealthHandler` to take a `bool` instead of an `error`, keeping the handler decoupled from load internals.

## Test plan
- [x] Unit tests updated and passing (`go test ./pkg/lifecycle-server/...`)
- [ ] Verify readiness returns 200 when catalog has no lifecycle metadata
- [ ] Verify readiness returns 503 with generic message when FBC loading fails
- [ ] Verify error details appear in server logs at startup (not in HTTP response or on each probe poll)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Health & Reliability**
  * Refined health endpoints: liveness stays healthy; readiness now accurately reports degraded state (returns 503) when initialization fails, improving monitoring signals.

* **Bug Fixes**
  * Initialization now logs lifecycle load results and continues startup on load failures while surfacing clearer readiness status and error messages for diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->