### PR TITLE
OCPBUGS-54790: Fix packageserver PDB annotation for HyperShift

### DIFF
--- a/manifests/0000_50_olm_00-packageserver.pdb.yaml
+++ b/manifests/0000_50_olm_00-packageserver.pdb.yaml
@@ -4,10 +4,8 @@ metadata:
   name: packageserver-pdb
   namespace: openshift-operator-lifecycle-manager
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
-    include.release.openshift.io/hypershift: "true"
 spec:
   maxUnavailable: 1
   selector:

--- a/microshift-manifests/0000_50_olm_00-packageserver.pdb.yaml
+++ b/microshift-manifests/0000_50_olm_00-packageserver.pdb.yaml
@@ -4,10 +4,8 @@ metadata:
   name: packageserver-pdb
   namespace: openshift-operator-lifecycle-manager
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     capability.openshift.io/name: "OperatorLifecycleManager"
-    include.release.openshift.io/hypershift: "true"
 spec:
   maxUnavailable: 1
   selector:

--- a/scripts/generate_crds_manifests.sh
+++ b/scripts/generate_crds_manifests.sh
@@ -561,6 +561,9 @@ for f in $(find "${hypershift_manifests_dir}" -type f -name "*.yaml"); do
    fi
 done
 
+${YQ} d -d'*' --inplace manifests/0000_50_olm_00-packageserver.pdb.yaml 'metadata.annotations[include.release.openshift.io/ibm-cloud-managed]'
+${YQ} d -d'*' --inplace manifests/0000_50_olm_00-packageserver.pdb.yaml 'metadata.annotations[include.release.openshift.io/hypershift]'
+
 find "${ROOT_DIR}/manifests" -type f -exec $SED -i "/^#/d" {} \;
 find "${ROOT_DIR}/manifests" -type f -exec $SED -i "1{/---/d}" {} \;
 


### PR DESCRIPTION
## What this PR does / why we need it:

The packageserver PDB (`packageserver-pdb`) in the data plane namespace
`openshift-operator-lifecycle-manager` has no matching pods because the
packageserver pods are deployed on the control plane in HyperShift.

This PR remove the `include.release.openshift.io/hypershift: "true"`
and `include.release.openshift.io/ibm-cloud-managed: "true"`
so the PDB is no longer deployed to HyperShift data planes where it
serves no purpose.

## Which issue(s) this PR fixes:

Fixes https://redhat.atlassian.net/browse/OCPBUGS-54790

## Special notes for your reviewer:

Single annotation change in `manifests/0000_50_olm_00-packageserver.pdb.yaml`.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed platform-specific annotations that indicated Hypershift and IBM Cloud managed inclusion.
  * Preserved high-availability and operator capability annotations so runtime behavior is unchanged.
  * Generation/build step now automatically applies these annotation adjustments to manifests for consistent deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->