### PR TITLE
fix(olm): fix ConversionWebhook spec.conversion lifecycle during CSV upgrades

### DIFF
--- a/staging/operator-lifecycle-manager/pkg/controller/install/deployment.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/install/deployment.go
@@ -123,12 +123,36 @@ func (i *StrategyDeploymentInstaller) createOrUpdateCertResourcesForDeployment()
 				return err
 			}
 		case *webhookDescriptionWithCAPEM:
+			// ConversionWebhook CRD patching is deferred to the post-Install readiness
+			// check (areWebhooksAvailable) so that spec.conversion is only written once
+			// the new deployment's pods are actually serving /convert. Writing it here
+			// during Install() — before any pod is ready — causes a window where the
+			// apiserver routes conversion calls to pods that return HTTP 404.
+			if d.webhookDescription.Type == v1alpha1.ConversionWebhook {
+				continue
+			}
 			err := i.createOrUpdateWebhook(d.caPEM, d.webhookDescription)
 			if err != nil {
 				return err
 			}
 		default:
 			return fmt.Errorf("unsupported CA Resource")
+		}
+	}
+	return nil
+}
+
+// EnsureConversionWebhooks writes spec.conversion on CRDs for any ConversionWebhook
+// entries in the cert resources. Called after the deployment is confirmed ready so that
+// the conversion endpoint is only activated when the new pods are serving /convert.
+func (i *StrategyDeploymentInstaller) EnsureConversionWebhooks() error {
+	for _, desc := range i.getCertResources() {
+		d, ok := desc.(*webhookDescriptionWithCAPEM)
+		if !ok || d.webhookDescription.Type != v1alpha1.ConversionWebhook {
+			continue
+		}
+		if err := i.createOrUpdateConversionWebhook(d.caPEM, d.webhookDescription); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/apiservices.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/apiservices.go
@@ -562,7 +562,11 @@ func (a *Operator) cleanUpRemovedWebhooks(csv *v1alpha1.ClusterServiceVersion) e
 	return nil
 }
 
-func (a *Operator) areWebhooksAvailable(csv *v1alpha1.ClusterServiceVersion) (bool, error) {
+// areWebhooksAvailable checks that all webhook resources declared in the CSV exist and
+// are correctly configured. For ConversionWebhook entries it also writes spec.conversion
+// on the target CRDs using the provided installer, ensuring conversion is only activated
+// once the new deployment's pods are ready to serve /convert.
+func (a *Operator) areWebhooksAvailable(csv *v1alpha1.ClusterServiceVersion, installer install.StrategyInstaller) (bool, error) {
 	err := a.cleanUpRemovedWebhooks(csv)
 	if err != nil {
 		return false, err
@@ -593,6 +597,14 @@ func (a *Operator) areWebhooksAvailable(csv *v1alpha1.ClusterServiceVersion) (bo
 			}
 			webhookCount = len(webhookList.Items)
 		case v1alpha1.ConversionWebhook:
+			// Write spec.conversion on each target CRD now that the deployment is confirmed
+			// ready. This is deferred from Install() to prevent routing conversion calls to
+			// pods that are not yet serving /convert.
+			if sdi, ok := installer.(*install.StrategyDeploymentInstaller); ok {
+				if err := sdi.EnsureConversionWebhooks(); err != nil {
+					return false, fmt.Errorf("conversionWebhook not ready: %w", err)
+				}
+			}
 			for _, conversionCRD := range desc.ConversionCRDs {
 				// check if CRD exists on cluster
 				crd, err := a.opClient.ApiextensionsInterface().ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), conversionCRD, metav1.GetOptions{})

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/apiservices.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/apiservices.go
@@ -600,10 +600,12 @@ func (a *Operator) areWebhooksAvailable(csv *v1alpha1.ClusterServiceVersion, ins
 			// Write spec.conversion on each target CRD now that the deployment is confirmed
 			// ready. This is deferred from Install() to prevent routing conversion calls to
 			// pods that are not yet serving /convert.
-			if sdi, ok := installer.(*install.StrategyDeploymentInstaller); ok {
-				if err := sdi.EnsureConversionWebhooks(); err != nil {
-					return false, fmt.Errorf("conversionWebhook not ready: %w", err)
-				}
+			sdi, ok := installer.(*install.StrategyDeploymentInstaller)
+			if !ok {
+				return false, fmt.Errorf("conversionWebhook requires a StrategyDeploymentInstaller, got %T", installer)
+			}
+			if err := sdi.EnsureConversionWebhooks(); err != nil {
+				return false, fmt.Errorf("conversionWebhook not ready: %w", err)
 			}
 			for _, conversionCRD := range desc.ConversionCRDs {
 				// check if CRD exists on cluster

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
@@ -2641,9 +2641,11 @@ func (a *Operator) updateInstallStatus(csv *v1alpha1.ClusterServiceVersion, inst
 	// Only attempt to write spec.conversion once the deployment is confirmed ready.
 	// areWebhooksAvailable calls EnsureConversionWebhooks, so calling it when
 	// strategyInstalled is false would recreate the upgrade race we are fixing.
+	// Note: CheckInstalled never returns (true, non-nil error), so strategyInstalled
+	// is sufficient — no need to also gate on strategyErr.
 	webhooksInstalled := false
 	var webhookErr error
-	if strategyInstalled && strategyErr == nil {
+	if strategyInstalled {
 		webhooksInstalled, webhookErr = a.areWebhooksAvailable(csv, installer)
 	}
 

--- a/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
+++ b/staging/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
@@ -1302,11 +1302,27 @@ func (a *Operator) handleClusterServiceVersionDeletion(obj interface{}) {
 	// webhook from the CRD definition.
 	csvs, err := a.lister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(clusterServiceVersion.GetNamespace()).List(labels.Everything())
 	if err != nil {
-		logger.Errorf("error listing csvs: %v\n", err)
+		// Without a complete CSV list we cannot safely determine which CRDs are still
+		// covered by a replacement CSV. Bail out to avoid incorrectly clearing
+		// spec.conversion on CRDs that a replacement still owns.
+		logger.Errorf("error listing csvs, skipping conversion webhook cleanup: %v\n", err)
+		return
 	}
+
+	// Build the set of CRDs whose ConversionWebhook is still covered by the replacement CSV.
+	// If the replacement dropped the ConversionWebhook for a given CRD, spec.conversion on
+	// that CRD must be reset — otherwise it keeps pointing at the now-deleted service and
+	// all CR requests against that CRD will fail.
+	coveredCRDs := map[string]bool{}
 	for _, csv := range csvs {
 		if csv.Spec.Replaces == clusterServiceVersion.GetName() {
-			return
+			for _, desc := range csv.Spec.WebhookDefinitions {
+				if desc.Type == v1alpha1.ConversionWebhook {
+					for _, crdName := range desc.ConversionCRDs {
+						coveredCRDs[crdName] = true
+					}
+				}
+			}
 		}
 	}
 
@@ -1316,6 +1332,12 @@ func (a *Operator) handleClusterServiceVersionDeletion(obj interface{}) {
 		}
 
 		for i, crdName := range desc.ConversionCRDs {
+			if coveredCRDs[crdName] {
+				// Replacement CSV still has a ConversionWebhook for this CRD; leave
+				// spec.conversion intact so in-flight conversion calls keep working.
+				continue
+			}
+
 			crd, err := a.opClient.ApiextensionsInterface().ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), crdName, metav1.GetOptions{})
 			if err != nil {
 				logger.Errorf("error getting CRD %v which was defined in CSVs spec.WebhookDefinition[%d]: %v\n", crdName, i, err)
@@ -1323,11 +1345,13 @@ func (a *Operator) handleClusterServiceVersionDeletion(obj interface{}) {
 			}
 
 			copy := crd.DeepCopy()
-			copy.Spec.Conversion.Strategy = apiextensionsv1.NoneConverter
-			copy.Spec.Conversion.Webhook = nil
+			if copy.Spec.Conversion != nil {
+				copy.Spec.Conversion.Strategy = apiextensionsv1.NoneConverter
+				copy.Spec.Conversion.Webhook = nil
 
-			if _, err = a.opClient.ApiextensionsInterface().ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), copy, metav1.UpdateOptions{}); err != nil {
-				logger.Errorf("error updating conversion strategy for CRD %v: %v\n", crdName, err)
+				if _, err = a.opClient.ApiextensionsInterface().ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), copy, metav1.UpdateOptions{}); err != nil {
+					logger.Errorf("error updating conversion strategy for CRD %v: %v\n", crdName, err)
+				}
 			}
 		}
 	}
@@ -2614,7 +2638,14 @@ func (a *Operator) updateInstallStatus(csv *v1alpha1.ClusterServiceVersion, inst
 	}
 
 	apiServicesInstalled, apiServiceErr := a.areAPIServicesAvailable(csv)
-	webhooksInstalled, webhookErr := a.areWebhooksAvailable(csv)
+	// Only attempt to write spec.conversion once the deployment is confirmed ready.
+	// areWebhooksAvailable calls EnsureConversionWebhooks, so calling it when
+	// strategyInstalled is false would recreate the upgrade race we are fixing.
+	webhooksInstalled := false
+	var webhookErr error
+	if strategyInstalled && strategyErr == nil {
+		webhooksInstalled, webhookErr = a.areWebhooksAvailable(csv, installer)
+	}
 
 	if strategyInstalled && apiServicesInstalled && webhooksInstalled {
 		// if there's no error, we're successfully running

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install/deployment.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install/deployment.go
@@ -123,12 +123,36 @@ func (i *StrategyDeploymentInstaller) createOrUpdateCertResourcesForDeployment()
 				return err
 			}
 		case *webhookDescriptionWithCAPEM:
+			// ConversionWebhook CRD patching is deferred to the post-Install readiness
+			// check (areWebhooksAvailable) so that spec.conversion is only written once
+			// the new deployment's pods are actually serving /convert. Writing it here
+			// during Install() — before any pod is ready — causes a window where the
+			// apiserver routes conversion calls to pods that return HTTP 404.
+			if d.webhookDescription.Type == v1alpha1.ConversionWebhook {
+				continue
+			}
 			err := i.createOrUpdateWebhook(d.caPEM, d.webhookDescription)
 			if err != nil {
 				return err
 			}
 		default:
 			return fmt.Errorf("unsupported CA Resource")
+		}
+	}
+	return nil
+}
+
+// EnsureConversionWebhooks writes spec.conversion on CRDs for any ConversionWebhook
+// entries in the cert resources. Called after the deployment is confirmed ready so that
+// the conversion endpoint is only activated when the new pods are serving /convert.
+func (i *StrategyDeploymentInstaller) EnsureConversionWebhooks() error {
+	for _, desc := range i.getCertResources() {
+		d, ok := desc.(*webhookDescriptionWithCAPEM)
+		if !ok || d.webhookDescription.Type != v1alpha1.ConversionWebhook {
+			continue
+		}
+		if err := i.createOrUpdateConversionWebhook(d.caPEM, d.webhookDescription); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/apiservices.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/apiservices.go
@@ -562,7 +562,11 @@ func (a *Operator) cleanUpRemovedWebhooks(csv *v1alpha1.ClusterServiceVersion) e
 	return nil
 }
 
-func (a *Operator) areWebhooksAvailable(csv *v1alpha1.ClusterServiceVersion) (bool, error) {
+// areWebhooksAvailable checks that all webhook resources declared in the CSV exist and
+// are correctly configured. For ConversionWebhook entries it also writes spec.conversion
+// on the target CRDs using the provided installer, ensuring conversion is only activated
+// once the new deployment's pods are ready to serve /convert.
+func (a *Operator) areWebhooksAvailable(csv *v1alpha1.ClusterServiceVersion, installer install.StrategyInstaller) (bool, error) {
 	err := a.cleanUpRemovedWebhooks(csv)
 	if err != nil {
 		return false, err
@@ -593,6 +597,14 @@ func (a *Operator) areWebhooksAvailable(csv *v1alpha1.ClusterServiceVersion) (bo
 			}
 			webhookCount = len(webhookList.Items)
 		case v1alpha1.ConversionWebhook:
+			// Write spec.conversion on each target CRD now that the deployment is confirmed
+			// ready. This is deferred from Install() to prevent routing conversion calls to
+			// pods that are not yet serving /convert.
+			if sdi, ok := installer.(*install.StrategyDeploymentInstaller); ok {
+				if err := sdi.EnsureConversionWebhooks(); err != nil {
+					return false, fmt.Errorf("conversionWebhook not ready: %w", err)
+				}
+			}
 			for _, conversionCRD := range desc.ConversionCRDs {
 				// check if CRD exists on cluster
 				crd, err := a.opClient.ApiextensionsInterface().ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), conversionCRD, metav1.GetOptions{})

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/apiservices.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/apiservices.go
@@ -600,10 +600,12 @@ func (a *Operator) areWebhooksAvailable(csv *v1alpha1.ClusterServiceVersion, ins
 			// Write spec.conversion on each target CRD now that the deployment is confirmed
 			// ready. This is deferred from Install() to prevent routing conversion calls to
 			// pods that are not yet serving /convert.
-			if sdi, ok := installer.(*install.StrategyDeploymentInstaller); ok {
-				if err := sdi.EnsureConversionWebhooks(); err != nil {
-					return false, fmt.Errorf("conversionWebhook not ready: %w", err)
-				}
+			sdi, ok := installer.(*install.StrategyDeploymentInstaller)
+			if !ok {
+				return false, fmt.Errorf("conversionWebhook requires a StrategyDeploymentInstaller, got %T", installer)
+			}
+			if err := sdi.EnsureConversionWebhooks(); err != nil {
+				return false, fmt.Errorf("conversionWebhook not ready: %w", err)
 			}
 			for _, conversionCRD := range desc.ConversionCRDs {
 				// check if CRD exists on cluster

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
@@ -2641,9 +2641,11 @@ func (a *Operator) updateInstallStatus(csv *v1alpha1.ClusterServiceVersion, inst
 	// Only attempt to write spec.conversion once the deployment is confirmed ready.
 	// areWebhooksAvailable calls EnsureConversionWebhooks, so calling it when
 	// strategyInstalled is false would recreate the upgrade race we are fixing.
+	// Note: CheckInstalled never returns (true, non-nil error), so strategyInstalled
+	// is sufficient — no need to also gate on strategyErr.
 	webhooksInstalled := false
 	var webhookErr error
-	if strategyInstalled && strategyErr == nil {
+	if strategyInstalled {
 		webhooksInstalled, webhookErr = a.areWebhooksAvailable(csv, installer)
 	}
 

--- a/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
+++ b/vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go
@@ -1302,11 +1302,27 @@ func (a *Operator) handleClusterServiceVersionDeletion(obj interface{}) {
 	// webhook from the CRD definition.
 	csvs, err := a.lister.OperatorsV1alpha1().ClusterServiceVersionLister().ClusterServiceVersions(clusterServiceVersion.GetNamespace()).List(labels.Everything())
 	if err != nil {
-		logger.Errorf("error listing csvs: %v\n", err)
+		// Without a complete CSV list we cannot safely determine which CRDs are still
+		// covered by a replacement CSV. Bail out to avoid incorrectly clearing
+		// spec.conversion on CRDs that a replacement still owns.
+		logger.Errorf("error listing csvs, skipping conversion webhook cleanup: %v\n", err)
+		return
 	}
+
+	// Build the set of CRDs whose ConversionWebhook is still covered by the replacement CSV.
+	// If the replacement dropped the ConversionWebhook for a given CRD, spec.conversion on
+	// that CRD must be reset — otherwise it keeps pointing at the now-deleted service and
+	// all CR requests against that CRD will fail.
+	coveredCRDs := map[string]bool{}
 	for _, csv := range csvs {
 		if csv.Spec.Replaces == clusterServiceVersion.GetName() {
-			return
+			for _, desc := range csv.Spec.WebhookDefinitions {
+				if desc.Type == v1alpha1.ConversionWebhook {
+					for _, crdName := range desc.ConversionCRDs {
+						coveredCRDs[crdName] = true
+					}
+				}
+			}
 		}
 	}
 
@@ -1316,6 +1332,12 @@ func (a *Operator) handleClusterServiceVersionDeletion(obj interface{}) {
 		}
 
 		for i, crdName := range desc.ConversionCRDs {
+			if coveredCRDs[crdName] {
+				// Replacement CSV still has a ConversionWebhook for this CRD; leave
+				// spec.conversion intact so in-flight conversion calls keep working.
+				continue
+			}
+
 			crd, err := a.opClient.ApiextensionsInterface().ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), crdName, metav1.GetOptions{})
 			if err != nil {
 				logger.Errorf("error getting CRD %v which was defined in CSVs spec.WebhookDefinition[%d]: %v\n", crdName, i, err)
@@ -1323,11 +1345,13 @@ func (a *Operator) handleClusterServiceVersionDeletion(obj interface{}) {
 			}
 
 			copy := crd.DeepCopy()
-			copy.Spec.Conversion.Strategy = apiextensionsv1.NoneConverter
-			copy.Spec.Conversion.Webhook = nil
+			if copy.Spec.Conversion != nil {
+				copy.Spec.Conversion.Strategy = apiextensionsv1.NoneConverter
+				copy.Spec.Conversion.Webhook = nil
 
-			if _, err = a.opClient.ApiextensionsInterface().ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), copy, metav1.UpdateOptions{}); err != nil {
-				logger.Errorf("error updating conversion strategy for CRD %v: %v\n", crdName, err)
+				if _, err = a.opClient.ApiextensionsInterface().ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), copy, metav1.UpdateOptions{}); err != nil {
+					logger.Errorf("error updating conversion strategy for CRD %v: %v\n", crdName, err)
+				}
 			}
 		}
 	}
@@ -2614,7 +2638,14 @@ func (a *Operator) updateInstallStatus(csv *v1alpha1.ClusterServiceVersion, inst
 	}
 
 	apiServicesInstalled, apiServiceErr := a.areAPIServicesAvailable(csv)
-	webhooksInstalled, webhookErr := a.areWebhooksAvailable(csv)
+	// Only attempt to write spec.conversion once the deployment is confirmed ready.
+	// areWebhooksAvailable calls EnsureConversionWebhooks, so calling it when
+	// strategyInstalled is false would recreate the upgrade race we are fixing.
+	webhooksInstalled := false
+	var webhookErr error
+	if strategyInstalled && strategyErr == nil {
+		webhooksInstalled, webhookErr = a.areWebhooksAvailable(csv, installer)
+	}
 
 	if strategyInstalled && apiServicesInstalled && webhooksInstalled {
 		// if there's no error, we're successfully running


### PR DESCRIPTION
## Problems

### 1. spec.conversion written before pods are ready (upgrade race)

During an OLM-managed upgrade, `spec.conversion` is written to CRDs during `Install()` — specifically inside `installDeployments()` → `createOrUpdateCertResourcesForDeployment()` — before any pod from the new deployment is scheduled or ready.

Once `spec.conversion` is set, the apiserver routes conversion calls to the new webhook service endpoint. But since no new pod is serving `/convert` yet, those calls return HTTP 404. This breaks CRD version conversion mid-upgrade and causes upgrade failures.

Empirical evidence from testing: `manager=catalog` writes `spec.conversion` at T+0 (no caBundle), `manager=olm` overwrites at T+8s (adds caBundle, points to new service) — both happen before any new pod is ready.

This is the root cause of the RHOAI 3.5 GA blocker RHOAIENG-76183.

### 2. spec.conversion not cleared when replacement CSV drops the ConversionWebhook

`handleClusterServiceVersionDeletion` returned unconditionally when any replacement CSV was found, assuming the replacement would manage `spec.conversion` going forward. If the replacement dropped the ConversionWebhook entirely, `spec.conversion` was left pointing at the now-deleted service. All CR conversion requests then fail with connection refused.

## Fixes

### Fix 1: defer spec.conversion write until deployment is ready

Skip `ConversionWebhook` descriptors in `createOrUpdateCertResourcesForDeployment()` so that `spec.conversion` is never written during `Install()`.

Add `EnsureConversionWebhooks()` on `*StrategyDeploymentInstaller` and call it from `areWebhooksAvailable()`, which is only invoked from `updateInstallStatus()` after `CheckInstalled()` confirms the deployment's pods are ready. Gate `areWebhooksAvailable()` behind `strategyInstalled && strategyErr == nil` so `EnsureConversionWebhooks()` is never called before readiness is confirmed.

#### Why not extend the StrategyInstaller interface?

`EnsureConversionWebhooks()` is intentionally a concrete method on `*StrategyDeploymentInstaller` rather than an interface method. Adding it to `StrategyInstaller` would require updating `NullStrategyInstaller` and all generated counterfeiter fakes. The `areWebhooksAvailable()` call site type-asserts to `*StrategyDeploymentInstaller` before calling the method — a safe assert since `NullStrategyInstaller` never has `ConversionWebhook` entries.

### Fix 2: clear spec.conversion for CRDs dropped by the replacement CSV

Instead of returning unconditionally when a replacement CSV is found, build the set of CRDs still covered by a ConversionWebhook in the replacement. Only reset `spec.conversion` to `NoneConverter` for CRDs the new CSV dropped. CRDs the replacement still covers are left intact so in-flight conversion calls keep working during a normal upgrade.

Also adds a nil guard on `crd.Spec.Conversion` before writing to it, fixing a latent panic in the no-replacement path.

## Files changed

- `staging/operator-lifecycle-manager/pkg/controller/install/deployment.go`: skip ConversionWebhook in `createOrUpdateCertResourcesForDeployment()`, add `EnsureConversionWebhooks()`
- `staging/operator-lifecycle-manager/pkg/controller/operators/olm/apiservices.go`: add `installer` param to `areWebhooksAvailable()`, call `EnsureConversionWebhooks()` before checking CRD state
- `staging/operator-lifecycle-manager/pkg/controller/operators/olm/operator.go`: gate `areWebhooksAvailable()` behind `strategyInstalled && strategyErr == nil`; fix `handleClusterServiceVersionDeletion` to only clear `spec.conversion` for CRDs the replacement CSV dropped

## Testing

Both packages compile cleanly:
```
go build ./staging/operator-lifecycle-manager/pkg/controller/install/...
go build ./staging/operator-lifecycle-manager/pkg/controller/operators/olm/...
```

Companion operator-side fix: [opendatahub-io/opendatahub-operator#3958](https://github.com/opendatahub-io/opendatahub-operator/pull/3958) removes `ConversionWebhook` from the bundle CRD manifests and adds a runtime Runnable to patch `spec.conversion` after the webhook server is confirmed ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversion webhook installation by applying configuration after deployments are ready.
  * Added readiness checks and retry handling when conversion webhooks are unavailable.
  * Prevented unnecessary removal of conversion webhooks during CSV upgrades and deletions.
  * Improved cleanup safety when replacement resources exist, listings fail, or conversion settings are missing.
  * Install status now validates webhook availability only after a successful installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->