### PR TITLE
OPRUN-4639: Update to golang 1.26.3 and openshift-4.23 builders

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.25-openshift-4.22
+  tag: rhel-9-release-golang-1.26-openshift-4.23

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to bootstrap build and test in openshift-ci
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-4.23
 
 ARG KUBEBUILDER_RELEASE=2.3.1
 # Install test dependencies

--- a/codegen.Dockerfile
+++ b/codegen.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine
+FROM golang:1.26-alpine
 
 RUN apk update && \
     apk add make git protobuf

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/operator-framework-olm
 
-go 1.25.7
+go 1.26.3
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/operator-framework-tools.Dockerfile
+++ b/operator-framework-tools.Dockerfile
@@ -1,18 +1,18 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.25-openshift-4.22 AS builder-rhel8
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.26-openshift-4.23 AS builder-rhel8
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 WORKDIR /src
 COPY . .
 RUN make build/registry cross
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-4.23 AS builder
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 WORKDIR /src
 COPY . .
 RUN make build/registry cross
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.23:base-rhel9
 ENTRYPOINT ["sh", "-c", "echo 'Running this image is not supported' && exit 1"]
 # clear any default CMD
 CMD []

--- a/operator-lifecycle-manager.Dockerfile
+++ b/operator-lifecycle-manager.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-4.23 AS builder
 
 ENV GO111MODULE auto
 ENV GOPATH /go
@@ -26,7 +26,7 @@ RUN make build/olm bin/cpb && \
        cp ./bin/olmv0-tests-ext /tmp/build/olmv0-tests-ext && \
        gzip -f /tmp/build/olmv0-tests-ext
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.23:base-rhel9
 
 ADD manifests/ /manifests
 LABEL io.openshift.release.operator=true

--- a/operator-registry.Dockerfile
+++ b/operator-registry.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-4.23 AS builder
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
@@ -11,7 +11,7 @@ RUN make build/registry cross
 # copy and build vendored grpc_health_probe
 RUN CGO_ENABLED=0 go build -mod=vendor -tags netgo -ldflags "-w" ./vendor/github.com/grpc-ecosystem/grpc-health-probe/...
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.23:base-rhel9
 
 COPY --from=builder /src/bin/* /bin/registry/
 COPY --from=builder /src/grpc-health-probe /bin/grpc_health_probe

--- a/staging/api/go.mod
+++ b/staging/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/operator-framework/api
 
-go 1.25.7
+go 1.26.3
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/staging/operator-lifecycle-manager/go.mod
+++ b/staging/operator-lifecycle-manager/go.mod
@@ -1,6 +1,6 @@
 module github.com/operator-framework/operator-lifecycle-manager
 
-go 1.25.7
+go 1.26.3
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/staging/operator-registry/alpha/declcfg/declcfg_to_model.go
+++ b/staging/operator-registry/alpha/declcfg/declcfg_to_model.go
@@ -221,7 +221,7 @@ func ConvertToModel(cfg DeclarativeConfig) (model.Model, error) {
 
 		for j, entry := range deprecation.Entries {
 			if entry.Reference.Schema == "" {
-				return nil, fmt.Errorf("schema must be set for deprecation entry [%v] for package %q", deprecation.Package, j)
+				return nil, fmt.Errorf("schema must be set for deprecation entry [%d] for package %q", j, deprecation.Package)
 			}
 
 			if references.Has(entry.Reference) {

--- a/staging/operator-registry/go.mod
+++ b/staging/operator-registry/go.mod
@@ -1,6 +1,6 @@
 module github.com/operator-framework/operator-registry
 
-go 1.25.7
+go 1.26.3
 
 require (
 	github.com/akrylysov/pogreb v0.10.2

--- a/staging/operator-registry/upstream-builder.Dockerfile
+++ b/staging/operator-registry/upstream-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 RUN apk update && apk add sqlite build-base git mercurial bash linux-headers
 WORKDIR /build

--- a/tests-extension/go.mod
+++ b/tests-extension/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/operator-framework-olm/tests-extension
 
-go 1.24.3
+go 1.26.3
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/vendor/github.com/operator-framework/operator-registry/alpha/declcfg/declcfg_to_model.go
+++ b/vendor/github.com/operator-framework/operator-registry/alpha/declcfg/declcfg_to_model.go
@@ -221,7 +221,7 @@ func ConvertToModel(cfg DeclarativeConfig) (model.Model, error) {
 
 		for j, entry := range deprecation.Entries {
 			if entry.Reference.Schema == "" {
-				return nil, fmt.Errorf("schema must be set for deprecation entry [%v] for package %q", deprecation.Package, j)
+				return nil, fmt.Errorf("schema must be set for deprecation entry [%d] for package %q", j, deprecation.Package)
 			}
 
 			if references.Has(entry.Reference) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -636,7 +636,7 @@ github.com/openshift/client-go/config/listers/config/v1alpha2
 ## explicit; go 1.24.0
 github.com/openshift/library-go/pkg/crypto
 # github.com/operator-framework/api v0.42.0 => ./staging/api
-## explicit; go 1.25.7
+## explicit; go 1.26.3
 github.com/operator-framework/api/crds
 github.com/operator-framework/api/pkg/constraints
 github.com/operator-framework/api/pkg/encoding
@@ -655,7 +655,7 @@ github.com/operator-framework/api/pkg/validation/errors
 github.com/operator-framework/api/pkg/validation/interfaces
 github.com/operator-framework/api/pkg/validation/internal
 # github.com/operator-framework/operator-lifecycle-manager v0.0.0-00010101000000-000000000000 => ./staging/operator-lifecycle-manager
-## explicit; go 1.25.7
+## explicit; go 1.26.3
 github.com/operator-framework/operator-lifecycle-manager/cmd/catalog
 github.com/operator-framework/operator-lifecycle-manager/cmd/copy-content
 github.com/operator-framework/operator-lifecycle-manager/cmd/olm
@@ -754,7 +754,7 @@ github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/vers
 github.com/operator-framework/operator-lifecycle-manager/pkg/version
 github.com/operator-framework/operator-lifecycle-manager/util/cpb
 # github.com/operator-framework/operator-registry v1.69.0 => ./staging/operator-registry
-## explicit; go 1.25.7
+## explicit; go 1.26.3
 github.com/operator-framework/operator-registry/alpha/action
 github.com/operator-framework/operator-registry/alpha/action/migrations
 github.com/operator-framework/operator-registry/alpha/declcfg


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain across modules to Go 1.26.
  * Upgraded OpenShift build environment to 4.23.
  * Updated Docker base images for build and runtime to match the new Go/OpenShift versions.
  * Adjusted CI/release build configuration to target the updated platform and toolchain.
* **Bug Fixes**
  * Corrected an internal error message formatting for clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->