### PR TITLE
fix: pin CatalogSource pods to restricted-v2 SCC on OpenShift HCP

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
@@ -356,6 +356,12 @@ func Pod(source *operatorsv1alpha1.CatalogSource, name, opmImg, utilImage, img s
 	if securityContextConfig == operatorsv1alpha1.Restricted {
 		// Apply 'restricted' security settings
 		addSecurityContext(pod, runAsUser)
+
+		// Pin SCC selection to prevent custom SCCs from preempting catalog pods on
+		// HCP, where the creating user has broader SCC access than the local SA.
+		if _, alreadySet := podAnnotations["openshift.io/required-scc"]; !alreadySet {
+			podAnnotations["openshift.io/required-scc"] = "restricted-v2"
+		}
 	}
 
 	// Set priorityclass if its annotation exists

--- a/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler_test.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler_test.go
@@ -523,7 +523,7 @@ func TestPodExtractContent(t *testing.T) {
 					GenerateName: "test-",
 					Namespace:    "testns",
 					Labels:       map[string]string{"olm.pod-spec-hash": "8qB6OcFt60v8HdhXnPkB1cjF39t7RkFx9K0JxW", "olm.managed": "true"},
-					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
+					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true", "openshift.io/required-scc": "restricted-v2"},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -606,7 +606,7 @@ func TestPodExtractContent(t *testing.T) {
 					GenerateName: "test-",
 					Namespace:    "testns",
 					Labels:       map[string]string{"olm.pod-spec-hash": "3xuLPXGJ2pzekw21PFU68XUKOYc7PTuW45M521", "olm.managed": "true"},
-					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
+					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true", "openshift.io/required-scc": "restricted-v2"},
 				},
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
@@ -738,7 +738,7 @@ func TestPodExtractContent(t *testing.T) {
 					GenerateName: "test-",
 					Namespace:    "testns",
 					Labels:       map[string]string{"olm.pod-spec-hash": "7noQSgGmkI4BD1MPKe0pEFFfOE3jJtN2DUyZuD", "olm.managed": "true"},
-					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
+					Annotations:  map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true", "openshift.io/required-scc": "restricted-v2"},
 				},
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
@@ -1155,6 +1155,58 @@ func TestPodContainerSecurityContext(t *testing.T) {
 
 			// Assert ContainerSecurityContext
 			require.Equal(t, testcase.expectedContainerSecurityContext, outputPod.Spec.Containers[0].SecurityContext)
+		})
+	}
+}
+
+func TestPodRequiredSCCAnnotation(t *testing.T) {
+	testcases := []struct {
+		title              string
+		securityConfig     v1alpha1.SecurityConfig
+		inputAnnotations   map[string]string
+		expectAnnotation   bool
+		expectedSCCValue   string
+	}{
+		{
+			title:            "Restricted config adds required-scc annotation",
+			securityConfig:   v1alpha1.Restricted,
+			inputAnnotations: map[string]string{},
+			expectAnnotation: true,
+			expectedSCCValue: "restricted-v2",
+		},
+		{
+			title:            "Legacy config does not add required-scc annotation",
+			securityConfig:   v1alpha1.Legacy,
+			inputAnnotations: map[string]string{},
+			expectAnnotation: false,
+		},
+		{
+			title:            "User-provided required-scc annotation is preserved",
+			securityConfig:   v1alpha1.Restricted,
+			inputAnnotations: map[string]string{"openshift.io/required-scc": "nonroot-v2"},
+			expectAnnotation: true,
+			expectedSCCValue: "nonroot-v2",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.title, func(t *testing.T) {
+			catsrc := &v1alpha1.CatalogSource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: testNamespace,
+				},
+			}
+			pod, err := Pod(catsrc, "catalog", "opmImage", "utilImage", "busybox", serviceAccount("", "service-account"), map[string]string{}, tc.inputAnnotations, int32(0), int32(0), workloadUserID, tc.securityConfig)
+			require.NoError(t, err)
+
+			val, exists := pod.Annotations["openshift.io/required-scc"]
+			if tc.expectAnnotation {
+				require.True(t, exists, "expected openshift.io/required-scc annotation to be present")
+				require.Equal(t, tc.expectedSCCValue, val)
+			} else {
+				require.False(t, exists, "expected openshift.io/required-scc annotation to be absent")
+			}
 		})
 	}
 }

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go
@@ -356,6 +356,12 @@ func Pod(source *operatorsv1alpha1.CatalogSource, name, opmImg, utilImage, img s
 	if securityContextConfig == operatorsv1alpha1.Restricted {
 		// Apply 'restricted' security settings
 		addSecurityContext(pod, runAsUser)
+
+		// Pin SCC selection to prevent custom SCCs from preempting catalog pods on
+		// HCP, where the creating user has broader SCC access than the local SA.
+		if _, alreadySet := podAnnotations["openshift.io/required-scc"]; !alreadySet {
+			podAnnotations["openshift.io/required-scc"] = "restricted-v2"
+		}
 	}
 
 	// Set priorityclass if its annotation exists


### PR DESCRIPTION
## Summary

On ROSA HCP clusters, CatalogSource pods can be assigned a customer-installed SCC instead of `restricted-v2`, causing the pod to run with an unexpected UID and crash with `permission denied` errors on pre-baked cache directories.

This PR adds the `openshift.io/required-scc: restricted-v2` annotation to CatalogSource pods when `securityContextConfig` is `Restricted`, pinning SCC selection and preventing custom SCCs from preempting admission.

## Problem

OpenShift's SCC admission selects the "most restrictive" SCC from the candidate set of the **creating user**. On HCP, the entity that creates catalog pods on the data plane has broader SCC access than the local `catalog-operator` ServiceAccount on classic OpenShift — evidenced by the `security.openshift.io/validated-scc-subject-type: user` annotation on affected pods.

A custom SCC with `runAsUser.type: MustRunAs` (single fixed UID) scores as more restrictive than `restricted-v2`'s `MustRunAsRange`. When such an SCC wins, it mutates the pod to a UID that differs from the image's expected UID (1001 per `USER` directive), resulting in:

```
open /tmp/cache/pogreb.v1/db/lock: permission denied
```

This does not reproduce on classic OpenShift — the same custom SCC installed on classic causes `restricted-v2` to still win, consistent with the local `catalog-operator` SA not having access to customer-installed SCCs.

## Fix

Uses the `openshift.io/required-scc` pod annotation (GA since OCP 4.14, [openshift/enhancements#1391](https://github.com/openshift/enhancements/pull/1391)) to pin SCC selection to `restricted-v2` within the existing `Restricted` security context branch.

Key properties:
- **No-op on non-OpenShift**: The annotation is silently ignored where no SCC admission controller exists
- **Respects user overrides**: `!alreadySet` check preserves any annotation passed through CatalogSource annotations
- **Minimal blast radius**: Only fires in the `Restricted` branch (PSA-labeled namespaces or explicit `grpcPodConfig.securityContextConfig: restricted`)

## Test Plan

- [x] Existing `TestPodExtractContent` tests updated to expect the new annotation in Restricted mode
- [x] New `TestPodRequiredSCCAnnotation` test validates:
  - Restricted config adds the annotation
  - Legacy config does not add the annotation
  - User-provided annotation value is preserved (not overwritten)
- [x] Full `pkg/controller/registry/reconciler/` test suite passes

## References

- Issue: https://github.com/openshift/operator-framework-olm/issues/1331
- Incident: ROSA HCP CrashLoopBackOff
- Enhancement: https://github.com/openshift/enhancements/pull/1391