### PR TITLE
OPRUN-4448: Remove feature gate from ExperimentalListPackageCustomSchemas e2e test

### DIFF
--- a/tests-extension/.openshift-tests-extension/openshift_payload_olmv0.json
+++ b/tests-extension/.openshift-tests-extension/openshift_payload_olmv0.json
@@ -643,11 +643,13 @@
     }
   },
   {
-    "name": "[sig-operator][Jira:OLM][OCPFeatureGate:OLMLifecycleAndCompatibility] OLMv0 custom schema gRPC endpoint ExperimentalListPackageCustomSchemas returns custom schema FBC",
+    "name": "[sig-operator][Jira:OLM] OLMv0 custom schema gRPC endpoint ExperimentalListPackageCustomSchemas returns custom schema FBC",
+    "originalName": "[sig-operator][Jira:OLM][OCPFeatureGate:OLMLifecycleAndCompatibility] OLMv0 custom schema gRPC endpoint ExperimentalListPackageCustomSchemas returns custom schema FBC",
     "labels": {
       "Extended": {},
       "NonHyperShiftHOST": {},
-      "ReleaseGate": {}
+      "ReleaseGate": {},
+      "original-name:[sig-operator][Jira:OLM][OCPFeatureGate:OLMLifecycleAndCompatibility] OLMv0 custom schema gRPC endpoint ExperimentalListPackageCustomSchemas returns custom schema FBC": {}
     },
     "resources": {
       "isolation": {}

--- a/tests-extension/test/qe/specs/olmv0_custom_schema.go
+++ b/tests-extension/test/qe/specs/olmv0_custom_schema.go
@@ -17,7 +17,7 @@ const (
 	grpcRequestTimeout = 60 * time.Second
 )
 
-var _ = g.Describe("[sig-operator][Jira:OLM][OCPFeatureGate:OLMLifecycleAndCompatibility] OLMv0 custom schema gRPC endpoint", g.Label("NonHyperShiftHOST"), func() {
+var _ = g.Describe("[sig-operator][Jira:OLM] OLMv0 custom schema gRPC endpoint", g.Label("NonHyperShiftHOST"), func() {
 	defer g.GinkgoRecover()
 
 	var (
@@ -39,7 +39,7 @@ var _ = g.Describe("[sig-operator][Jira:OLM][OCPFeatureGate:OLMLifecycleAndCompa
 		dr.RmIr(itName)
 	})
 
-	g.It("ExperimentalListPackageCustomSchemas returns custom schema FBC", g.Label("ReleaseGate"), func() {
+	g.It("ExperimentalListPackageCustomSchemas returns custom schema FBC", g.Label("ReleaseGate", "original-name:[sig-operator][Jira:OLM][OCPFeatureGate:OLMLifecycleAndCompatibility] OLMv0 custom schema gRPC endpoint ExperimentalListPackageCustomSchemas returns custom schema FBC"), func() {
 		namespace := oc.Namespace()
 		catalogName := "custom-schema-" + exutil.GetRandomString()
 		itName := g.CurrentSpecReport().FullText()

--- a/tests-extension/test/qe/util/olmv0util/custom_schema_grpc.go
+++ b/tests-extension/test/qe/util/olmv0util/custom_schema_grpc.go
@@ -212,7 +212,7 @@ func PortForwardToCatalogPod(oc *exutil.CLI, namespace, catalogName string) (str
 	e2e.Logf("found catalog pod: %s", podName)
 
 	// Find a free local port
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	listener, err := net.Listen("tcp", "localhost:0")
 	o.Expect(err).NotTo(o.HaveOccurred())
 	localPort := listener.Addr().(*net.TCPAddr).Port
 	_ = listener.Close()


### PR DESCRIPTION
## Summary

The `OLMLifecycleAndCompatibility` feature gate has been flipped to GA ([OPRUN-4691](https://redhat.atlassian.net/browse/OPRUN-4691)), so the `[OCPFeatureGate:OLMLifecycleAndCompatibility]` tag on the `ExperimentalListPackageCustomSchemas` e2e test is no longer needed. This removes the tag so the test runs unconditionally on 5.0+ clusters.

### Changes
- Removed `[OCPFeatureGate:OLMLifecycleAndCompatibility]` from the test's `g.Describe` block
- Added `original-name:` Ginkgo label to preserve test ID continuity across the rename

### Related
- Feature gate GA: [OPRUN-4691](https://redhat.atlassian.net/browse/OPRUN-4691)
- Parent epic: [OPRUN-4444](https://redhat.atlassian.net/browse/OPRUN-4444) (OLMv0 Lifecycle Metadata)
- Original e2e tests: #1327

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Test Updates**
  * Updated OLMv0 test labels to use simplified test names.
  * Preserved the original feature-gated test name for traceability.
  * Removed the feature-gate requirement from the OLMv0 custom schema test.
* **Bug Fixes**
  * Improved local catalog pod port forwarding by using the system-resolved localhost interface when selecting an available port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->