### PR TITLE
OCPBUGS-104542: force node arch for opm and catalogsource pod for multiarch tests; fix test failure

### DIFF
--- a/tests-extension/pkg/bindata/qe/bindata.go
+++ b/tests-extension/pkg/bindata/qe/bindata.go
@@ -510,6 +510,9 @@ objects:
     name: "${NAME}"
     namespace: "${NAMESPACE}"
   spec:
+    grpcPodConfig:
+      nodeSelector:
+        kubernetes.io/arch: "${ARCH}"
     image: "${ADDRESS}"
     secrets:
     - "${SECRET}"  
@@ -532,6 +535,7 @@ parameters:
 - name: SECRET
 - name: INTERVAL
   value: "10m0s"
+- name: ARCH
 `)
 
 func testQeTestdataOlmCatalogsourceImageYamlBytes() ([]byte, error) {
@@ -6952,6 +6956,8 @@ objects:
     name: "${NAME}"
     namespace: "${NAMESPACE}"
   spec:
+    nodeSelector:
+      kubernetes.io/arch: "${ARCH}"
     output:
       to:
         kind: ImageStreamTag
@@ -6968,6 +6974,7 @@ parameters:
 - name: NAME
 - name: NAMESPACE
 - name: BASE_IMAGE
+- name: ARCH
 `)
 
 func testQeTestdataOlmCustomSchemaBuildconfigYamlBytes() ([]byte, error) {

--- a/tests-extension/test/qe/specs/olmv0_custom_schema.go
+++ b/tests-extension/test/qe/specs/olmv0_custom_schema.go
@@ -53,7 +53,10 @@ var _ = g.Describe("[sig-operator][Jira:OLM][OCPFeatureGate:OLMLifecycleAndCompa
 		fbcContent, err := os.ReadFile(exutil.FixturePath("testdata", "custom-schema", "index.json"))
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		imageRef := olmv0util.BuildCustomCatalogImage(oc, namespace, catalogName, baseImage, fbcContent)
+		testArch := olmv0util.GetNodeArch(oc)
+		e2e.Logf("test running on architecture: %s", testArch)
+
+		imageRef := olmv0util.BuildCustomCatalogImage(oc, namespace, catalogName, baseImage, testArch, fbcContent)
 		e2e.Logf("built catalog image: %s", imageRef)
 
 		// Register build resources for cleanup
@@ -67,6 +70,7 @@ var _ = g.Describe("[sig-operator][Jira:OLM][OCPFeatureGate:OLMLifecycleAndCompa
 			SourceType: "grpc",
 			Address:    imageRef,
 			Template:   exutil.FixturePath("testdata", "olm", "catalogsource-image.yaml"),
+			Arch:       testArch,
 		}
 		catsrc.CreateWithCheck(oc, itName, dr)
 

--- a/tests-extension/test/qe/testdata/olm/catalogsource-image.yaml
+++ b/tests-extension/test/qe/testdata/olm/catalogsource-image.yaml
@@ -9,6 +9,9 @@ objects:
     name: "${NAME}"
     namespace: "${NAMESPACE}"
   spec:
+    grpcPodConfig:
+      nodeSelector:
+        kubernetes.io/arch: "${ARCH}"
     image: "${ADDRESS}"
     secrets:
     - "${SECRET}"  
@@ -31,3 +34,4 @@ parameters:
 - name: SECRET
 - name: INTERVAL
   value: "10m0s"
+- name: ARCH

--- a/tests-extension/test/qe/testdata/olm/custom-schema-buildconfig.yaml
+++ b/tests-extension/test/qe/testdata/olm/custom-schema-buildconfig.yaml
@@ -9,6 +9,8 @@ objects:
     name: "${NAME}"
     namespace: "${NAMESPACE}"
   spec:
+    nodeSelector:
+      kubernetes.io/arch: "${ARCH}"
     output:
       to:
         kind: ImageStreamTag
@@ -25,3 +27,4 @@ parameters:
 - name: NAME
 - name: NAMESPACE
 - name: BASE_IMAGE
+- name: ARCH

--- a/tests-extension/test/qe/util/olmv0util/catalog_source.go
+++ b/tests-extension/test/qe/util/olmv0util/catalog_source.go
@@ -5,7 +5,9 @@ package olmv0util
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"runtime"
 	"strings"
 	"time"
 
@@ -33,6 +35,25 @@ type CatalogSourceDescription struct {
 	Interval      string // Update interval for the catalog source
 	ImageTemplate string // Image template for catalog updates
 	ClusterType   string // Target cluster type (e.g., "microshift")
+	Arch          string // Architecture for node selector
+}
+
+func GetNodeArch(oc *exutil.CLI) string {
+	envOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+		"nodes", "-o=jsonpath={.metadata.labels}",
+	).Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	for _, nodeLabels := range strings.Split(envOutput, " ") {
+		labels := map[string]string{}
+		err = json.Unmarshal([]byte(nodeLabels), &labels)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if nodeArch, ok := labels["kubernetes.io/arch"]; ok && len(nodeArch) > 0 {
+			return nodeArch
+		}
+	}
+
+	return runtime.GOARCH
 }
 
 // Create creates a CatalogSource resource using the provided template and parameters
@@ -49,6 +70,11 @@ func (catsrc *CatalogSourceDescription) Create(oc *exutil.CLI, itName string, dr
 		catsrc.Interval = "10m0s"
 		e2e.Logf("set interval to be 10m0s")
 	}
+
+	if catsrc.Arch == "" {
+		catsrc.Arch = GetNodeArch(oc)
+		e2e.Logf("set catalogsource node selector arch to %s", catsrc.Arch)
+	}
 	// Choose appropriate template application function based on cluster type
 	applyFn := ApplyResourceFromTemplate
 	if strings.Compare(catsrc.ClusterType, "microshift") == 0 {
@@ -63,7 +89,7 @@ func (catsrc *CatalogSourceDescription) Create(oc *exutil.CLI, itName string, dr
 	err := applyFn(oc, "--ignore-unknown-parameters=true", "-f", catsrc.Template,
 		"-p", "NAME="+catsrc.Name, "NAMESPACE="+catsrc.Namespace, "ADDRESS="+catsrc.Address, "SECRET="+catsrc.Secret,
 		"DISPLAYNAME="+"\""+catsrc.DisplayName+"\"", "PUBLISHER="+"\""+catsrc.Publisher+"\"", "SOURCETYPE="+catsrc.SourceType,
-		"INTERVAL="+catsrc.Interval, "IMAGETEMPLATE="+imageTemplate)
+		"INTERVAL="+catsrc.Interval, "IMAGETEMPLATE="+imageTemplate, "ARCH="+catsrc.Arch)
 	o.Expect(err).NotTo(o.HaveOccurred())
 	// Configure security context constraints for non-microshift clusters
 	if strings.Compare(catsrc.ClusterType, "microshift") != 0 {

--- a/tests-extension/test/qe/util/olmv0util/catalog_source.go
+++ b/tests-extension/test/qe/util/olmv0util/catalog_source.go
@@ -5,7 +5,6 @@ package olmv0util
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"runtime"
 	"strings"
@@ -38,21 +37,21 @@ type CatalogSourceDescription struct {
 	Arch          string // Architecture for node selector
 }
 
+// Query architecture directly from a worker node's status.
+// Use worker nodes specifically since BuildConfig and CatalogSource
+// pods are scheduled on worker nodes.
 func GetNodeArch(oc *exutil.CLI) string {
-	envOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
-		"nodes", "-o=jsonpath={.metadata.labels}",
+	arch, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+		"nodes",
+		"-l", "node-role.kubernetes.io/worker",
+		"--field-selector", "spec.unschedulable!=true",
+		"-o", "jsonpath={.items[0].status.nodeInfo.architecture}",
 	).Output()
-	o.Expect(err).NotTo(o.HaveOccurred())
-
-	for _, nodeLabels := range strings.Split(envOutput, " ") {
-		labels := map[string]string{}
-		err = json.Unmarshal([]byte(nodeLabels), &labels)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		if nodeArch, ok := labels["kubernetes.io/arch"]; ok && len(nodeArch) > 0 {
-			return nodeArch
-		}
+	if err == nil && len(strings.TrimSpace(arch)) > 0 {
+		return strings.TrimSpace(arch)
 	}
 
+	e2e.Logf("failed to get node architecture from cluster (%v), falling back to runtime.GOARCH (%s)", err, runtime.GOARCH)
 	return runtime.GOARCH
 }
 

--- a/tests-extension/test/qe/util/olmv0util/custom_schema_grpc.go
+++ b/tests-extension/test/qe/util/olmv0util/custom_schema_grpc.go
@@ -123,7 +123,7 @@ func GetOPMBaseImage(oc *exutil.CLI) string {
 // BuildConfig. It creates an ImageStream and BuildConfig, starts a binary build
 // from the provided FBC content, and waits for completion.
 // Returns the internal registry image reference.
-func BuildCustomCatalogImage(oc *exutil.CLI, namespace, name, baseImage string, fbcContent []byte) string {
+func BuildCustomCatalogImage(oc *exutil.CLI, namespace, name, baseImage, arch string, fbcContent []byte) string {
 	// Create ImageStream
 	isTemplate := exutil.FixturePath("testdata", "olm", "custom-schema-imagestream.yaml")
 	err := ApplyResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", isTemplate,
@@ -132,11 +132,14 @@ func BuildCustomCatalogImage(oc *exutil.CLI, namespace, name, baseImage string, 
 	e2e.Logf("created ImageStream %s/%s", namespace, name)
 
 	// Create BuildConfig
+	if arch == "" {
+		arch = GetNodeArch(oc)
+	}
 	bcTemplate := exutil.FixturePath("testdata", "olm", "custom-schema-buildconfig.yaml")
 	err = ApplyResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", bcTemplate,
-		"-p", "NAME="+name, "NAMESPACE="+namespace, "BASE_IMAGE="+baseImage)
+		"-p", "NAME="+name, "NAMESPACE="+namespace, "BASE_IMAGE="+baseImage, "ARCH="+arch)
 	o.Expect(err).NotTo(o.HaveOccurred())
-	e2e.Logf("created BuildConfig %s/%s with base image %s", namespace, name, baseImage)
+	e2e.Logf("created BuildConfig %s/%s with base image %s for arch %s", namespace, name, baseImage, arch)
 
 	// Prepare build directory
 	buildDir, err := os.MkdirTemp("", "custom-schema-build-")


### PR DESCRIPTION
## What this does

  Fixes the multiarch node-architecture detection used to pin the `opm`/BuildConfig build and the CatalogSource pod to a compatible node.

  This PR **supersedes #1351**. It includes the original change from that PR (forcing the node arch for the opm and CatalogSource pods) plus a
  corrected implementation of `GetNodeArch` that fixes the test failure introduced by the original approach.

  ## Why

  The original `GetNodeArch` in #1351 fetched `nodes -o=jsonpath={.metadata.labels}` for *all* nodes and returned the arch of the **first node in the 
  list**. That has two problems on multiarch clusters:

  - The first node may be a **control-plane node**, whose architecture can differ from the worker nodes. BuildConfig and CatalogSource pods are
  scheduled on **worker** nodes, so pinning them to the control-plane arch can make them unschedulable.
  - It could also select an **unschedulable/cordoned** node.

  The result was `custom-schema` build / CatalogSource pods failing to schedule (or building for the wrong arch), causing the e2e test to fail.

  ## What changed

  `GetNodeArch` now queries the architecture directly from a schedulable worker node's status instead of parsing all node labels:

  - Selects worker nodes only: `-l node-role.kubernetes.io/worker`
  - Excludes cordoned nodes: `--field-selector spec.unschedulable!=true`
  - Reads the authoritative value: `jsonpath={.items[0].status.nodeInfo.architecture}`
  - Falls back to `runtime.GOARCH` with a log line if the lookup fails
  - Removes the now-unused `encoding/json` import and manual label unmarshalling

  Callers are unchanged (`olmv0_custom_schema.go`, `custom_schema_grpc.go`, and `CatalogSourceDescription`).

## Previous Revert (#1344)

Worth noting:  the first attempt at this fix (#1344) was reverted by #1349 because it introduced a permafailing test on **arm64-only** environments:

  `[sig-operator][Jira:OLM][OCPFeatureGate:OLMLifecycleAndCompatibility] OLMv0 custom schema gRPC endpoint ExperimentalListPackageCustomSchemas returns
  custom schema FBC`

  The change was aimed at mixed-arch clusters but did not handle arm64-only clusters, causing failures in
  `periodic-ci-openshift-multiarch-main-nightly-5.0-ocp-e2e-aws-ovn-multi-a-a` and blocking `5.0.0-0.nightly-multi` payloads. It was reverted to
  unblock payloads ahead of branching, with the note that the fix should be reworked to handle arm64-only environments correctly.

This PR reworks `GetNodeArch` to read the architecture from an actual **schedulable worker node**, which is where the BuildConfig and CatalogSource
  pods run:

  - restricts the lookup to worker nodes (`-l node-role.kubernetes.io/worker`)
  - excludes cordoned/unschedulable nodes (`--field-selector spec.unschedulable!=true`)
  - reads the authoritative value from node status (`jsonpath={.items[0].status.nodeInfo.architecture}`)
  - falls back to `runtime.GOARCH` (with a log line) only if the lookup fails

  ## Testing

  - `gofmt -l` / `go build ./...` clean on `tests-extension`.
  - e2e: `ExperimentalListPackageCustomSchemas returns custom schema FBC` (the `ReleaseGate`-labeled spec that calls `GetNodeArch`) — PASSED on amd64 cluster.

  ## Related

  - Supersedes #1351
  - Jira: OCPBUGS-104542


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-architecture compatibility for QE catalog and build workflows.
  * CatalogSource gRPC pods, catalog builds, and related workloads now run on the detected cluster architecture.
  * Added fallback architecture detection to support environments where worker node details are unavailable.
  * Architecture settings are now applied consistently across custom catalog images and Kubernetes test resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->