### PR TITLE
OCPBUGS-83412: set catalogsource spec.grpcpodconfig.scc: restricted for all non-legacy cases

### DIFF
--- a/tests-extension/pkg/bindata/qe/bindata.go
+++ b/tests-extension/pkg/bindata/qe/bindata.go
@@ -359,6 +359,7 @@ objects:
   spec:
     image: "${ADDRESS}"
     grpcPodConfig:
+      securityContextConfig: restricted
       extractContent:
         catalogDir: /configs
     secrets:
@@ -412,6 +413,7 @@ objects:
   spec:
     image: "${ADDRESS}"
     grpcPodConfig:
+      securityContextConfig: restricted
       extractContent:
         cacheDir: /tmp/cache
         catalogDir: /configs
@@ -465,15 +467,17 @@ objects:
     namespace: "${NAMESPACE}"
   spec:
     image: "${ADDRESS}"
+    grpcPodConfig:
+      securityContextConfig: restricted
     secrets:
-    - "${SECRET}"  
+    - "${SECRET}"
     displayName: "${DISPLAYNAME}"
     icon:
       base64data: ""
       mediatype: ""
     publisher: "${PUBLISHER}"
     sourceType: "${SOURCETYPE}"
-    updateStrategy: 
+    updateStrategy:
       registryPoll: {}
 parameters:
 - name: NAME
@@ -482,7 +486,8 @@ parameters:
 - name: DISPLAYNAME
 - name: PUBLISHER
 - name: SOURCETYPE
-- name: SECRET`)
+- name: SECRET
+`)
 
 func testQeTestdataOlmCatalogsourceImageIncorrectUpdatestrategyYamlBytes() ([]byte, error) {
 	return _testQeTestdataOlmCatalogsourceImageIncorrectUpdatestrategyYaml, nil
@@ -511,6 +516,7 @@ objects:
     namespace: "${NAMESPACE}"
   spec:
     grpcPodConfig:
+      securityContextConfig: restricted
       nodeSelector:
         kubernetes.io/arch: "${ARCH}"
     image: "${ADDRESS}"
@@ -645,6 +651,7 @@ objects:
     namespace: "${NAMESPACE}"
   spec:
     grpcPodConfig:
+      securityContextConfig: restricted
       extractContent:
         cacheDir: /tmp/cache
         catalogDir: /configs
@@ -6732,8 +6739,10 @@ objects:
     namespace: "${NAMESPACE}"
   spec:
     image: "${ADDRESS}"
+    grpcPodConfig:
+      securityContextConfig: restricted
     secrets:
-    - "${SECRET}"  
+    - "${SECRET}"
     displayName: "${DISPLAYNAME}"
     publisher: "${PUBLISHER}"
     sourceType: "${SOURCETYPE}"
@@ -6824,8 +6833,10 @@ objects:
     namespace: "${NAMESPACE}"
   spec:
     image: "${ADDRESS}"
+    grpcPodConfig:
+      securityContextConfig: restricted
     secrets:
-    - "${SECRET}"  
+    - "${SECRET}"
     displayName: "${DISPLAYNAME}"
     publisher: "${PUBLISHER}"
     sourceType: "${SOURCETYPE}"

--- a/tests-extension/test/qe/testdata/olm/catalogsource-image-cacheless.yaml
+++ b/tests-extension/test/qe/testdata/olm/catalogsource-image-cacheless.yaml
@@ -11,6 +11,7 @@ objects:
   spec:
     image: "${ADDRESS}"
     grpcPodConfig:
+      securityContextConfig: restricted
       extractContent:
         catalogDir: /configs
     secrets:

--- a/tests-extension/test/qe/testdata/olm/catalogsource-image-extract.yaml
+++ b/tests-extension/test/qe/testdata/olm/catalogsource-image-extract.yaml
@@ -11,6 +11,7 @@ objects:
   spec:
     image: "${ADDRESS}"
     grpcPodConfig:
+      securityContextConfig: restricted
       extractContent:
         cacheDir: /tmp/cache
         catalogDir: /configs

--- a/tests-extension/test/qe/testdata/olm/catalogsource-image-incorrect-updatestrategy.yaml
+++ b/tests-extension/test/qe/testdata/olm/catalogsource-image-incorrect-updatestrategy.yaml
@@ -10,15 +10,17 @@ objects:
     namespace: "${NAMESPACE}"
   spec:
     image: "${ADDRESS}"
+    grpcPodConfig:
+      securityContextConfig: restricted
     secrets:
-    - "${SECRET}"  
+    - "${SECRET}"
     displayName: "${DISPLAYNAME}"
     icon:
       base64data: ""
       mediatype: ""
     publisher: "${PUBLISHER}"
     sourceType: "${SOURCETYPE}"
-    updateStrategy: 
+    updateStrategy:
       registryPoll: {}
 parameters:
 - name: NAME

--- a/tests-extension/test/qe/testdata/olm/catalogsource-image.yaml
+++ b/tests-extension/test/qe/testdata/olm/catalogsource-image.yaml
@@ -10,6 +10,7 @@ objects:
     namespace: "${NAMESPACE}"
   spec:
     grpcPodConfig:
+      securityContextConfig: restricted
       nodeSelector:
         kubernetes.io/arch: "${ARCH}"
     image: "${ADDRESS}"

--- a/tests-extension/test/qe/testdata/olm/catalogsource-opm.yaml
+++ b/tests-extension/test/qe/testdata/olm/catalogsource-opm.yaml
@@ -10,6 +10,7 @@ objects:
     namespace: "${NAMESPACE}"
   spec:
     grpcPodConfig:
+      securityContextConfig: restricted
       extractContent:
         cacheDir: /tmp/cache
         catalogDir: /configs

--- a/tests-extension/test/qe/testdata/olm/cs-image-template.yaml
+++ b/tests-extension/test/qe/testdata/olm/cs-image-template.yaml
@@ -12,8 +12,10 @@ objects:
     namespace: "${NAMESPACE}"
   spec:
     image: "${ADDRESS}"
+    grpcPodConfig:
+      securityContextConfig: restricted
     secrets:
-    - "${SECRET}"  
+    - "${SECRET}"
     displayName: "${DISPLAYNAME}"
     publisher: "${PUBLISHER}"
     sourceType: "${SOURCETYPE}"

--- a/tests-extension/test/qe/testdata/olm/cs-without-interval.yaml
+++ b/tests-extension/test/qe/testdata/olm/cs-without-interval.yaml
@@ -12,8 +12,10 @@ objects:
     namespace: "${NAMESPACE}"
   spec:
     image: "${ADDRESS}"
+    grpcPodConfig:
+      securityContextConfig: restricted
     secrets:
-    - "${SECRET}"  
+    - "${SECRET}"
     displayName: "${DISPLAYNAME}"
     publisher: "${PUBLISHER}"
     sourceType: "${SOURCETYPE}"


### PR DESCRIPTION
Set explicit SCC for all catsrc specs used for non-legacy cases (defined as where the opm version inside does not support PSA labeling concerns for OCP... pre 1.21), since this can cause a PodSecurityViolation event to get logged.
Since these specs are used in namespaces other than openshift-* naming but do not actually test legacy pre-PSA-support behavior, best practice is to define the SCC so that OLM will set appropriate labels to satisfy OCP PSA audits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - CatalogSource gRPC pods now use a restricted security context by default across supported deployment templates.
  - Improves workload isolation and aligns CatalogSource deployments with stricter security requirements.

- **Tests**
  - Updated CatalogSource test scenarios to validate deployments using the restricted security configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->