### PR TITLE
OCPBUGS-104542: force same arch for opm and catalogsource pod for multiarch tests

### DIFF
--- a/tests-extension/pkg/bindata/qe/bindata.go
+++ b/tests-extension/pkg/bindata/qe/bindata.go
@@ -510,6 +510,9 @@ objects:
     name: "${NAME}"
     namespace: "${NAMESPACE}"
   spec:
+    grpcPodConfig:
+      nodeSelector:
+        kubernetes.io/arch: "${ARCH}"
     image: "${ADDRESS}"
     secrets:
     - "${SECRET}"  
@@ -532,6 +535,7 @@ parameters:
 - name: SECRET
 - name: INTERVAL
   value: "10m0s"
+- name: ARCH
 `)
 
 func testQeTestdataOlmCatalogsourceImageYamlBytes() ([]byte, error) {
@@ -6952,6 +6956,8 @@ objects:
     name: "${NAME}"
     namespace: "${NAMESPACE}"
   spec:
+    nodeSelector:
+      kubernetes.io/arch: "${ARCH}"
     output:
       to:
         kind: ImageStreamTag
@@ -6968,6 +6974,7 @@ parameters:
 - name: NAME
 - name: NAMESPACE
 - name: BASE_IMAGE
+- name: ARCH
 `)
 
 func testQeTestdataOlmCustomSchemaBuildconfigYamlBytes() ([]byte, error) {

--- a/tests-extension/test/qe/specs/olmv0_custom_schema.go
+++ b/tests-extension/test/qe/specs/olmv0_custom_schema.go
@@ -3,6 +3,7 @@ package specs
 import (
 	"context"
 	"os"
+	"runtime"
 	"time"
 
 	g "github.com/onsi/ginkgo/v2"
@@ -53,7 +54,10 @@ var _ = g.Describe("[sig-operator][Jira:OLM][OCPFeatureGate:OLMLifecycleAndCompa
 		fbcContent, err := os.ReadFile(exutil.FixturePath("testdata", "custom-schema", "index.json"))
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		imageRef := olmv0util.BuildCustomCatalogImage(oc, namespace, catalogName, baseImage, fbcContent)
+		testArch := runtime.GOARCH
+		e2e.Logf("test running on architecture: %s", testArch)
+
+		imageRef := olmv0util.BuildCustomCatalogImage(oc, namespace, catalogName, baseImage, testArch, fbcContent)
 		e2e.Logf("built catalog image: %s", imageRef)
 
 		// Register build resources for cleanup
@@ -67,6 +71,7 @@ var _ = g.Describe("[sig-operator][Jira:OLM][OCPFeatureGate:OLMLifecycleAndCompa
 			SourceType: "grpc",
 			Address:    imageRef,
 			Template:   exutil.FixturePath("testdata", "olm", "catalogsource-image.yaml"),
+			Arch:       testArch,
 		}
 		catsrc.CreateWithCheck(oc, itName, dr)
 

--- a/tests-extension/test/qe/testdata/olm/catalogsource-image.yaml
+++ b/tests-extension/test/qe/testdata/olm/catalogsource-image.yaml
@@ -9,6 +9,9 @@ objects:
     name: "${NAME}"
     namespace: "${NAMESPACE}"
   spec:
+    grpcPodConfig:
+      nodeSelector:
+        kubernetes.io/arch: "${ARCH}"
     image: "${ADDRESS}"
     secrets:
     - "${SECRET}"  
@@ -31,3 +34,4 @@ parameters:
 - name: SECRET
 - name: INTERVAL
   value: "10m0s"
+- name: ARCH

--- a/tests-extension/test/qe/testdata/olm/custom-schema-buildconfig.yaml
+++ b/tests-extension/test/qe/testdata/olm/custom-schema-buildconfig.yaml
@@ -9,6 +9,8 @@ objects:
     name: "${NAME}"
     namespace: "${NAMESPACE}"
   spec:
+    nodeSelector:
+      kubernetes.io/arch: "${ARCH}"
     output:
       to:
         kind: ImageStreamTag
@@ -25,3 +27,4 @@ parameters:
 - name: NAME
 - name: NAMESPACE
 - name: BASE_IMAGE
+- name: ARCH

--- a/tests-extension/test/qe/util/olmv0util/catalog_source.go
+++ b/tests-extension/test/qe/util/olmv0util/catalog_source.go
@@ -6,6 +6,7 @@ package olmv0util
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"strings"
 	"time"
 
@@ -33,6 +34,7 @@ type CatalogSourceDescription struct {
 	Interval      string // Update interval for the catalog source
 	ImageTemplate string // Image template for catalog updates
 	ClusterType   string // Target cluster type (e.g., "microshift")
+	Arch          string // Architecture for node selector
 }
 
 // Create creates a CatalogSource resource using the provided template and parameters
@@ -49,6 +51,10 @@ func (catsrc *CatalogSourceDescription) Create(oc *exutil.CLI, itName string, dr
 		catsrc.Interval = "10m0s"
 		e2e.Logf("set interval to be 10m0s")
 	}
+	if catsrc.Arch == "" {
+		catsrc.Arch = runtime.GOARCH
+		e2e.Logf("set catalogsource node selector arch to %s", catsrc.Arch)
+	}
 	// Choose appropriate template application function based on cluster type
 	applyFn := ApplyResourceFromTemplate
 	if strings.Compare(catsrc.ClusterType, "microshift") == 0 {
@@ -63,7 +69,7 @@ func (catsrc *CatalogSourceDescription) Create(oc *exutil.CLI, itName string, dr
 	err := applyFn(oc, "--ignore-unknown-parameters=true", "-f", catsrc.Template,
 		"-p", "NAME="+catsrc.Name, "NAMESPACE="+catsrc.Namespace, "ADDRESS="+catsrc.Address, "SECRET="+catsrc.Secret,
 		"DISPLAYNAME="+"\""+catsrc.DisplayName+"\"", "PUBLISHER="+"\""+catsrc.Publisher+"\"", "SOURCETYPE="+catsrc.SourceType,
-		"INTERVAL="+catsrc.Interval, "IMAGETEMPLATE="+imageTemplate)
+		"INTERVAL="+catsrc.Interval, "IMAGETEMPLATE="+imageTemplate, "ARCH="+catsrc.Arch)
 	o.Expect(err).NotTo(o.HaveOccurred())
 	// Configure security context constraints for non-microshift clusters
 	if strings.Compare(catsrc.ClusterType, "microshift") != 0 {

--- a/tests-extension/test/qe/util/olmv0util/custom_schema_grpc.go
+++ b/tests-extension/test/qe/util/olmv0util/custom_schema_grpc.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -123,7 +124,7 @@ func GetOPMBaseImage(oc *exutil.CLI) string {
 // BuildConfig. It creates an ImageStream and BuildConfig, starts a binary build
 // from the provided FBC content, and waits for completion.
 // Returns the internal registry image reference.
-func BuildCustomCatalogImage(oc *exutil.CLI, namespace, name, baseImage string, fbcContent []byte) string {
+func BuildCustomCatalogImage(oc *exutil.CLI, namespace, name, baseImage, arch string, fbcContent []byte) string {
 	// Create ImageStream
 	isTemplate := exutil.FixturePath("testdata", "olm", "custom-schema-imagestream.yaml")
 	err := ApplyResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", isTemplate,
@@ -132,11 +133,14 @@ func BuildCustomCatalogImage(oc *exutil.CLI, namespace, name, baseImage string, 
 	e2e.Logf("created ImageStream %s/%s", namespace, name)
 
 	// Create BuildConfig
+	if arch == "" {
+		arch = runtime.GOARCH
+	}
 	bcTemplate := exutil.FixturePath("testdata", "olm", "custom-schema-buildconfig.yaml")
 	err = ApplyResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", bcTemplate,
-		"-p", "NAME="+name, "NAMESPACE="+namespace, "BASE_IMAGE="+baseImage)
+		"-p", "NAME="+name, "NAMESPACE="+namespace, "BASE_IMAGE="+baseImage, "ARCH="+arch)
 	o.Expect(err).NotTo(o.HaveOccurred())
-	e2e.Logf("created BuildConfig %s/%s with base image %s", namespace, name, baseImage)
+	e2e.Logf("created BuildConfig %s/%s with base image %s for arch %s", namespace, name, baseImage, arch)
 
 	// Prepare build directory
 	buildDir, err := os.MkdirTemp("", "custom-schema-build-")


### PR DESCRIPTION
OpenShift BuildConfigs create single arch images even with a multi-arch source. The opm image created by the BuildConfig will thus match whatever arch the build environment is. In a multi-arch cluster, this arch may differ from the arch of the node the catalogsource pod gets deployed in with the newly built test catalog.

This PR forces both the BuildConfig and CatalogSource pods to use the same arch. This requirement will prevent this arch mismatch between catalogsource build environment and runtime environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Kubernetes catalog and custom schema builds for architecture-specific environments.
  - Automatically detects the host architecture and schedules related workloads on compatible nodes.
  - Added architecture configuration to catalog sources and build processes, reducing deployment failures on non-default architectures.

- **Tests**
  - Expanded validation coverage to confirm architecture-aware catalog and custom schema workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->