### PR TITLE
OCPBUGS-86895: Ensure packageserver pod seccompProfile is always set

### DIFF
--- a/pkg/package-server-manager/config.go
+++ b/pkg/package-server-manager/config.go
@@ -149,6 +149,21 @@ func ensureCSVHighAvailability(image string, csv *olmv1alpha1.ClusterServiceVers
 		modified = true
 	}
 
+	// Ensure pod-level seccompProfile is always set. The openshift-operator-lifecycle-manager
+	// namespace enforces restricted:latest PodSecurity, which requires seccompProfile. The CSV
+	// template includes this field, but it may be absent if the cluster CSV was created by an
+	// older version or if SCC/PSA admission ordering masks the missing field on most clusters.
+	if deployment.Template.Spec.SecurityContext == nil {
+		deployment.Template.Spec.SecurityContext = &corev1.PodSecurityContext{}
+	}
+	if deployment.Template.Spec.SecurityContext.SeccompProfile == nil ||
+		deployment.Template.Spec.SecurityContext.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		deployment.Template.Spec.SecurityContext.SeccompProfile = &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		}
+		modified = true
+	}
+
 	if modified {
 		csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[0].Spec = *deployment
 	}

--- a/pkg/package-server-manager/controller_test.go
+++ b/pkg/package-server-manager/controller_test.go
@@ -94,6 +94,21 @@ func withAffinity(affinity *corev1.Affinity) func(*olmv1alpha1.ClusterServiceVer
 		csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[0].Spec.Template.Spec.Affinity = affinity
 	}
 }
+
+func withoutSeccompProfile() testCSVOption {
+	return func(csv *olmv1alpha1.ClusterServiceVersion) {
+		podSpec := &csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[0].Spec.Template.Spec
+		if podSpec.SecurityContext != nil {
+			podSpec.SecurityContext.SeccompProfile = nil
+		}
+	}
+}
+
+func withNilPodSecurityContext() testCSVOption {
+	return func(csv *olmv1alpha1.ClusterServiceVersion) {
+		csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[0].Spec.Template.Spec.SecurityContext = nil
+	}
+}
 func withRollingUpdateStrategy(strategy *appsv1.RollingUpdateDeployment) func(*olmv1alpha1.ClusterServiceVersion) {
 	return func(csv *olmv1alpha1.ClusterServiceVersion) {
 		csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[0].Spec.Strategy.RollingUpdate = strategy
@@ -254,6 +269,27 @@ func TestEnsureCSV(t *testing.T) {
 			highlyAvailable: false,
 			inputCSV:        newTestCSV(withReplicas(singleReplicas), withRollingUpdateStrategy(emptyRollout), withAffinity(&corev1.Affinity{})),
 			expectedCSV:     newTestCSV(withReplicas(singleReplicas), withRollingUpdateStrategy(emptyRollout), withAffinity(&corev1.Affinity{})),
+		},
+		{
+			name:            "Modified/HighlyAvailable/MissingSeccompProfile",
+			want:            wanted{true, nil},
+			highlyAvailable: true,
+			inputCSV:        newTestCSV(withReplicas(defaultReplicas), withRollingUpdateStrategy(defaultRollout), withAffinity(defaultAffinity), withoutSeccompProfile()),
+			expectedCSV:     newTestCSV(withReplicas(defaultReplicas), withRollingUpdateStrategy(defaultRollout), withAffinity(defaultAffinity)),
+		},
+		{
+			name:            "Modified/SingleReplica/MissingSeccompProfile",
+			want:            wanted{true, nil},
+			highlyAvailable: false,
+			inputCSV:        newTestCSV(withReplicas(singleReplicas), withRollingUpdateStrategy(emptyRollout), withAffinity(&corev1.Affinity{}), withoutSeccompProfile()),
+			expectedCSV:     newTestCSV(withReplicas(singleReplicas), withRollingUpdateStrategy(emptyRollout), withAffinity(&corev1.Affinity{})),
+		},
+		{
+			name:            "Modified/HighlyAvailable/NilPodSecurityContext",
+			want:            wanted{true, nil},
+			highlyAvailable: true,
+			inputCSV:        newTestCSV(withReplicas(defaultReplicas), withRollingUpdateStrategy(defaultRollout), withAffinity(defaultAffinity), withNilPodSecurityContext()),
+			expectedCSV:     newTestCSV(withReplicas(defaultReplicas), withRollingUpdateStrategy(defaultRollout), withAffinity(defaultAffinity)),
 		},
 	}
 


### PR DESCRIPTION
## Summary

- The `openshift-operator-lifecycle-manager` namespace enforces `restricted:latest` PodSecurity, requiring `seccompProfile: RuntimeDefault` on all pods.
- The packageserver CSV template includes this field, but the cluster-stored CSV can diverge (created before the field was added, or via an upgrade race where OLM processes a cached pre-update CSV).
- OLM faithfully reproduces whatever is in the cluster CSV, so the generated Deployment pod template is missing `seccompProfile`. On most clusters the `restricted-v2` SCC mutating admission adds it before PSA validates — masking the bug. On OSD/ROSA Classic, PSA runs before SCC mutation, so pods are rejected and OLM enters a perpetual reinstall loop (observed at generation=716, revision=566).
- Fix: explicitly enforce `seccompProfile: RuntimeDefault` in `ensureCSVHighAvailability`, which runs on every PSM reconcile, making the field mandatory regardless of the stored CSV state.

## Test plan

- [x] Three new unit test cases added to `TestEnsureCSV`: missing `seccompProfile` (HA topology), missing `seccompProfile` (single-replica topology), nil `SecurityContext`
- [x] `go test ./pkg/package-server-manager/...` passes
- [ ] Backport to all active release branches (4.18, 4.19, 4.20, ...)

Fixes: https://issues.redhat.com/browse/OCPBUGS-86895

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment security by ensuring pods use the `RuntimeDefault` seccomp profile.
  * Automatically creates or restores missing pod security configuration.
  * Applies these corrections consistently to highly available and single-replica deployments.
  * Deployments are now marked for update when security settings require correction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->