### PR TITLE
[release-4.22] OCPBUGS-95458 OCPBUGS-95441: bumping containerd to v1.7.33

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
 	github.com/containerd/cgroups/v3 v3.1.2 // indirect
-	github.com/containerd/containerd v1.7.30 // indirect
+	github.com/containerd/containerd v1.7.33 // indirect
 	github.com/containerd/containerd/api v1.10.0 // indirect
 	github.com/containerd/continuity v0.4.5 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/clipperhouse/uax29/v2 v2.5.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsV
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/containerd/cgroups/v3 v3.1.2 h1:OSosXMtkhI6Qove637tg1XgK4q+DhR0mX8Wi8EhrHa4=
 github.com/containerd/cgroups/v3 v3.1.2/go.mod h1:PKZ2AcWmSBsY/tJUVhtS/rluX0b1uq1GmPO1ElCmbOw=
-github.com/containerd/containerd v1.7.30 h1:/2vezDpLDVGGmkUXmlNPLCCNKHJ5BbC5tJB5JNzQhqE=
-github.com/containerd/containerd v1.7.30/go.mod h1:fek494vwJClULlTpExsmOyKCMUAbuVjlFsJQc4/j44M=
+github.com/containerd/containerd v1.7.33 h1:iAkYGC/ifR/V+0eR4iXWHNGYUF0DF2PmGV5iz4Irj5M=
+github.com/containerd/containerd v1.7.33/go.mod h1:gSbSCVjPCdkfJCjyrzz7aRC+xFlqVbatNpfHfVCYGUM=
 github.com/containerd/containerd/api v1.10.0 h1:5n0oHYVBwN4VhoX9fFykCV9dF1/BvAXeg2F8W6UYq1o=
 github.com/containerd/containerd/api v1.10.0/go.mod h1:NBm1OAk8ZL+LG8R0ceObGxT5hbUYj7CzTmR3xh0DlMM=
 github.com/containerd/continuity v0.4.5 h1:ZRoN1sXq9u7V6QoHMcVWGhOwDFqZ4B9i5H6un1Wh0x4=

--- a/vendor/github.com/containerd/containerd/archive/tar_unix.go
+++ b/vendor/github.com/containerd/containerd/archive/tar_unix.go
@@ -80,7 +80,7 @@ func openFile(name string, flag int, perm os.FileMode) (*os.File, error) {
 		return nil, err
 	}
 	// Call chmod to avoid permission mask
-	if err := os.Chmod(name, perm); err != nil {
+	if err := f.Chmod(perm); err != nil {
 		f.Close()
 		return nil, err
 	}

--- a/vendor/github.com/containerd/containerd/labels/labels.go
+++ b/vendor/github.com/containerd/containerd/labels/labels.go
@@ -16,6 +16,18 @@
 
 package labels
 
+// ReservedPrefix is the prefix of the label namespace reserved for labels
+// defined and consumed by containerd itself. Labels in this namespace must
+// not be copied from untrusted sources such as image config labels. Use
+// IsReserved to check for such labels.
+const ReservedPrefix = "containerd.io/"
+
+// CRIContainerdPrefix is the prefix of the label namespace reserved for
+// labels defined and consumed by containerd's CRI plugin. Labels in this
+// namespace must not be copied from untrusted sources such as image config
+// labels. Use IsReserved to check for such labels.
+const CRIContainerdPrefix = "io.cri-containerd"
+
 // LabelUncompressed is added to compressed layer contents.
 // The value is digest of the uncompressed content.
 const LabelUncompressed = "containerd.io/uncompressed"

--- a/vendor/github.com/containerd/containerd/labels/validate.go
+++ b/vendor/github.com/containerd/containerd/labels/validate.go
@@ -18,6 +18,7 @@ package labels
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/containerd/containerd/errdefs"
 )
@@ -38,4 +39,12 @@ func Validate(k, v string) error {
 		return fmt.Errorf("label key and value length (%d bytes) greater than maximum size (%d bytes), key: %s: %w", total, maxSize, k, errdefs.ErrInvalidArgument)
 	}
 	return nil
+}
+
+// IsReserved returns true if the label key is in a namespace reserved for
+// containerd (ReservedPrefix) or its CRI plugin (CRIContainerdPrefix).
+// Reserved labels are interpreted by containerd and must not be copied from
+// untrusted sources such as image config labels.
+func IsReserved(k string) bool {
+	return strings.HasPrefix(k, ReservedPrefix) || strings.HasPrefix(k, CRIContainerdPrefix)
 }

--- a/vendor/github.com/containerd/containerd/mount/temp.go
+++ b/vendor/github.com/containerd/containerd/mount/temp.go
@@ -87,7 +87,7 @@ func RemoveVolatileOption(mounts []Mount) []Mount {
 			continue
 		}
 		for j, opt := range m.Options {
-			if opt == "volatile" {
+			if opt == "volatile" || opt == "fsync=volatile" {
 				if out == nil {
 					out = copyMounts(mounts)
 				}

--- a/vendor/github.com/containerd/containerd/version/version.go
+++ b/vendor/github.com/containerd/containerd/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.7.30+unknown"
+	Version = "1.7.33+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -95,7 +95,7 @@ github.com/clipperhouse/uax29/v2/graphemes
 # github.com/containerd/cgroups/v3 v3.1.2
 ## explicit; go 1.22.0
 github.com/containerd/cgroups/v3/cgroup1/stats
-# github.com/containerd/containerd v1.7.30
+# github.com/containerd/containerd v1.7.33
 ## explicit; go 1.24.0
 github.com/containerd/containerd/archive
 github.com/containerd/containerd/archive/compression


### PR DESCRIPTION
OCPBUGS-95458: Bump github.com/containerd/containerd to v1.7.33 to remediated the CVE-2026-53488

## Summary
- Bump `github.com/containerd/containerd` from v1.7.30 to v1.7.33 to address CVE-2026-53488
- CVE-2026-53488: Host-root command execution via unvalidated image config labels in containerd CRI plugin
- This component uses containerd only as a library for OCI image operations and is NOT affected by the CVE (CRI plugin code is not vendored), but bumping to the fixed version as a best practise. 

## Test plan
- [x] `go build ./cmd/...` passes
- [x] `go test ./...` passes (pre-existing grpc-health-probe import error unrelated)
- [x] `go list -deps ./cmd/...` confirms containerd is not compiled into any production binary