### PR TITLE
OPRUN-4612: Add E2E tests for ExperimentalListPackageCustomSchemas gRPC endpoint

### DIFF
--- a/tests-extension/.openshift-tests-extension/openshift_payload_olmv0.json
+++ b/tests-extension/.openshift-tests-extension/openshift_payload_olmv0.json
@@ -643,6 +643,22 @@
     }
   },
   {
+    "name": "[sig-operator][Jira:OLM][OCPFeatureGate:OLMLifecycleAndCompatibility] OLMv0 custom schema gRPC endpoint ExperimentalListPackageCustomSchemas returns custom schema FBC",
+    "labels": {
+      "Extended": {},
+      "NonHyperShiftHOST": {},
+      "ReleaseGate": {}
+    },
+    "resources": {
+      "isolation": {}
+    },
+    "source": "openshift:payload:olmv0",
+    "lifecycle": "blocking",
+    "environmentSelector": {
+      "exclude": "topology==\"External\""
+    }
+  },
+  {
     "name": "[sig-operator][Jira:OLM] OLMv0 optional should PolarionID:68679-[OTP][Skipped:Disconnected]catalogsource with invalid name is created",
     "originalName": "[sig-operator][Jira:OLM] OLMv0 optional should PolarionID:68679-[Skipped:Disconnected]catalogsource with invalid name is created",
     "labels": {

--- a/tests-extension/go.mod
+++ b/tests-extension/go.mod
@@ -16,6 +16,8 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/pretty v1.2.1
 	golang.org/x/oauth2 v0.30.0
+	google.golang.org/grpc v1.74.2
+	google.golang.org/protobuf v1.36.7
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.33.2
 	k8s.io/apiextensions-apiserver v0.33.2
@@ -118,8 +120,6 @@ require (
 	golang.org/x/tools v0.35.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250818200422-3122310a409c // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250818200422-3122310a409c // indirect
-	google.golang.org/grpc v1.74.2 // indirect
-	google.golang.org/protobuf v1.36.7 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/tests-extension/pkg/bindata/qe/bindata.go
+++ b/tests-extension/pkg/bindata/qe/bindata.go
@@ -1,5 +1,6 @@
 // Code generated for package testdata by go-bindata DO NOT EDIT. (@generated)
 // sources:
+// test/qe/testdata/custom-schema/index.json
 // test/qe/testdata/olm/apiservice.yaml
 // test/qe/testdata/olm/catalogsource-address.yaml
 // test/qe/testdata/olm/catalogsource-configmap.yaml
@@ -31,6 +32,8 @@
 // test/qe/testdata/olm/cs-without-interval.yaml
 // test/qe/testdata/olm/cs-without-scc.yaml
 // test/qe/testdata/olm/csc.yaml
+// test/qe/testdata/olm/custom-schema-buildconfig.yaml
+// test/qe/testdata/olm/custom-schema-imagestream.yaml
 // test/qe/testdata/olm/env-subscription.yaml
 // test/qe/testdata/olm/envfrom-subscription.yaml
 // test/qe/testdata/olm/etcd-cluster.yaml
@@ -194,6 +197,29 @@ func (fi bindataFileInfo) IsDir() bool {
 // Sys return file is sys mode
 func (fi bindataFileInfo) Sys() interface{} {
 	return nil
+}
+
+var _testQeTestdataCustomSchemaIndexJson = []byte(`{"schema":"olm.package","name":"test-custom-pkg","defaultChannel":"stable"}
+{"schema":"olm.channel","name":"stable","package":"test-custom-pkg","entries":[{"name":"test-custom-pkg.v0.1.0"}]}
+{"schema":"olm.bundle","name":"test-custom-pkg.v0.1.0","package":"test-custom-pkg","image":"registry.example.com/test:v0.1.0","properties":[{"type":"olm.package","value":{"packageName":"test-custom-pkg","version":"0.1.0"}}]}
+{"schema":"custom.operator.io","package":"test-custom-pkg","name":"custom-metadata-1","data":{"key":"value1"}}
+{"schema":"custom.operator.io","package":"test-custom-pkg","name":"custom-metadata-2","data":{"key":"value2"}}
+{"schema":"custom.operator.io","name":"packageless-metadata","data":{"key":"global"}}
+`)
+
+func testQeTestdataCustomSchemaIndexJsonBytes() ([]byte, error) {
+	return _testQeTestdataCustomSchemaIndexJson, nil
+}
+
+func testQeTestdataCustomSchemaIndexJson() (*asset, error) {
+	bytes, err := testQeTestdataCustomSchemaIndexJsonBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/qe/testdata/custom-schema/index.json", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
 }
 
 var _testQeTestdataOlmApiserviceYaml = []byte(`apiVersion: template.openshift.io/v1
@@ -6911,6 +6937,80 @@ func testQeTestdataOlmCscYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "test/qe/testdata/olm/csc.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testQeTestdataOlmCustomSchemaBuildconfigYaml = []byte(`apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: custom-schema-buildconfig-template
+objects:
+- apiVersion: build.openshift.io/v1
+  kind: BuildConfig
+  metadata:
+    name: "${NAME}"
+    namespace: "${NAMESPACE}"
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: "${NAME}:latest"
+    source:
+      type: Binary
+    strategy:
+      type: Docker
+      dockerStrategy:
+        from:
+          kind: DockerImage
+          name: "${BASE_IMAGE}"
+parameters:
+- name: NAME
+- name: NAMESPACE
+- name: BASE_IMAGE
+`)
+
+func testQeTestdataOlmCustomSchemaBuildconfigYamlBytes() ([]byte, error) {
+	return _testQeTestdataOlmCustomSchemaBuildconfigYaml, nil
+}
+
+func testQeTestdataOlmCustomSchemaBuildconfigYaml() (*asset, error) {
+	bytes, err := testQeTestdataOlmCustomSchemaBuildconfigYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/qe/testdata/olm/custom-schema-buildconfig.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testQeTestdataOlmCustomSchemaImagestreamYaml = []byte(`apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: custom-schema-imagestream-template
+objects:
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    name: "${NAME}"
+    namespace: "${NAMESPACE}"
+parameters:
+- name: NAME
+- name: NAMESPACE
+`)
+
+func testQeTestdataOlmCustomSchemaImagestreamYamlBytes() ([]byte, error) {
+	return _testQeTestdataOlmCustomSchemaImagestreamYaml, nil
+}
+
+func testQeTestdataOlmCustomSchemaImagestreamYaml() (*asset, error) {
+	bytes, err := testQeTestdataOlmCustomSchemaImagestreamYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/qe/testdata/olm/custom-schema-imagestream.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -18599,6 +18699,7 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
+	"test/qe/testdata/custom-schema/index.json":                                                                  testQeTestdataCustomSchemaIndexJson,
 	"test/qe/testdata/olm/apiservice.yaml":                                                                       testQeTestdataOlmApiserviceYaml,
 	"test/qe/testdata/olm/catalogsource-address.yaml":                                                            testQeTestdataOlmCatalogsourceAddressYaml,
 	"test/qe/testdata/olm/catalogsource-configmap.yaml":                                                          testQeTestdataOlmCatalogsourceConfigmapYaml,
@@ -18630,6 +18731,8 @@ var _bindata = map[string]func() (*asset, error){
 	"test/qe/testdata/olm/cs-without-interval.yaml":                                                              testQeTestdataOlmCsWithoutIntervalYaml,
 	"test/qe/testdata/olm/cs-without-scc.yaml":                                                                   testQeTestdataOlmCsWithoutSccYaml,
 	"test/qe/testdata/olm/csc.yaml":                                                                              testQeTestdataOlmCscYaml,
+	"test/qe/testdata/olm/custom-schema-buildconfig.yaml":                                                        testQeTestdataOlmCustomSchemaBuildconfigYaml,
+	"test/qe/testdata/olm/custom-schema-imagestream.yaml":                                                        testQeTestdataOlmCustomSchemaImagestreamYaml,
 	"test/qe/testdata/olm/env-subscription.yaml":                                                                 testQeTestdataOlmEnvSubscriptionYaml,
 	"test/qe/testdata/olm/envfrom-subscription.yaml":                                                             testQeTestdataOlmEnvfromSubscriptionYaml,
 	"test/qe/testdata/olm/etcd-cluster.yaml":                                                                     testQeTestdataOlmEtcdClusterYaml,
@@ -18790,6 +18893,9 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"test": {nil, map[string]*bintree{
 		"qe": {nil, map[string]*bintree{
 			"testdata": {nil, map[string]*bintree{
+				"custom-schema": {nil, map[string]*bintree{
+					"index.json": {testQeTestdataCustomSchemaIndexJson, map[string]*bintree{}},
+				}},
 				"olm": {nil, map[string]*bintree{
 					"apiservice.yaml":                                   {testQeTestdataOlmApiserviceYaml, map[string]*bintree{}},
 					"catalogsource-address.yaml":                        {testQeTestdataOlmCatalogsourceAddressYaml, map[string]*bintree{}},
@@ -18822,6 +18928,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 					"cs-without-interval.yaml":                          {testQeTestdataOlmCsWithoutIntervalYaml, map[string]*bintree{}},
 					"cs-without-scc.yaml":                               {testQeTestdataOlmCsWithoutSccYaml, map[string]*bintree{}},
 					"csc.yaml":                                          {testQeTestdataOlmCscYaml, map[string]*bintree{}},
+					"custom-schema-buildconfig.yaml":                    {testQeTestdataOlmCustomSchemaBuildconfigYaml, map[string]*bintree{}},
+					"custom-schema-imagestream.yaml":                    {testQeTestdataOlmCustomSchemaImagestreamYaml, map[string]*bintree{}},
 					"env-subscription.yaml":                             {testQeTestdataOlmEnvSubscriptionYaml, map[string]*bintree{}},
 					"envfrom-subscription.yaml":                         {testQeTestdataOlmEnvfromSubscriptionYaml, map[string]*bintree{}},
 					"etcd-cluster.yaml":                                 {testQeTestdataOlmEtcdClusterYaml, map[string]*bintree{}},

--- a/tests-extension/test/qe/specs/olmv0_custom_schema.go
+++ b/tests-extension/test/qe/specs/olmv0_custom_schema.go
@@ -1,0 +1,124 @@
+package specs
+
+import (
+	"context"
+	"os"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	exutil "github.com/openshift/operator-framework-olm/tests-extension/test/qe/util"
+	"github.com/openshift/operator-framework-olm/tests-extension/test/qe/util/olmv0util"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	grpcRequestTimeout = 60 * time.Second
+)
+
+var _ = g.Describe("[sig-operator][Jira:OLM][OCPFeatureGate:OLMLifecycleAndCompatibility] OLMv0 custom schema gRPC endpoint", g.Label("NonHyperShiftHOST"), func() {
+	defer g.GinkgoRecover()
+
+	var (
+		oc = exutil.NewCLIWithoutNamespace("default")
+		dr = make(olmv0util.DescriberResrouce)
+	)
+
+	g.BeforeEach(func() {
+		exutil.SkipMicroshift(oc)
+		oc.SetupProject()
+		exutil.SkipNoOLMCore(oc)
+		itName := g.CurrentSpecReport().FullText()
+		dr.AddIr(itName)
+	})
+
+	g.AfterEach(func() {
+		itName := g.CurrentSpecReport().FullText()
+		dr.GetIr(itName).Cleanup()
+		dr.RmIr(itName)
+	})
+
+	g.It("ExperimentalListPackageCustomSchemas returns custom schema FBC", g.Label("ReleaseGate"), func() {
+		namespace := oc.Namespace()
+		catalogName := "custom-schema-" + exutil.GetRandomString()
+		itName := g.CurrentSpecReport().FullText()
+
+		g.By("get opm base image from catalog-operator deployment")
+		baseImage := olmv0util.GetOPMBaseImage(oc)
+		e2e.Logf("opm base image: %s", baseImage)
+		o.Expect(baseImage).NotTo(o.BeEmpty())
+
+		g.By("build custom catalog image with custom schema FBC in-cluster")
+		fbcContent, err := os.ReadFile(exutil.FixturePath("testdata", "custom-schema", "index.json"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		imageRef := olmv0util.BuildCustomCatalogImage(oc, namespace, catalogName, baseImage, fbcContent)
+		e2e.Logf("built catalog image: %s", imageRef)
+
+		// Register build resources for cleanup
+		dr.GetIr(itName).Add(olmv0util.NewResource(oc, "buildconfig", catalogName, exutil.RequireNS, namespace))
+		dr.GetIr(itName).Add(olmv0util.NewResource(oc, "imagestream", catalogName, exutil.RequireNS, namespace))
+
+		g.By("create CatalogSource and wait for READY")
+		catsrc := olmv0util.CatalogSourceDescription{
+			Name:       catalogName,
+			Namespace:  namespace,
+			SourceType: "grpc",
+			Address:    imageRef,
+			Template:   exutil.FixturePath("testdata", "olm", "catalogsource-image.yaml"),
+		}
+		catsrc.CreateWithCheck(oc, itName, dr)
+
+		g.By("port-forward to catalog pod gRPC endpoint")
+		grpcAddr, cleanupPF := olmv0util.PortForwardToCatalogPod(oc, namespace, catalogName)
+		defer cleanupPF()
+		e2e.Logf("gRPC address: %s", grpcAddr)
+
+		ctx, cancel := context.WithTimeout(context.Background(), grpcRequestTimeout)
+		defer cancel()
+
+		g.By("query with valid schema and package returns expected results")
+		results, err := olmv0util.ListPackageCustomSchemas(ctx, grpcAddr, "custom.operator.io", "test-custom-pkg")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(results).To(o.HaveLen(2), "expected 2 custom schema blobs for custom.operator.io/test-custom-pkg")
+		e2e.Logf("results for schema=custom.operator.io pkg=test-custom-pkg: %v", results)
+
+		foundNames := map[string]bool{}
+		for _, r := range results {
+			name, ok := r["name"].(string)
+			o.Expect(ok).To(o.BeTrue(), "expected 'name' field in result")
+			foundNames[name] = true
+			o.Expect(r["schema"]).To(o.Equal("custom.operator.io"))
+			o.Expect(r["package"]).To(o.Equal("test-custom-pkg"))
+		}
+		o.Expect(foundNames).To(o.HaveKey("custom-metadata-1"))
+		o.Expect(foundNames).To(o.HaveKey("custom-metadata-2"))
+
+		g.By("query with valid schema and nonexistent package returns empty")
+		results, err = olmv0util.ListPackageCustomSchemas(ctx, grpcAddr, "custom.operator.io", "no-such-pkg")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(results).To(o.BeEmpty(), "expected empty results for nonexistent package")
+
+		g.By("query with nonexistent schema returns empty")
+		results, err = olmv0util.ListPackageCustomSchemas(ctx, grpcAddr, "no.such.schema", "test-custom-pkg")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(results).To(o.BeEmpty(), "expected empty results for nonexistent schema")
+
+		g.By("query with valid schema and empty package returns packageless results")
+		results, err = olmv0util.ListPackageCustomSchemas(ctx, grpcAddr, "custom.operator.io", "")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(results).To(o.HaveLen(1), "expected 1 packageless custom schema blob for custom.operator.io")
+		o.Expect(results[0]["name"]).To(o.Equal("packageless-metadata"))
+		o.Expect(results[0]["schema"]).To(o.Equal("custom.operator.io"))
+
+		data, ok := results[0]["data"].(map[string]interface{})
+		o.Expect(ok).To(o.BeTrue(), "expected 'data' field to be a map")
+		o.Expect(data["key"]).To(o.Equal("global"))
+
+		g.By("query without x-acknowledge-experimental header returns empty")
+		results, err = olmv0util.ListPackageCustomSchemasWithoutExperimentalHeader(ctx, grpcAddr, "custom.operator.io", "test-custom-pkg")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(results).To(o.BeEmpty(), "expected empty results without experimental header")
+	})
+})

--- a/tests-extension/test/qe/testdata/custom-schema/index.json
+++ b/tests-extension/test/qe/testdata/custom-schema/index.json
@@ -1,0 +1,6 @@
+{"schema":"olm.package","name":"test-custom-pkg","defaultChannel":"stable"}
+{"schema":"olm.channel","name":"stable","package":"test-custom-pkg","entries":[{"name":"test-custom-pkg.v0.1.0"}]}
+{"schema":"olm.bundle","name":"test-custom-pkg.v0.1.0","package":"test-custom-pkg","image":"registry.example.com/test:v0.1.0","properties":[{"type":"olm.package","value":{"packageName":"test-custom-pkg","version":"0.1.0"}}]}
+{"schema":"custom.operator.io","package":"test-custom-pkg","name":"custom-metadata-1","data":{"key":"value1"}}
+{"schema":"custom.operator.io","package":"test-custom-pkg","name":"custom-metadata-2","data":{"key":"value2"}}
+{"schema":"custom.operator.io","name":"packageless-metadata","data":{"key":"global"}}

--- a/tests-extension/test/qe/testdata/olm/custom-schema-buildconfig.yaml
+++ b/tests-extension/test/qe/testdata/olm/custom-schema-buildconfig.yaml
@@ -1,0 +1,27 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: custom-schema-buildconfig-template
+objects:
+- apiVersion: build.openshift.io/v1
+  kind: BuildConfig
+  metadata:
+    name: "${NAME}"
+    namespace: "${NAMESPACE}"
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: "${NAME}:latest"
+    source:
+      type: Binary
+    strategy:
+      type: Docker
+      dockerStrategy:
+        from:
+          kind: DockerImage
+          name: "${BASE_IMAGE}"
+parameters:
+- name: NAME
+- name: NAMESPACE
+- name: BASE_IMAGE

--- a/tests-extension/test/qe/testdata/olm/custom-schema-imagestream.yaml
+++ b/tests-extension/test/qe/testdata/olm/custom-schema-imagestream.yaml
@@ -1,0 +1,13 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: custom-schema-imagestream-template
+objects:
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    name: "${NAME}"
+    namespace: "${NAMESPACE}"
+parameters:
+- name: NAME
+- name: NAMESPACE

--- a/tests-extension/test/qe/util/olmv0util/custom_schema_grpc.go
+++ b/tests-extension/test/qe/util/olmv0util/custom_schema_grpc.go
@@ -1,0 +1,349 @@
+package olmv0util
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	o "github.com/onsi/gomega"
+
+	exutil "github.com/openshift/operator-framework-olm/tests-extension/test/qe/util"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/encoding"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	portForwardTimeout = 60 * time.Second
+)
+
+// customSchemaCodec is a gRPC codec that handles raw bytes for request encoding
+// and structpb.Struct for response decoding.
+type customSchemaCodec struct{}
+
+type rawRequest struct {
+	bytes []byte
+}
+
+func (customSchemaCodec) Marshal(v any) ([]byte, error) {
+	if raw, ok := v.(*rawRequest); ok {
+		return raw.bytes, nil
+	}
+	return nil, fmt.Errorf("customSchemaCodec: unsupported marshal type %T", v)
+}
+
+func (customSchemaCodec) Unmarshal(data []byte, v any) error {
+	if s, ok := v.(*structpb.Struct); ok {
+		return proto.Unmarshal(data, s)
+	}
+	return fmt.Errorf("customSchemaCodec: unsupported unmarshal type %T", v)
+}
+
+func (customSchemaCodec) Name() string { return "proto" }
+
+var _ encoding.Codec = customSchemaCodec{}
+
+// encodeCustomSchemaRequest builds the protobuf wire encoding for
+// ExperimentalListPackageCustomSchemasRequest{schema, packageName}.
+func encodeCustomSchemaRequest(schema, packageName string) []byte {
+	var b []byte
+	if schema != "" {
+		b = protowire.AppendTag(b, 1, protowire.BytesType)
+		b = protowire.AppendString(b, schema)
+	}
+	if packageName != "" {
+		b = protowire.AppendTag(b, 2, protowire.BytesType)
+		b = protowire.AppendString(b, packageName)
+	}
+	return b
+}
+
+// GetOPMBaseImage extracts the opm image reference from the catalog-operator
+// deployment in openshift-operator-lifecycle-manager namespace.
+func GetOPMBaseImage(oc *exutil.CLI) string {
+	output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+		"deployment", "catalog-operator",
+		"-n", "openshift-operator-lifecycle-manager",
+		"-o=jsonpath={.spec.template.spec.containers[0].args}",
+	).Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// The output is a JSON array like ["--namespace","olm","--opmImage=registry..."]
+	var args []string
+	if err := json.Unmarshal([]byte(output), &args); err != nil {
+		e2e.Logf("failed to parse args as JSON array, falling back to string split: %v", err)
+		args = strings.Fields(strings.NewReplacer("[", "", "]", "", "\"", "", ",", " ").Replace(output))
+	}
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "--opmImage=") {
+			image := strings.TrimPrefix(arg, "--opmImage=")
+			e2e.Logf("found opm base image from args: %s", image)
+			return image
+		}
+	}
+
+	// Fallback: check container env vars for RELATED_IMAGE_OPM
+	envOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+		"deployment", "catalog-operator",
+		"-n", "openshift-operator-lifecycle-manager",
+		"-o=jsonpath={.spec.template.spec.containers[0].env[?(@.name==\"RELATED_IMAGE_OPM\")].value}",
+	).Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	if envOutput != "" {
+		e2e.Logf("found opm base image from env: %s", envOutput)
+		return envOutput
+	}
+
+	// Fallback: use the container image itself
+	imgOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+		"deployment", "catalog-operator",
+		"-n", "openshift-operator-lifecycle-manager",
+		"-o=jsonpath={.spec.template.spec.containers[0].image}",
+	).Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	e2e.Logf("fallback to catalog-operator container image as opm base: %s", imgOutput)
+	return imgOutput
+}
+
+// BuildCustomCatalogImage builds a catalog image in-cluster using OpenShift
+// BuildConfig. It creates an ImageStream and BuildConfig, starts a binary build
+// from the provided FBC content, and waits for completion.
+// Returns the internal registry image reference.
+func BuildCustomCatalogImage(oc *exutil.CLI, namespace, name, baseImage string, fbcContent []byte) string {
+	// Create ImageStream
+	isTemplate := exutil.FixturePath("testdata", "olm", "custom-schema-imagestream.yaml")
+	err := ApplyResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", isTemplate,
+		"-p", "NAME="+name, "NAMESPACE="+namespace)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	e2e.Logf("created ImageStream %s/%s", namespace, name)
+
+	// Create BuildConfig
+	bcTemplate := exutil.FixturePath("testdata", "olm", "custom-schema-buildconfig.yaml")
+	err = ApplyResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", bcTemplate,
+		"-p", "NAME="+name, "NAMESPACE="+namespace, "BASE_IMAGE="+baseImage)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	e2e.Logf("created BuildConfig %s/%s with base image %s", namespace, name, baseImage)
+
+	// Prepare build directory
+	buildDir, err := os.MkdirTemp("", "custom-schema-build-")
+	o.Expect(err).NotTo(o.HaveOccurred())
+	defer func() { _ = os.RemoveAll(buildDir) }()
+
+	configsDir := filepath.Join(buildDir, "configs")
+	err = os.MkdirAll(configsDir, 0755)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	err = os.WriteFile(filepath.Join(configsDir, "index.json"), fbcContent, 0644)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// Write Dockerfile following the pattern from
+	// https://github.com/operator-framework/operator-registry/blob/master/opm-example.Dockerfile
+	// The RUN step pre-populates the serve cache so the integrity check passes at runtime.
+	dockerfile := "FROM " + baseImage + "\n" +
+		"ENTRYPOINT [\"/bin/opm\"]\n" +
+		"CMD [\"serve\", \"/configs\", \"--cache-dir=/tmp/cache\"]\n" +
+		"COPY configs /configs\n" +
+		"RUN [\"/bin/opm\", \"serve\", \"/configs\", \"--cache-dir=/tmp/cache\", \"--cache-only\"]\n" +
+		"LABEL operators.operatorframework.io.index.configs.v1=/configs\n"
+	err = os.WriteFile(filepath.Join(buildDir, "Dockerfile"), []byte(dockerfile), 0644)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// Start binary build
+	output, err := oc.AsAdmin().WithoutNamespace().Run("start-build").Args(
+		name, "-n", namespace, "--from-dir="+buildDir, "--follow",
+	).Output()
+	if err != nil {
+		e2e.Logf("build output: %s", output)
+	}
+	o.Expect(err).NotTo(o.HaveOccurred())
+	e2e.Logf("build completed for %s/%s", namespace, name)
+
+	// Wait for build to complete successfully
+	err = wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 300*time.Second, false, func(ctx context.Context) (bool, error) {
+		phase, getErr := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+			"build", name+"-1", "-n", namespace,
+			"-o=jsonpath={.status.phase}",
+		).Output()
+		if getErr != nil {
+			e2e.Logf("error checking build status: %v", getErr)
+			return false, nil
+		}
+		if phase == "Complete" {
+			return true, nil
+		}
+		if phase == "Failed" || phase == "Error" || phase == "Cancelled" {
+			return false, fmt.Errorf("build %s-1 failed with phase %s", name, phase)
+		}
+		e2e.Logf("build %s-1 phase: %s", name, phase)
+		return false, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	imageRef := fmt.Sprintf("image-registry.openshift-image-registry.svc:5000/%s/%s:latest", namespace, name)
+	e2e.Logf("catalog image built: %s", imageRef)
+	return imageRef
+}
+
+// PortForwardToCatalogPod starts an oc port-forward to the gRPC port (50051)
+// of the catalog source pod. Returns the local address and a cleanup function.
+func PortForwardToCatalogPod(oc *exutil.CLI, namespace, catalogName string) (string, func()) {
+	// Find the catalog source pod
+	podName, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+		"pods", "-n", namespace,
+		"-l", "olm.catalogSource="+catalogName,
+		"-o=jsonpath={.items[0].metadata.name}",
+	).Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(podName).NotTo(o.BeEmpty(), "no pod found for catalog source %s", catalogName)
+	e2e.Logf("found catalog pod: %s", podName)
+
+	// Find a free local port
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	o.Expect(err).NotTo(o.HaveOccurred())
+	localPort := listener.Addr().(*net.TCPAddr).Port
+	_ = listener.Close()
+
+	// Start port-forward with a context so the process is killed on timeout
+	kubeconfig := exutil.KubeConfigPath()
+	ctx, cancel := context.WithTimeout(context.Background(), portForwardTimeout)
+	cmd := exec.CommandContext(ctx, "oc", "--kubeconfig="+kubeconfig,
+		"port-forward", "-n", namespace, podName,
+		fmt.Sprintf("%d:50051", localPort))
+
+	stdout, err := cmd.StdoutPipe()
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	err = cmd.Start()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	e2e.Logf("started port-forward to %s on local port %d", podName, localPort)
+
+	ready := make(chan struct{})
+	errCh := make(chan error, 2)
+
+	// Goroutine: scan stdout for the "Forwarding from" readiness line.
+	// If the process exits before printing it, scanner.Scan() returns false
+	// and we surface the scanner error (or a generic "closed without ready").
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			line := scanner.Text()
+			e2e.Logf("port-forward: %s", line)
+			if strings.Contains(line, "Forwarding from") {
+				close(ready)
+				return
+			}
+		}
+		if scanErr := scanner.Err(); scanErr != nil {
+			errCh <- fmt.Errorf("port-forward stdout: %w", scanErr)
+		} else {
+			errCh <- fmt.Errorf("port-forward: stdout closed before readiness")
+		}
+	}()
+
+	// Goroutine: wait for the process to exit. If it exits before ready is
+	// closed, we surface the real exit error (e.g. "pod not found").
+	go func() {
+		errCh <- fmt.Errorf("port-forward exited early: %w", cmd.Wait())
+	}()
+
+	select {
+	case <-ready:
+		e2e.Logf("port-forward ready on localhost:%d", localPort)
+	case waitErr := <-errCh:
+		cancel()
+		o.Expect(waitErr).NotTo(o.HaveOccurred(), "port-forward failed")
+	}
+
+	localAddr := fmt.Sprintf("localhost:%d", localPort)
+	cleanup := func() {
+		cancel()
+		if cmd.Process != nil {
+			e2e.Logf("stopping port-forward (pid %d)", cmd.Process.Pid)
+			_ = cmd.Process.Kill()
+		}
+	}
+	return localAddr, cleanup
+}
+
+// ListPackageCustomSchemas calls the ExperimentalListPackageCustomSchemas gRPC
+// endpoint with the x-acknowledge-experimental header and returns the results
+// as Go maps (one per streamed Struct message).
+func ListPackageCustomSchemas(ctx context.Context, grpcAddr, schema, packageName string) ([]map[string]interface{}, error) {
+	return listPackageCustomSchemas(ctx, grpcAddr, schema, packageName, true)
+}
+
+// ListPackageCustomSchemasWithoutExperimentalHeader calls the
+// ExperimentalListPackageCustomSchemas gRPC endpoint WITHOUT the
+// x-acknowledge-experimental header. The server should silently return an
+// empty stream in this case.
+func ListPackageCustomSchemasWithoutExperimentalHeader(ctx context.Context, grpcAddr, schema, packageName string) ([]map[string]interface{}, error) {
+	return listPackageCustomSchemas(ctx, grpcAddr, schema, packageName, false)
+}
+
+func listPackageCustomSchemas(ctx context.Context, grpcAddr, schema, packageName string, withExperimentalHeader bool) ([]map[string]interface{}, error) {
+	conn, err := grpc.NewClient(grpcAddr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to %s: %w", grpcAddr, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if withExperimentalHeader {
+		md := metadata.New(map[string]string{
+			"x-acknowledge-experimental": "true",
+		})
+		ctx = metadata.NewOutgoingContext(ctx, md)
+	}
+
+	desc := &grpc.StreamDesc{
+		StreamName:    "ExperimentalListPackageCustomSchemas",
+		ServerStreams: true,
+		ClientStreams: false,
+	}
+
+	stream, err := conn.NewStream(ctx, desc,
+		"/api.ExperimentalRegistry/ExperimentalListPackageCustomSchemas",
+		grpc.ForceCodec(customSchemaCodec{}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create stream: %w", err)
+	}
+
+	req := &rawRequest{bytes: encodeCustomSchemaRequest(schema, packageName)}
+	if err := stream.SendMsg(req); err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	if err := stream.CloseSend(); err != nil {
+		return nil, fmt.Errorf("failed to close send: %w", err)
+	}
+
+	var results []map[string]interface{}
+	for {
+		resp := &structpb.Struct{}
+		err := stream.RecvMsg(resp)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to receive response: %w", err)
+		}
+		results = append(results, resp.AsMap())
+	}
+
+	return results, nil
+}


### PR DESCRIPTION
## Summary
- Adds E2E tests for the new `api.ExperimentalRegistry/ExperimentalListPackageCustomSchemas` streaming gRPC endpoint introduced in [operator-registry#1981](https://github.com/operator-framework/operator-registry/pull/1981)
- Builds custom FBC catalog images in-cluster using the opm base image from the catalog-operator deployment, following the [opm-example.Dockerfile](https://github.com/operator-framework/operator-registry/blob/master/opm-example.Dockerfile) pattern (pre-populated cache with `--cache-only`)
- Tests the endpoint via port-forward to the CatalogSource pod using a lightweight Go gRPC client (protowire request encoding + structpb.Struct response decoding, no operator-registry dependency)

### Test scenarios
- Schema + package returns expected custom schema FBC blobs (multiple results)
- Schema + nonexistent package returns empty stream
- Nonexistent schema returns empty stream
- Schema + empty package returns packageless custom schema blobs
- Missing `x-acknowledge-experimental` header returns empty stream

## Test plan
- [x] `make bindata && make build && make update-metadata && make verify` — all pass
- [x] Ran against a live OpenShift cluster — all 5 scenarios pass (110s total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end OLMv0 test suite covering the custom schema gRPC endpoint, asserting correct results for valid queries and empty results for nonexistent packages/schemas.
  * Added coverage for packageless (global) custom schema results and verified behavior when the experimental header is omitted.
  * Introduced supporting custom-schema fixtures and catalog image templates used by the test suite.
* **Chores**
  * Updated module dependency declarations (no functional behavior changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->